### PR TITLE
Add simple captcha for contact page

### DIFF
--- a/app/controllers/api/contacts_controller.rb
+++ b/app/controllers/api/contacts_controller.rb
@@ -2,6 +2,10 @@ class Api::ContactsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
+    unless valid_captcha?
+      return render json: { errors: ['Invalid captcha answer'] }, status: :unprocessable_entity
+    end
+
     contact = Contact.new(contact_params)
     if contact.save
       render json: { message: 'Thank you for your message!' }, status: :created
@@ -14,5 +18,10 @@ class Api::ContactsController < ApplicationController
 
   def contact_params
     params.require(:contact).permit(:name, :email, :message)
+  end
+
+  def valid_captcha?
+    params[:contact][:captcha_answer].to_i ==
+      params[:contact][:captcha_num1].to_i + params[:contact][:captcha_num2].to_i
   end
 end

--- a/app/javascript/pages/Contact.jsx
+++ b/app/javascript/pages/Contact.jsx
@@ -1,21 +1,45 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { sendContact } from "../components/api";
 
 const Contact = () => {
   const [formData, setFormData] = useState({ name: "", email: "", message: "" });
   const [status, setStatus] = useState(null);
+  const [captcha, setCaptcha] = useState({ num1: 0, num2: 0 });
+  const [captchaAnswer, setCaptchaAnswer] = useState("");
+
+  const generateCaptcha = () => {
+    setCaptcha({
+      num1: Math.floor(Math.random() * 9) + 1,
+      num2: Math.floor(Math.random() * 9) + 1,
+    });
+    setCaptchaAnswer("");
+  };
+
+  useEffect(() => {
+    generateCaptcha();
+  }, []);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
     setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleCaptchaChange = (e) => {
+    setCaptchaAnswer(e.target.value);
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setStatus(null);
     try {
-      await sendContact(formData);
+      await sendContact({
+        ...formData,
+        captcha_num1: captcha.num1,
+        captcha_num2: captcha.num2,
+        captcha_answer: captchaAnswer,
+      });
       setFormData({ name: "", email: "", message: "" });
+      generateCaptcha();
       setStatus({ type: "success", text: "Message sent successfully." });
     } catch (err) {
       setStatus({ type: "error", text: err.response?.data?.errors?.join(", ") || "Failed to send message." });
@@ -54,6 +78,18 @@ const Contact = () => {
             onChange={handleChange}
             className="w-full px-4 py-2 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
           />
+          <div className="flex items-center space-x-2">
+            <span className="text-sm font-medium">
+              What is {captcha.num1} + {captcha.num2}?
+            </span>
+            <input
+              type="number"
+              value={captchaAnswer}
+              onChange={handleCaptchaChange}
+              required
+              className="w-20 px-2 py-1 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
           <button
             type="submit"
             className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2 rounded-lg font-medium"


### PR DESCRIPTION
## Summary
- implement a math captcha on the React contact form
- verify captcha answer in the contacts API controller

## Testing
- `yarn build` *(fails: package not present in lockfile)*
- `bin/rails --version` *(fails: ruby-3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fa807c1988322a65c0f2b6ed1bbc3