### PR TITLE
Add Notes feature

### DIFF
--- a/app/controllers/api/notes_controller.rb
+++ b/app/controllers/api/notes_controller.rb
@@ -1,0 +1,40 @@
+class Api::NotesController < Api::BaseController
+  before_action :set_note, only: [:update, :destroy]
+
+  def index
+    @notes = current_user.notes.order(created_at: :desc)
+    render json: @notes
+  end
+
+  def create
+    @note = current_user.notes.build(note_params)
+    if @note.save
+      render json: @note, status: :created
+    else
+      render json: { errors: @note.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @note.update(note_params)
+      render json: @note
+    else
+      render json: { errors: @note.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @note.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_note
+    @note = current_user.notes.find(params[:id])
+  end
+
+  def note_params
+    params.require(:note).permit(:title, :body)
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -10,6 +10,7 @@ import PdfPage from "./PdfPage";
 import Signup from "../pages/Signup";
 import Login from "../pages/Login";
 import PostPage from "../pages/PostPage";
+import Notes from "../pages/Notes";
 import Profile from "../components/Profile";
 import TodoBoard from "../components/TodoBoard/TodoBoard";
 import PdfEditor from '../pages/PdfEditor';
@@ -49,6 +50,7 @@ const App = () => {
               {/* 🔐 Protected */}
               <Route path="/" element={<PrivateRoute><MainLayout><PdfPage /></MainLayout></PrivateRoute>} />
               <Route path="/posts" element={<PrivateRoute><MainLayout><PostPage /></MainLayout></PrivateRoute>} />
+              <Route path="/notes" element={<PrivateRoute><MainLayout><Notes /></MainLayout></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
               <Route path="/todo" element={<PrivateRoute><MainLayout><TodoBoard /></MainLayout></PrivateRoute>} />
               <Route path="/pdf_editor" element={<PrivateRoute><MainLayout><PdfEditor /></MainLayout></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -37,7 +37,7 @@ const Navbar = () => {
             </NavLink>
             {user ? (
               <>
-                {["posts", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (
+                {["posts", "notes", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (
                   <NavLink
                     key={route}
                     to={`/${route}`}

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -81,6 +81,12 @@ export const createPost = (d) => api.post("/posts", d);
 export const updatePost = (i, d) => api.put(`/posts/${i}`, d);
 export const deletePost = (i) => api.delete(`/posts/${i}`);
 
+// NOTE ENDPOINTS
+export const fetchNotes = () => api.get('/notes.json');
+export const createNote = (d) => api.post('/notes.json', { note: d });
+export const updateNote = (id, d) => api.patch(`/notes/${id}.json`, { note: d });
+export const deleteNote = (id) => api.delete(`/notes/${id}.json`);
+
 // Fetch list of tables
 export const getTables = () => api.get('/admin/tables');
 // Fetch column metadata for a given table

--- a/app/javascript/pages/Notes.jsx
+++ b/app/javascript/pages/Notes.jsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from "react";
+import { fetchNotes, createNote, updateNote, deleteNote } from "../components/api";
+
+const Notes = () => {
+  const [notes, setNotes] = useState([]);
+  const [form, setForm] = useState({ id: null, title: "", body: "" });
+
+  const loadNotes = async () => {
+    try {
+      const { data } = await fetchNotes();
+      setNotes(Array.isArray(data) ? data : []);
+    } catch {
+      setNotes([]);
+    }
+  };
+
+  useEffect(() => {
+    loadNotes();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (form.id) {
+      await updateNote(form.id, { title: form.title, body: form.body });
+    } else {
+      await createNote({ title: form.title, body: form.body });
+    }
+    setForm({ id: null, title: "", body: "" });
+    loadNotes();
+  };
+
+  const handleEdit = (note) => {
+    setForm(note);
+  };
+
+  const handleDelete = async (id) => {
+    await deleteNote(id);
+    loadNotes();
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h2 className="text-2xl font-bold mb-4">My Notes</h2>
+      <form onSubmit={handleSubmit} className="bg-white shadow-md rounded p-4 mb-6">
+        <input
+          className="w-full mb-2 border rounded p-2"
+          placeholder="Title"
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+        <textarea
+          className="w-full mb-2 border rounded p-2"
+          placeholder="Body"
+          value={form.body}
+          onChange={(e) => setForm({ ...form, body: e.target.value })}
+        />
+        <button className="bg-indigo-600 text-white px-4 py-2 rounded">
+          {form.id ? "Update Note" : "Add Note"}
+        </button>
+        {form.id && (
+          <button
+            type="button"
+            className="ml-2 text-sm text-gray-500"
+            onClick={() => setForm({ id: null, title: "", body: "" })}
+          >
+            Cancel
+          </button>
+        )}
+      </form>
+
+      <ul className="space-y-4">
+        {notes.map((note) => (
+          <li key={note.id} className="bg-white shadow-md p-4 rounded border">
+            <h3 className="text-lg font-semibold">{note.title}</h3>
+            <p className="text-gray-700 whitespace-pre-line">{note.body}</p>
+            <div className="mt-2 flex justify-end space-x-2">
+              <button
+                className="text-sm text-blue-600"
+                onClick={() => handleEdit(note)}
+              >
+                Edit
+              </button>
+              <button
+                className="text-sm text-red-600"
+                onClick={() => handleDelete(note.id)}
+              >
+                Delete
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Notes;

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,0 +1,6 @@
+class Note < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true
+  validates :body, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
     resources :sprints, only: [:index, :create, :update, :destroy]
     resources :developers, only: [:index]
     resources :tasks, only: [:index, :create, :update, :destroy]
+    resources :notes, only: [:index, :create, :update, :destroy]
 
     resources :contacts, only: [:create]
 

--- a/db/migrate/20250609000000_create_notes.rb
+++ b/db/migrate/20250609000000_create_notes.rb
@@ -1,0 +1,11 @@
+class CreateNotes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :notes do |t|
+      t.string :title, null: false
+      t.text :body, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Note model with basic validations
- create API endpoints for notes CRUD
- expose notes routes
- implement note management page with React
- wire up frontend routes and navbar link
- extend API helper functions for notes

## Testing
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fac083e4c8322b9cc0ed394173b17