### PR TITLE
Display user profile pictures

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,10 +1,11 @@
 class Api::UsersController < Api::BaseController
+  include Rails.application.routes.url_helpers
   before_action :set_user, only: [:update, :destroy, :update_profile]
 
   # GET /api/users.json
   def index
     @users = User.order(created_at: :desc)
-    render json: @users
+    render json: @users.map { |user| serialize_user(user) }
   end
 
   # PATCH /api/users/:id.json
@@ -40,4 +41,15 @@ class Api::UsersController < Api::BaseController
   def user_params
     params.require(:user).permit(:first_name, :last_name, :email, :date_of_birth)
   end
-end
+
+  def serialize_user(user)
+    {
+      id: user.id,
+      email: user.email,
+      first_name: user.first_name,
+      last_name: user.last_name,
+      date_of_birth: user.date_of_birth,
+      profile_picture: user.profile_picture.attached? ?
+        rails_blob_url(user.profile_picture, only_path: true) : nil
+    }
+  endend

--- a/app/javascript/pages/Users.jsx
+++ b/app/javascript/pages/Users.jsx
@@ -42,9 +42,15 @@ const Users = () => {
             key={user.id}
             className="bg-white border border-gray-100 shadow-md rounded-xl p-6 flex flex-col items-center text-center transition-transform transform hover:-translate-y-1 hover:shadow-lg"
           >
-            <div className="w-20 h-20 mb-4 rounded-full bg-gradient-to-tr from-indigo-500 to-blue-500 text-white text-3xl font-bold flex items-center justify-center">
-              {(user.first_name || user.email).charAt(0).toUpperCase()}
-            </div>
+            <img
+              src={
+                user.profile_picture && user.profile_picture !== 'null'
+                  ? user.profile_picture
+                  : 'https://via.placeholder.com/150'
+              }
+              alt="Profile"
+              className="w-20 h-20 mb-4 rounded-full object-cover border-2 border-gray-200"
+            />
             <h2 className="text-lg font-semibold mb-1">
               {user.first_name} {user.last_name}
             </h2>


### PR DESCRIPTION
## Summary
- include route helpers in `Api::UsersController`
- serialize users with profile picture URLs for JSON index
- show profile pictures in the user directory page

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2a9346bc8322ac5746b4909ba671