### PR TITLE
Add science and tech news cards

### DIFF
--- a/app/javascript/components/Knowledge/ScienceNewsCard.jsx
+++ b/app/javascript/components/Knowledge/ScienceNewsCard.jsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+
+const API_KEYS = {
+  GUARDIAN: "YOUR_GUARDIAN_KEY", // secondary
+};
+
+const fetchers = [
+  // 1) Spaceflight News API (no key required)
+  () =>
+    fetch("https://api.spaceflightnewsapi.net/v4/articles/?limit=5")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.results?.length)
+          return data.results.map((a) => ({ title: a.title, url: a.url }));
+        throw new Error("Invalid Spaceflight News response");
+      }),
+
+  // 2) The Guardian science section
+  () =>
+    fetch(
+      `https://content.guardianapis.com/search?section=science&page-size=5&api-key=${API_KEYS.GUARDIAN}`
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.response?.results?.length)
+          return data.response.results.map((a) => ({ title: a.webTitle, url: a.webUrl }));
+        throw new Error("Invalid Guardian response");
+      }),
+
+  // 3) Inshorts science news (unofficial)
+  () =>
+    fetch("https://inshorts.vercel.app/api/news?category=science")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.data?.length)
+          return data.data.slice(0, 5).map((a) => ({ title: a.title, url: a.url }));
+        throw new Error("Invalid Inshorts response");
+      }),
+];
+
+export default function ScienceNewsCard() {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchWithFallback() {
+      setLoading(true);
+      for (const fetcher of fetchers) {
+        try {
+          const results = await fetcher();
+          if (mounted) {
+            setArticles(results);
+            setLoading(false);
+          }
+          return;
+        } catch (e) {
+          console.warn("Science news fetch failed:", e.message);
+        }
+      }
+      if (mounted) {
+        setArticles([]);
+        setLoading(false);
+      }
+    }
+
+    fetchWithFallback();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+      <h2 className="text-lg font-semibold mb-2">🔬 Science News</h2>
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : articles.length ? (
+        <ul className="text-sm space-y-2 text-gray-700 overflow-auto">
+          {articles.map((article, idx) => (
+            <li key={idx}>
+              <a href={article.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                • {article.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="text-sm text-gray-500">No science news available</div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/components/Knowledge/TechNewsCard.jsx
+++ b/app/javascript/components/Knowledge/TechNewsCard.jsx
@@ -1,0 +1,98 @@
+import React, { useEffect, useState } from "react";
+
+const API_KEYS = {
+  NEWSAPI: "YOUR_NEWSAPI_KEY", // secondary
+};
+
+const fetchers = [
+  // 1) Hacker News Algolia API
+  () =>
+    fetch(
+      "https://hn.algolia.com/api/v1/search?tags=story&query=technology&hitsPerPage=5"
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.hits?.length)
+          return data.hits.map((a) => ({ title: a.title, url: a.url }));
+        throw new Error("Invalid Hacker News response");
+      }),
+
+  // 2) NewsAPI technology headlines
+  () =>
+    fetch(
+      `https://newsapi.org/v2/top-headlines?country=us&category=technology&apiKey=${API_KEYS.NEWSAPI}`
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.articles?.length)
+          return data.articles.slice(0, 5).map((a) => ({ title: a.title, url: a.url }));
+        throw new Error("Invalid NewsAPI response");
+      }),
+
+  // 3) Ars Technica RSS via rss2json
+  () =>
+    fetch(
+      "https://api.rss2json.com/v1/api.json?rss_url=https://feeds.arstechnica.com/arstechnica/index"
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.items?.length)
+          return data.items.slice(0, 5).map((a) => ({ title: a.title, url: a.link }));
+        throw new Error("Invalid Ars Technica RSS response");
+      }),
+];
+
+export default function TechNewsCard() {
+  const [articles, setArticles] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchWithFallback() {
+      setLoading(true);
+      for (const fetcher of fetchers) {
+        try {
+          const results = await fetcher();
+          if (mounted) {
+            setArticles(results);
+            setLoading(false);
+          }
+          return;
+        } catch (e) {
+          console.warn("Tech news fetch failed:", e.message);
+        }
+      }
+      if (mounted) {
+        setArticles([]);
+        setLoading(false);
+      }
+    }
+
+    fetchWithFallback();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+      <h2 className="text-lg font-semibold mb-2">💻 Tech News</h2>
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : articles.length ? (
+        <ul className="text-sm space-y-2 text-gray-700 overflow-auto">
+          {articles.map((article, idx) => (
+            <li key={idx}>
+              <a href={article.url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                • {article.title}
+              </a>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="text-sm text-gray-500">No tech news available</div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -5,6 +5,8 @@ import TopNewsCard from "../components/Knowledge/TopNewsCard";
 import DailyFactCard from "../components/Knowledge/DailyFactCard";
 import WordOfTheDayCard from "../components/Knowledge/WordOfTheDayCard";
 import RandomCodingTipCard from "../components/Knowledge/RandomCodingTipCard";
+import ScienceNewsCard from "../components/Knowledge/ScienceNewsCard";
+import TechNewsCard from "../components/Knowledge/TechNewsCard";
 
 export default function KnowledgeDashboard() {
   // Example states for toggles & dark mode omitted for brevity
@@ -24,6 +26,8 @@ export default function KnowledgeDashboard() {
         <AnimatedCard><DailyFactCard /></AnimatedCard>
         <AnimatedCard><WordOfTheDayCard /></AnimatedCard>
         <AnimatedCard><RandomCodingTipCard /></AnimatedCard>
+        <AnimatedCard><ScienceNewsCard /></AnimatedCard>
+        <AnimatedCard><TechNewsCard /></AnimatedCard>
       </div>
 
       {/* Optional: My Library saved items panel */}


### PR DESCRIPTION
## Summary
- enrich Knowledge Dashboard with Science and Tech news cards
- load science news from SpaceflightNews API with fallbacks to Guardian and Inshorts
- load tech news from Hacker News with fallbacks to NewsAPI and Ars Technica RSS

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e2d63fd3c8322bf324dafa00f0d99