### PR TITLE
Add Weather feature with API and frontend

### DIFF
--- a/app/controllers/api/weather_controller.rb
+++ b/app/controllers/api/weather_controller.rb
@@ -1,0 +1,32 @@
+class Api::WeatherController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+  require 'faraday'
+  require 'json'
+  require 'uri'
+
+  def show
+    location = if params[:lat].present? && params[:lon].present?
+                 "#{params[:lat]},#{params[:lon]}"
+               else
+                 params[:city].presence || 'London'
+               end
+
+    encoded_location = URI.encode_www_form_component(location)
+    response = Faraday.get("https://wttr.in/#{encoded_location}?format=j1")
+    data = JSON.parse(response.body)
+    current = data['current_condition']&.first || {}
+
+    weather = {
+      location: location,
+      temp_c: current['temp_C'],
+      temp_f: current['temp_F'],
+      description: current.dig('weatherDesc', 0, 'value'),
+      icon_url: current.dig('weatherIconUrl', 0, 'value')
+    }
+
+    render json: weather
+  rescue StandardError => e
+    Rails.logger.error "Weather error: #{e.message}"
+    render json: { error: 'Failed to fetch weather data' }, status: 500
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -20,6 +20,7 @@ import Users from "../pages/Users";
 import Event from "../pages/Event";
 import Ticket from "../pages/Ticket";
 import Contact from "../pages/Contact";
+import Weather from "../pages/Weather";
 
 
 function AuthLayout({ children }) {
@@ -44,6 +45,7 @@ const App = () => {
               <Route path="/login" element={<AuthLayout><Login /></AuthLayout>} />
               <Route path="/event" element={<MainLayout><Event /></MainLayout>} />
               <Route path="/contact" element={<MainLayout><Contact /></MainLayout>} />
+              <Route path="/weather" element={<MainLayout><Weather /></MainLayout>} />
               <Route path="/ticket" element={<MainLayout><Ticket /></MainLayout>} />
 
               {/* 🔐 Protected */}

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -35,6 +35,16 @@ const Navbar = () => {
             >
               Contact
             </NavLink>
+            <NavLink
+              to="/weather"
+              className={({ isActive }) =>
+                `relative pb-1 text-gray-700 font-medium hover:text-indigo-600 transition ${
+                  isActive ? "after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-indigo-500" : ""
+                }`
+              }
+            >
+              Weather
+            </NavLink>
             {user ? (
               <>
                 {["posts", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -99,4 +99,5 @@ export const fetchTicket = (sessionId) => api.get(`/ticket`, { params: { session
 
 // CONTACT ENDPOINT
 export const sendContact = (data) => api.post('/contacts', { contact: data });
+export const getWeather = (params) => api.get('/weather', { params });
 export default api;

--- a/app/javascript/pages/Weather.jsx
+++ b/app/javascript/pages/Weather.jsx
@@ -1,0 +1,84 @@
+import React, { useState, useEffect } from 'react';
+import { getWeather } from '../components/api';
+
+const Weather = () => {
+  const [city, setCity] = useState('');
+  const [weather, setWeather] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchByLocation = () => {
+    if (!navigator.geolocation) return;
+    setLoading(true);
+    navigator.geolocation.getCurrentPosition(
+      async (pos) => {
+        try {
+          const { data } = await getWeather({ lat: pos.coords.latitude, lon: pos.coords.longitude });
+          setWeather(data);
+          setError(null);
+        } catch {
+          setError('Unable to retrieve weather.');
+        } finally {
+          setLoading(false);
+        }
+      },
+      () => setLoading(false)
+    );
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!city) return;
+    setLoading(true);
+    try {
+      const { data } = await getWeather({ city });
+      setWeather(data);
+      setError(null);
+    } catch {
+      setError('Unable to retrieve weather.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchByLocation();
+  }, []);
+
+  return (
+    <div className="max-w-md mx-auto p-6 bg-white rounded-lg shadow-md mt-8">
+      <h1 className="text-2xl font-semibold mb-4 text-center">Weather</h1>
+      <form onSubmit={handleSubmit} className="flex mb-4 space-x-2">
+        <input
+          type="text"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          placeholder="Enter city"
+          className="flex-grow border border-gray-300 rounded px-3 py-2"
+        />
+        <button
+          type="submit"
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          Search
+        </button>
+      </form>
+      {loading && <p className="text-center">Loading...</p>}
+      {error && <p className="text-red-600 text-center">{error}</p>}
+      {weather && !loading && (
+        <div className="text-center">
+          <h2 className="text-xl font-medium mb-2">{weather.location}</h2>
+          {weather.icon_url && (
+            <img src={weather.icon_url} alt="icon" className="mx-auto h-16" />
+          )}
+          <p className="text-lg">
+            {weather.temp_c}&deg;C / {weather.temp_f}&deg;F
+          </p>
+          <p className="capitalize text-gray-600">{weather.description}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Weather;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
     get 'english_word', to: 'english_words#show'
     get 'english_tense', to: 'english_tenses#show'
     get 'english_phrase', to: 'english_phrases#show'
+    get 'weather', to: 'weather#show'
 
     resources :users, only: [:index, :update, :destroy]
     resources :posts, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- implement `WeatherController` for public weather endpoint
- expose `/api/weather` route
- allow fetching weather data via Axios helper
- add new `Weather` page and route
- link to the Weather page from the Navbar

## Testing
- `bin/rails routes | grep weather` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fac1b443483228ab2c12f0db30067