### PR TITLE
Add API fallback logic for stock cards

### DIFF
--- a/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
+++ b/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
@@ -1,11 +1,42 @@
 import React, { useEffect, useState } from "react";
 
-const sampleBuying = [
-  { symbol: "HDFCBANK", qty: "9M" },
-  { symbol: "RELIANCE", qty: "8M" },
-  { symbol: "BHARTIARTL", qty: "7M" },
-  { symbol: "ITC", qty: "6M" },
-  { symbol: "AXISBANK", qty: "5M" },
+// API keys for buy volume data
+const API_KEYS = {
+  FMP: "YOUR_FMP_API_KEY", // Financial Modeling Prep
+  ALPHA: "YOUR_ALPHA_VANTAGE_KEY", // AlphaVantage fallback
+};
+
+const fetchers = [
+  // 1) Financial Modeling Prep actives endpoint as a proxy for heavy buying
+  () =>
+    fetch(
+      `https://financialmodelingprep.com/api/v3/stock_market/actives?apikey=${API_KEYS.FMP}`
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        if (Array.isArray(data) && data.length)
+          return data.slice(0, 5).map((d) => ({
+            symbol: d.symbol || d.ticker,
+            qty: d.volume || d.avgVolume || "N/A",
+          }));
+        throw new Error("Invalid FMP response");
+      }),
+
+  // 2) AlphaVantage market movers for most active stocks
+  () =>
+    fetch(
+      `https://www.alphavantage.co/query?function=TOP_GAINERS_LOSERS&apikey=${API_KEYS.ALPHA}`
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        const arr = data?.most_actively_traded || data?.mostActiveStock;
+        if (Array.isArray(arr) && arr.length)
+          return arr.slice(0, 5).map((d) => ({
+            symbol: d.ticker || d.symbol,
+            qty: d.volume || "N/A",
+          }));
+        throw new Error("Invalid AlphaVantage response");
+      }),
 ];
 
 export default function TopBuyingStocksCard() {
@@ -13,8 +44,33 @@ export default function TopBuyingStocksCard() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    setStocks(sampleBuying);
-    setLoading(false);
+    let mounted = true;
+
+    async function fetchWithFallback() {
+      setLoading(true);
+      for (const fetcher of fetchers) {
+        try {
+          const results = await fetcher();
+          if (mounted) {
+            setStocks(results);
+            setLoading(false);
+          }
+          return;
+        } catch (e) {
+          console.warn("Top buying fetch failed:", e.message);
+        }
+      }
+      if (mounted) {
+        setStocks([]);
+        setLoading(false);
+      }
+    }
+
+    fetchWithFallback();
+
+    return () => {
+      mounted = false;
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- fetch real data for TopVolumeStocksCard with fallback
- fetch real data for TopGainersCard with fallback
- fetch real data for TopBuyingStocksCard with fallback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e33a1061083229107ab647220d8e3