### PR TITLE
Add personal vault feature

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -1,0 +1,44 @@
+class Api::ItemsController < Api::BaseController
+  before_action :set_item, only: [:update, :destroy]
+
+  def index
+    items = current_user.items
+    if params[:q].present?
+      query = "%#{params[:q]}%"
+      items = items.where("title ILIKE ? OR content ILIKE ?", query, query)
+    end
+    render json: items.order(:id)
+  end
+
+  def create
+    item = current_user.items.build(item_params)
+    if item.save
+      render json: item, status: :created
+    else
+      render json: { errors: item.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @item.update(item_params)
+      render json: @item
+    else
+      render json: { errors: @item.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @item.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_item
+    @item = current_user.items.find(params[:id])
+  end
+
+  def item_params
+    params.require(:item).permit(:title, :category, :content)
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -25,6 +25,7 @@ import QuotesPage from "../pages/QuotesPage";
 import Greeting from "../pages/Greeting";
 import Weather from "../pages/Weather";
 import Joke from "../pages/Joke";
+import Vault from "../pages/Vault";
 
 
 function AuthLayout({ children }) {
@@ -59,6 +60,7 @@ const App = () => {
               <Route path="/posts" element={<PrivateRoute><MainLayout><PostPage /></MainLayout></PrivateRoute>} />
               <Route path="/quotes" element={<PrivateRoute><MainLayout><QuotesPage /></MainLayout></PrivateRoute>} />
               <Route path="/notes" element={<PrivateRoute><MainLayout><Notes /></MainLayout></PrivateRoute>} />
+              <Route path="/vault" element={<PrivateRoute><MainLayout><Vault /></MainLayout></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
               <Route path="/todo" element={<PrivateRoute><MainLayout><TodoBoard /></MainLayout></PrivateRoute>} />
               <Route path="/pdf_editor" element={<PrivateRoute><MainLayout><PdfEditor /></MainLayout></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -67,7 +67,7 @@ const Navbar = () => {
             </NavLink>
             {user ? (
               <>
-                {["posts", "notes", "quotes", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (
+                {["posts", "notes", "vault", "quotes", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin"].map((route) => (
                   <NavLink
                     key={route}
                     to={`/${route}`}

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -90,6 +90,12 @@ export const createNote = (d) => api.post('/notes.json', { note: d });
 export const updateNote = (id, d) => api.patch(`/notes/${id}.json`, { note: d });
 export const deleteNote = (id) => api.delete(`/notes/${id}.json`);
 
+// ITEM ENDPOINTS
+export const fetchItems = (q) => api.get('/items.json', { params: q ? { q } : {} });
+export const createItem = (d) => api.post('/items.json', { item: d });
+export const updateItem = (id, d) => api.patch(`/items/${id}.json`, { item: d });
+export const deleteItem = (id) => api.delete(`/items/${id}.json`);
+
 // Fetch list of tables
 export const getTables = () => api.get('/admin/tables');
 // Fetch column metadata for a given table

--- a/app/javascript/pages/Vault.jsx
+++ b/app/javascript/pages/Vault.jsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useState } from "react";
+import { fetchItems, createItem, deleteItem } from "../components/api";
+
+const Vault = () => {
+  const [items, setItems] = useState([]);
+  const [search, setSearch] = useState("");
+  const [form, setForm] = useState({ title: "", category: "", content: "" });
+
+  const loadItems = async (q = "") => {
+    try {
+      const { data } = await fetchItems(q);
+      setItems(Array.isArray(data) ? data : []);
+    } catch {
+      setItems([]);
+    }
+  };
+
+  useEffect(() => {
+    loadItems();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.title.trim() || !form.content.trim()) return;
+    await createItem(form);
+    setForm({ title: "", category: "", content: "" });
+    loadItems(search);
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm("Delete this item?")) return;
+    await deleteItem(id);
+    loadItems(search);
+  };
+
+  const handleCopy = (text) => {
+    navigator.clipboard.writeText(text);
+    alert("Copied!");
+  };
+
+  const handleExport = () => {
+    const blob = new Blob([JSON.stringify(items, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "items_export.json";
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto">
+      <div className="flex items-center mt-4 mb-2">
+        <input
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            loadItems(e.target.value);
+          }}
+          placeholder="Search..."
+          className="border p-2 flex-grow mr-2"
+        />
+        <button onClick={handleExport} className="bg-gray-200 px-3 py-2 rounded">Export</button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded mb-6">
+        <input
+          className="w-full border rounded p-2 mb-2"
+          placeholder="Title"
+          value={form.title}
+          onChange={(e) => setForm({ ...form, title: e.target.value })}
+        />
+        <input
+          className="w-full border rounded p-2 mb-2"
+          placeholder="Category"
+          value={form.category}
+          onChange={(e) => setForm({ ...form, category: e.target.value })}
+        />
+        <textarea
+          className="w-full border rounded p-2 mb-2"
+          rows="3"
+          placeholder="Content"
+          value={form.content}
+          onChange={(e) => setForm({ ...form, content: e.target.value })}
+        />
+        <button className="bg-indigo-600 text-white px-4 py-2 rounded">Add Item</button>
+      </form>
+
+      <table className="w-full text-left border-collapse">
+        <thead>
+          <tr>
+            <th className="border p-2">Title</th>
+            <th className="border p-2">Category</th>
+            <th className="border p-2">Content</th>
+            <th className="border p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.id}>
+              <td className="border p-2 align-top">{item.title}</td>
+              <td className="border p-2 align-top">{item.category}</td>
+              <td className="border p-2 whitespace-pre-wrap align-top">
+                {item.content.length > 50 ? item.content.slice(0, 50) + "..." : item.content}
+              </td>
+              <td className="border p-2 align-top">
+                <button onClick={() => handleCopy(item.content)} className="mr-2 text-sm text-blue-600">Copy</button>
+                <button onClick={() => handleDelete(item.id)} className="text-sm text-red-600">Delete</button>
+              </td>
+            </tr>
+          ))}
+          {items.length === 0 && (
+            <tr>
+              <td colSpan="4" className="border p-2 text-center italic">No items</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Vault;

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,0 +1,6 @@
+class Item < ApplicationRecord
+  belongs_to :user
+
+  validates :title, presence: true
+  validates :content, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
   has_one_attached :profile_picture
   has_many :posts
   has_many :tasks, foreign_key: :assigned_to
+  has_many :items
 
   # This is a class attribute that will store the current user for the current request.
   # It needs to be thread-safe.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
     resources :tasks, only: [:index, :create, :update, :destroy]
     resources :notes, only: [:index, :create, :update, :destroy]
 
+    resources :items, only: [:index, :create, :update, :destroy]
+
     resources :quotes, only: [:index, :create]
 
     resources :contacts, only: [:create]

--- a/db/migrate/20250711000000_create_items.rb
+++ b/db/migrate/20250711000000_create_items.rb
@@ -1,0 +1,12 @@
+class CreateItems < ActiveRecord::Migration[7.1]
+  def change
+    create_table :items do |t|
+      t.string :title, null: false
+      t.string :category
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Item model and migration
- expose `/api/items` endpoints
- extend User with items association
- provide React page for managing items
- wire up routes and navigation

## Testing
- `npm test` *(fails: Missing script)*
- `bundle exec rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686fb3f57bd48322be42f2607963f083