### PR TITLE
Add random joke page with API

### DIFF
--- a/app/controllers/api/jokes_controller.rb
+++ b/app/controllers/api/jokes_controller.rb
@@ -1,0 +1,15 @@
+class Api::JokesController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+
+  JOKES = [
+    "Why do programmers prefer dark mode? Because light attracts bugs!",
+    "I would tell you a UDP joke, but you might not get it.",
+    "What's a programmer's favorite hangout place? Foo Bar.",
+    "Why did the developer go broke? Because they used up all their cache.",
+    "How many programmers does it take to change a light bulb? None, that's a hardware problem!"
+  ].freeze
+
+  def show
+    render json: { joke: JOKES.sample }
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -20,6 +20,7 @@ import Users from "../pages/Users";
 import Event from "../pages/Event";
 import Ticket from "../pages/Ticket";
 import Contact from "../pages/Contact";
+import Joke from "../pages/Joke";
 
 
 function AuthLayout({ children }) {
@@ -44,6 +45,7 @@ const App = () => {
               <Route path="/login" element={<AuthLayout><Login /></AuthLayout>} />
               <Route path="/event" element={<MainLayout><Event /></MainLayout>} />
               <Route path="/contact" element={<MainLayout><Contact /></MainLayout>} />
+              <Route path="/joke" element={<MainLayout><Joke /></MainLayout>} />
               <Route path="/ticket" element={<MainLayout><Ticket /></MainLayout>} />
 
               {/* 🔐 Protected */}

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -35,6 +35,16 @@ const Navbar = () => {
             >
               Contact
             </NavLink>
+            <NavLink
+              to="/joke"
+              className={({ isActive }) =>
+                `relative pb-1 text-gray-700 font-medium hover:text-indigo-600 transition ${
+                  isActive ? "after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-indigo-500" : ""
+                }`
+              }
+            >
+              Joke
+            </NavLink>
             {user ? (
               <>
                 {["posts", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -99,4 +99,7 @@ export const fetchTicket = (sessionId) => api.get(`/ticket`, { params: { session
 
 // CONTACT ENDPOINT
 export const sendContact = (data) => api.post('/contacts', { contact: data });
+
+// FUN JOKE ENDPOINT
+export const fetchJoke = () => api.get('/joke');
 export default api;

--- a/app/javascript/pages/Joke.jsx
+++ b/app/javascript/pages/Joke.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import { fetchJoke } from "../components/api";
+
+const Joke = () => {
+  const [joke, setJoke] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  const loadJoke = async () => {
+    try {
+      const { data } = await fetchJoke();
+      setJoke(data.joke);
+    } catch (e) {
+      setJoke("Failed to load joke.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadJoke();
+  }, []);
+
+  return (
+    <div className="max-w-xl mx-auto p-8">
+      <h1 className="text-3xl font-bold mb-4">Random Programming Joke</h1>
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        <p className="text-lg">{joke}</p>
+      )}
+      <button
+        onClick={() => {
+          setLoading(true);
+          loadJoke();
+        }}
+        className="mt-4 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded"
+      >
+        New Joke
+      </button>
+    </div>
+  );
+};
+
+export default Joke;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     get 'english_word', to: 'english_words#show'
     get 'english_tense', to: 'english_tenses#show'
     get 'english_phrase', to: 'english_phrases#show'
+    get 'joke', to: 'jokes#show'
 
     resources :users, only: [:index, :update, :destroy]
     resources :posts, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- implement `Api::JokesController` with random joke endpoint
- expose `GET /api/joke` route
- add `fetchJoke` helper to API client
- create new `Joke` React page
- link new page in navbar and router

## Testing
- `bin/rails routes | grep joke` *(fails: ruby not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fac143c7883228de93a590ef9571b