### PR TITLE
Add contact form page

### DIFF
--- a/app/controllers/api/contacts_controller.rb
+++ b/app/controllers/api/contacts_controller.rb
@@ -1,0 +1,18 @@
+class Api::ContactsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def create
+    contact = Contact.new(contact_params)
+    if contact.save
+      render json: { message: 'Thank you for your message!' }, status: :created
+    else
+      render json: { errors: contact.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def contact_params
+    params.require(:contact).permit(:name, :email, :message)
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -19,6 +19,7 @@ import Admin from '../components/Admin/Admin';
 import Users from "../pages/Users";
 import Event from "../pages/Event";
 import Ticket from "../pages/Ticket";
+import Contact from "../pages/Contact";
 
 
 function AuthLayout({ children }) {
@@ -42,6 +43,7 @@ const App = () => {
               <Route path="/signup" element={<AuthLayout><Signup /></AuthLayout>} />
               <Route path="/login" element={<AuthLayout><Login /></AuthLayout>} />
               <Route path="/event" element={<MainLayout><Event /></MainLayout>} />
+              <Route path="/contact" element={<MainLayout><Contact /></MainLayout>} />
               <Route path="/ticket" element={<MainLayout><Ticket /></MainLayout>} />
 
               {/* 🔐 Protected */}

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -25,6 +25,16 @@ const Navbar = () => {
             >
               Event
             </NavLink>
+            <NavLink
+              to="/contact"
+              className={({ isActive }) =>
+                `relative pb-1 text-gray-700 font-medium hover:text-indigo-600 transition ${
+                  isActive ? "after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-indigo-500" : ""
+                }`
+              }
+            >
+              Contact
+            </NavLink>
             {user ? (
               <>
                 {["posts", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -96,4 +96,7 @@ export const deleteRecord = (table, id) => api.delete(`/admin/${table}/${id}`);
 // EVENT BOOKING ENDPOINTS
 export const bookEvent = () => api.post('/event/book');
 export const fetchTicket = (sessionId) => api.get(`/ticket`, { params: { session_id: sessionId } });
+
+// CONTACT ENDPOINT
+export const sendContact = (data) => api.post('/contacts', { contact: data });
 export default api;

--- a/app/javascript/pages/Contact.jsx
+++ b/app/javascript/pages/Contact.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from "react";
+import { sendContact } from "../components/api";
+
+const Contact = () => {
+  const [formData, setFormData] = useState({ name: "", email: "", message: "" });
+  const [status, setStatus] = useState(null);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setStatus(null);
+    try {
+      await sendContact(formData);
+      setFormData({ name: "", email: "", message: "" });
+      setStatus({ type: "success", text: "Message sent successfully." });
+    } catch (err) {
+      setStatus({ type: "error", text: err.response?.data?.errors?.join(", ") || "Failed to send message." });
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-100">
+      <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-2xl border border-gray-100">
+        <h2 className="text-3xl font-bold text-center mb-6">Contact Us</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input
+            type="text"
+            name="name"
+            placeholder="Name"
+            required
+            value={formData.name}
+            onChange={handleChange}
+            className="w-full px-4 py-2 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          />
+          <input
+            type="email"
+            name="email"
+            placeholder="Email"
+            required
+            value={formData.email}
+            onChange={handleChange}
+            className="w-full px-4 py-2 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          />
+          <textarea
+            name="message"
+            placeholder="Message"
+            rows="4"
+            required
+            value={formData.message}
+            onChange={handleChange}
+            className="w-full px-4 py-2 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+          />
+          <button
+            type="submit"
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded-lg font-medium"
+          >
+            Send Message
+          </button>
+        </form>
+        {status && (
+          <div className={`mt-4 p-3 rounded-lg ${status.type === 'success' ? 'bg-green-50 text-green-600 border border-green-200' : 'bg-red-50 text-red-600 border border-red-200'}`}> {status.text} </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Contact;

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,0 +1,3 @@
+class Contact < ApplicationRecord
+  validates :name, :email, :message, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
     resources :developers, only: [:index]
     resources :tasks, only: [:index, :create, :update, :destroy]
 
+    resources :contacts, only: [:create]
+
     get 'admin/tables', to: 'admin#tables'
     get 'admin_meta/:table', to: 'admin#meta'
   

--- a/db/migrate/20250608000000_create_contacts.rb
+++ b/db/migrate/20250608000000_create_contacts.rb
@@ -1,0 +1,11 @@
+class CreateContacts < ActiveRecord::Migration[7.1]
+  def change
+    create_table :contacts do |t|
+      t.string :name, null: false
+      t.string :email, null: false
+      t.text :message, null: false
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- create `Contact` model and migration
- add API controller for contact messages
- hook POST `/api/contacts` route
- expose `sendContact` helper and new React page
- link contact page in navbar and router

## Testing
- `bin/rails --version` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fa61f1554832292e53778ec6d4264