### PR TITLE
Add Quotes page with API

### DIFF
--- a/app/controllers/api/quotes_controller.rb
+++ b/app/controllers/api/quotes_controller.rb
@@ -1,0 +1,21 @@
+class Api::QuotesController < Api::BaseController
+  def index
+    quotes = Quote.order(created_at: :desc)
+    render json: quotes
+  end
+
+  def create
+    quote = Quote.new(quote_params)
+    if quote.save
+      render json: quote, status: :created
+    else
+      render json: { errors: quote.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def quote_params
+    params.require(:quote).permit(:content, :author)
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -20,6 +20,7 @@ import Users from "../pages/Users";
 import Event from "../pages/Event";
 import Ticket from "../pages/Ticket";
 import Contact from "../pages/Contact";
+import QuotesPage from "../pages/QuotesPage";
 
 
 function AuthLayout({ children }) {
@@ -49,6 +50,7 @@ const App = () => {
               {/* 🔐 Protected */}
               <Route path="/" element={<PrivateRoute><MainLayout><PdfPage /></MainLayout></PrivateRoute>} />
               <Route path="/posts" element={<PrivateRoute><MainLayout><PostPage /></MainLayout></PrivateRoute>} />
+              <Route path="/quotes" element={<PrivateRoute><MainLayout><QuotesPage /></MainLayout></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
               <Route path="/todo" element={<PrivateRoute><MainLayout><TodoBoard /></MainLayout></PrivateRoute>} />
               <Route path="/pdf_editor" element={<PrivateRoute><MainLayout><PdfEditor /></MainLayout></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -37,7 +37,7 @@ const Navbar = () => {
             </NavLink>
             {user ? (
               <>
-                {["posts", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (
+                {["posts", "quotes", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (
                   <NavLink
                     key={route}
                     to={`/${route}`}

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -81,6 +81,10 @@ export const createPost = (d) => api.post("/posts", d);
 export const updatePost = (i, d) => api.put(`/posts/${i}`, d);
 export const deletePost = (i) => api.delete(`/posts/${i}`);
 
+// QUOTE ENDPOINTS
+export const fetchQuotes = () => api.get('/quotes');
+export const createQuote = (d) => api.post('/quotes', d);
+
 // Fetch list of tables
 export const getTables = () => api.get('/admin/tables');
 // Fetch column metadata for a given table

--- a/app/javascript/pages/QuotesPage.jsx
+++ b/app/javascript/pages/QuotesPage.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from "react";
+import { fetchQuotes, createQuote } from "../components/api";
+
+const QuotesPage = () => {
+  const [quotes, setQuotes] = useState([]);
+  const [content, setContent] = useState("");
+  const [author, setAuthor] = useState("");
+
+  const loadQuotes = async () => {
+    try {
+      const { data } = await fetchQuotes();
+      setQuotes(Array.isArray(data) ? data : []);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    loadQuotes();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await createQuote({ quote: { content, author } });
+    setContent("");
+    setAuthor("");
+    loadQuotes();
+  };
+
+  return (
+    <div className="max-w-xl mx-auto space-y-6 mt-10">
+      <h2 className="text-2xl font-bold">Add a Quote</h2>
+      <form onSubmit={handleSubmit} className="bg-white p-4 rounded shadow">
+        <input
+          type="text"
+          value={content}
+          placeholder="Quote"
+          onChange={(e) => setContent(e.target.value)}
+          className="w-full border rounded p-2 mb-2"
+          required
+        />
+        <input
+          type="text"
+          value={author}
+          placeholder="Author"
+          onChange={(e) => setAuthor(e.target.value)}
+          className="w-full border rounded p-2 mb-2"
+        />
+        <button className="w-full bg-indigo-500 text-white rounded p-2 hover:bg-indigo-600">
+          Save Quote
+        </button>
+      </form>
+
+      <h2 className="text-2xl font-bold">Recent Quotes</h2>
+      <ul className="space-y-4">
+        {quotes.map((q) => (
+          <li key={q.id} className="bg-white p-4 rounded shadow">
+            <p className="text-gray-800">{q.content}</p>
+            {q.author && <p className="text-sm text-gray-500">- {q.author}</p>}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default QuotesPage;

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,0 +1,3 @@
+class Quote < ApplicationRecord
+  validates :content, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
     resources :developers, only: [:index]
     resources :tasks, only: [:index, :create, :update, :destroy]
 
+    resources :quotes, only: [:index, :create]
+
     resources :contacts, only: [:create]
 
     get 'admin/tables', to: 'admin#tables'

--- a/db/migrate/20250710000000_create_quotes.rb
+++ b/db/migrate/20250710000000_create_quotes.rb
@@ -1,0 +1,10 @@
+class CreateQuotes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :quotes do |t|
+      t.string :content
+      t.string :author
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,6 +98,13 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_06_124130) do
     t.index ["type"], name: "index_tasks_on_type"
   end
 
+  create_table "quotes", force: :cascade do |t|
+    t.string "content"
+    t.string "author"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false


### PR DESCRIPTION
## Summary
- create Quote model and migration
- provide API routes and controller for quotes
- expose fetchQuotes and createQuote calls in frontend api helper
- add Quotes React page to add and list quotes
- link to new Quotes page from Navbar and React Router

## Testing
- `npm run build` *(fails: `esbuild: not found`)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686fac2db46483228453183248c30c47