### PR TITLE
Add English learning cards

### DIFF
--- a/app/controllers/api/english_phrases_controller.rb
+++ b/app/controllers/api/english_phrases_controller.rb
@@ -1,0 +1,14 @@
+class Api::EnglishPhrasesController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+  require 'faraday'
+  require 'json'
+
+  def show
+    response = Faraday.get('https://api.quotable.io/random')
+    data = JSON.parse(response.body)
+    render json: { phrase: data['content'], author: data['author'] }
+  rescue StandardError => e
+    Rails.logger.error "EnglishPhrases error: #{e.message}"
+    render json: { error: 'Failed to fetch phrase' }, status: 500
+  end
+end

--- a/app/controllers/api/english_tenses_controller.rb
+++ b/app/controllers/api/english_tenses_controller.rb
@@ -1,0 +1,17 @@
+class Api::EnglishTensesController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+  require 'faraday'
+  require 'json'
+
+  API_URL = 'https://gist.githubusercontent.com/linguistics/87389a915632/raw/tenses.json'
+
+  def show
+    response = Faraday.get(API_URL)
+    items = JSON.parse(response.body)
+    tense = items.sample
+    render json: tense
+  rescue StandardError => e
+    Rails.logger.error "EnglishTenses error: #{e.message}"
+    render json: { error: 'Failed to fetch tense' }, status: 500
+  end
+end

--- a/app/controllers/api/english_words_controller.rb
+++ b/app/controllers/api/english_words_controller.rb
@@ -1,0 +1,15 @@
+class Api::EnglishWordsController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+  require 'faraday'
+  require 'json'
+
+  def show
+    response = Faraday.get('https://random-word-api.herokuapp.com/word?number=1')
+    data = JSON.parse(response.body)
+    word = data.is_a?(Array) ? data.first : data
+    render json: { word: word }
+  rescue StandardError => e
+    Rails.logger.error "EnglishWords error: #{e.message}"
+    render json: { error: 'Failed to fetch word' }, status: 500
+  end
+end

--- a/app/javascript/components/Knowledge/CommonEnglishWordCard.jsx
+++ b/app/javascript/components/Knowledge/CommonEnglishWordCard.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react";
+
+export default function CommonEnglishWordCard() {
+  const [word, setWord] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadWord() {
+      try {
+        const res = await fetch("/api/english_word");
+        if (!res.ok) throw new Error("Network error");
+        const data = await res.json();
+        setWord(data.word);
+      } catch (err) {
+        setWord("Unable to fetch word");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadWord();
+  }, []);
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+      <h2 className="text-lg font-semibold mb-2">\uD83D\uDCD6 Common English Word</h2>
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : (
+        <div className="text-sm text-gray-700">{word}</div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/components/Knowledge/EnglishPhraseCard.jsx
+++ b/app/javascript/components/Knowledge/EnglishPhraseCard.jsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from "react";
+
+export default function EnglishPhraseCard() {
+  const [phrase, setPhrase] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadPhrase() {
+      try {
+        const res = await fetch("/api/english_phrase");
+        if (!res.ok) throw new Error("Network error");
+        const data = await res.json();
+        setPhrase(data);
+      } catch (err) {
+        setPhrase({ phrase: "Unable to fetch phrase" });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadPhrase();
+  }, []);
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+      <h2 className="text-lg font-semibold mb-2">\uD83D\uDCDD English Phrase</h2>
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : (
+        <div className="text-sm text-gray-700">
+          <p>“{phrase.phrase}”</p>
+          {phrase.author && (
+            <p className="text-right text-gray-500">— {phrase.author}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/components/Knowledge/EnglishTenseCard.jsx
+++ b/app/javascript/components/Knowledge/EnglishTenseCard.jsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+
+export default function EnglishTenseCard() {
+  const [tense, setTense] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadTense() {
+      try {
+        const res = await fetch("/api/english_tense");
+        if (!res.ok) throw new Error("Network error");
+        const data = await res.json();
+        setTense(data);
+      } catch (err) {
+        setTense({ tense: "Unable to fetch tense" });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadTense();
+  }, []);
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+      <h2 className="text-lg font-semibold mb-2">\u23F3 English Tense</h2>
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : (
+        <div className="text-sm text-gray-700 space-y-1">
+          <div className="font-medium">{tense.tense}</div>
+          {tense.example && <div className="italic">Example: {tense.example}</div>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -11,6 +11,9 @@ import TopGainersCard from "../components/Knowledge/TopGainersCard";
 import TopVolumeStocksCard from "../components/Knowledge/TopVolumeStocksCard";
 import TopBuyingStocksCard from "../components/Knowledge/TopBuyingStocksCard";
 import IndianStockNewsCard from "../components/Knowledge/IndianStockNewsCard";
+import CommonEnglishWordCard from "../components/Knowledge/CommonEnglishWordCard";
+import EnglishTenseCard from "../components/Knowledge/EnglishTenseCard";
+import EnglishPhraseCard from "../components/Knowledge/EnglishPhraseCard";
 
 export default function KnowledgeDashboard() {
   // Example states for toggles & dark mode omitted for brevity
@@ -29,6 +32,9 @@ export default function KnowledgeDashboard() {
         <AnimatedCard><TopNewsCard /></AnimatedCard>
         <AnimatedCard><DailyFactCard /></AnimatedCard>
         <AnimatedCard><WordOfTheDayCard /></AnimatedCard>
+        <AnimatedCard><CommonEnglishWordCard /></AnimatedCard>
+        <AnimatedCard><EnglishTenseCard /></AnimatedCard>
+        <AnimatedCard><EnglishPhraseCard /></AnimatedCard>
         <AnimatedCard><RandomCodingTipCard /></AnimatedCard>
         <AnimatedCard><ScienceNewsCard /></AnimatedCard>
         <AnimatedCard><TechNewsCard /></AnimatedCard>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,9 @@ Rails.application.routes.draw do
     get 'view_profile', to: 'auth#view_profile'
     post 'update_profile', to: 'auth#update_profile'
     get 'coding_tip', to: 'coding_tips#show'
+    get 'english_word', to: 'english_words#show'
+    get 'english_tense', to: 'english_tenses#show'
+    get 'english_phrase', to: 'english_phrases#show'
 
     resources :users, only: [:index, :update, :destroy]
     resources :posts, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- add CommonEnglishWordCard, EnglishTenseCard and EnglishPhraseCard
- show those new cards on the Knowledge Dashboard
- expose new `/api/english_*` endpoints to serve data

## Testing
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e404fa79c8322a330b9ac709c8285