### PR TITLE
Add greeting feature

### DIFF
--- a/app/controllers/api/greetings_controller.rb
+++ b/app/controllers/api/greetings_controller.rb
@@ -1,0 +1,7 @@
+class Api::GreetingsController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+
+  def show
+    render json: { message: 'Hello from Rails!' }
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -20,6 +20,7 @@ import Users from "../pages/Users";
 import Event from "../pages/Event";
 import Ticket from "../pages/Ticket";
 import Contact from "../pages/Contact";
+import Greeting from "../pages/Greeting";
 
 
 function AuthLayout({ children }) {
@@ -44,6 +45,7 @@ const App = () => {
               <Route path="/login" element={<AuthLayout><Login /></AuthLayout>} />
               <Route path="/event" element={<MainLayout><Event /></MainLayout>} />
               <Route path="/contact" element={<MainLayout><Contact /></MainLayout>} />
+              <Route path="/greeting" element={<MainLayout><Greeting /></MainLayout>} />
               <Route path="/ticket" element={<MainLayout><Ticket /></MainLayout>} />
 
               {/* 🔐 Protected */}

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -35,6 +35,16 @@ const Navbar = () => {
             >
               Contact
             </NavLink>
+            <NavLink
+              to="/greeting"
+              className={({ isActive }) =>
+                `relative pb-1 text-gray-700 font-medium hover:text-indigo-600 transition ${
+                  isActive ? "after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-indigo-500" : ""
+                }`
+              }
+            >
+              Greeting
+            </NavLink>
             {user ? (
               <>
                 {["posts", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -99,4 +99,7 @@ export const fetchTicket = (sessionId) => api.get(`/ticket`, { params: { session
 
 // CONTACT ENDPOINT
 export const sendContact = (data) => api.post('/contacts', { contact: data });
+
+// GREETING ENDPOINT
+export const fetchGreeting = () => api.get('/greeting');
 export default api;

--- a/app/javascript/pages/Greeting.jsx
+++ b/app/javascript/pages/Greeting.jsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+import { fetchGreeting } from '../components/api';
+
+const Greeting = () => {
+  const [message, setMessage] = useState('Loading...');
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data } = await fetchGreeting();
+        setMessage(data.message);
+      } catch {
+        setMessage('Failed to load greeting');
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="bg-white shadow-md rounded-lg p-8">
+        <h1 className="text-2xl font-bold mb-4 text-center">Greeting</h1>
+        <p className="text-gray-700 text-center">{message}</p>
+      </div>
+    </div>
+  );
+};
+
+export default Greeting;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,8 @@ Rails.application.routes.draw do
 
     resources :contacts, only: [:create]
 
+    get 'greeting', to: 'greetings#show'
+
     get 'admin/tables', to: 'admin#tables'
     get 'admin_meta/:table', to: 'admin#meta'
   


### PR DESCRIPTION
## Summary
- add `greetings#show` API endpoint
- expose route `/api/greeting`
- implement `Greeting` React page
- link Greeting page in navbar
- wire new route in app router

## Testing
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fac2202548322b38813d45c634706