### PR TITLE
Add dashboard UI for vault items

### DIFF
--- a/app/javascript/pages/Vault.jsx
+++ b/app/javascript/pages/Vault.jsx
@@ -1,10 +1,24 @@
-import React, { useEffect, useState } from "react";
-import { fetchItems, createItem, deleteItem } from "../components/api";
+import React, { useState, useEffect } from "react";
+import { fetchItems, createItem, updateItem, deleteItem } from "../components/api";
+
+const gridStyle = "grid gap-4 sm:grid-cols-2 lg:grid-cols-3";
 
 const Vault = () => {
   const [items, setItems] = useState([]);
-  const [search, setSearch] = useState("");
-  const [form, setForm] = useState({ title: "", category: "", content: "" });
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const [newTitle, setNewTitle] = useState("");
+  const [newCategory, setNewCategory] = useState("");
+  const [newContent, setNewContent] = useState("");
+
+  const [editingId, setEditingId] = useState(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editCategory, setEditCategory] = useState("");
+  const [editContent, setEditContent] = useState("");
+
+  useEffect(() => {
+    loadItems();
+  }, []);
 
   const loadItems = async (q = "") => {
     try {
@@ -15,109 +29,180 @@ const Vault = () => {
     }
   };
 
-  useEffect(() => {
-    loadItems();
-  }, []);
-
-  const handleSubmit = async (e) => {
-    e.preventDefault();
-    if (!form.title.trim() || !form.content.trim()) return;
-    await createItem(form);
-    setForm({ title: "", category: "", content: "" });
-    loadItems(search);
+  const handleSearchChange = (e) => {
+    const q = e.target.value;
+    setSearchQuery(q);
+    loadItems(q);
   };
 
-  const handleDelete = async (id) => {
+  const handleAddItem = async (e) => {
+    e.preventDefault();
+    if (!newTitle.trim() || !newContent.trim()) return;
+    await createItem({ title: newTitle.trim(), category: newCategory.trim(), content: newContent.trim() });
+    setNewTitle("");
+    setNewCategory("");
+    setNewContent("");
+    loadItems(searchQuery);
+  };
+
+  const startEditing = (item) => {
+    setEditingId(item.id);
+    setEditTitle(item.title);
+    setEditCategory(item.category || "");
+    setEditContent(item.content);
+  };
+
+  const handleUpdateItem = async (id) => {
+    if (!editTitle.trim() || !editContent.trim()) return;
+    await updateItem(id, { title: editTitle.trim(), category: editCategory.trim(), content: editContent.trim() });
+    setEditingId(null);
+    loadItems(searchQuery);
+  };
+
+  const handleDeleteItem = async (id) => {
     if (!window.confirm("Delete this item?")) return;
     await deleteItem(id);
-    loadItems(search);
+    loadItems(searchQuery);
   };
 
-  const handleCopy = (text) => {
-    navigator.clipboard.writeText(text);
-    alert("Copied!");
+  const copyText = (text) => {
+    navigator.clipboard.writeText(text).then(() => alert("Copied to clipboard!"));
   };
 
-  const handleExport = () => {
-    const blob = new Blob([JSON.stringify(items, null, 2)], { type: "application/json" });
+  const handleExportAll = () => {
+    if (items.length === 0) return alert("No items to export.");
+    const dataStr = JSON.stringify(items, null, 2);
+    const blob = new Blob([dataStr], { type: "application/json" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = "items_export.json";
+    link.download = "my_items_export.json";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
     URL.revokeObjectURL(url);
   };
 
+  const credentials = items.filter((i) => i.category === "Credential");
+  const commands = items.filter((i) => i.category === "Command");
+  const others = items.filter((i) => i.category !== "Credential" && i.category !== "Command");
+
+  const renderEditCard = (id) => (
+    <div className="p-4 border rounded-lg bg-white shadow-sm">
+      <div className="font-semibold mb-2">Editing</div>
+      <input className="w-full border rounded p-1 mb-2" value={editTitle} onChange={(e) => setEditTitle(e.target.value)} placeholder="Title" />
+      <input className="w-full border rounded p-1 mb-2" value={editCategory} onChange={(e) => setEditCategory(e.target.value)} placeholder="Category" />
+      <textarea className="w-full border rounded p-1 mb-2" rows="3" value={editContent} onChange={(e) => setEditContent(e.target.value)} />
+      <button className="bg-indigo-600 text-white px-3 py-1 rounded" onClick={() => handleUpdateItem(id)}>Save</button>
+      <button className="ml-2 text-sm" onClick={() => setEditingId(null)}>Cancel</button>
+    </div>
+  );
+
+  const renderCredential = (item) => (
+    <div key={item.id} className="p-4 border rounded-lg bg-white shadow-sm">
+      {editingId === item.id ? (
+        renderEditCard(item.id)
+      ) : (
+        <>
+          <div className="font-semibold mb-1">{item.title}</div>
+          <div className="mb-2">Password: <span className="tracking-widest">••••••••</span></div>
+          <div className="space-x-2">
+            <button className="text-sm text-blue-600" onClick={() => copyText(item.title)}>Copy Username</button>
+            <button className="text-sm text-blue-600" onClick={() => copyText(item.content)}>Copy Password</button>
+          </div>
+          <div className="mt-2 space-x-2">
+            <button className="text-sm" onClick={() => startEditing(item)}>Edit</button>
+            <button className="text-sm text-red-600" onClick={() => handleDeleteItem(item.id)}>Delete</button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+
+  const renderCommand = (item) => (
+    <div key={item.id} className="p-4 border rounded-lg bg-white shadow-sm">
+      {editingId === item.id ? (
+        renderEditCard(item.id)
+      ) : (
+        <>
+          <div className="font-semibold mb-1">{item.title}</div>
+          <pre className="bg-gray-100 p-2 rounded mb-2 whitespace-pre-wrap break-words">{item.content}</pre>
+          <button className="text-sm text-blue-600" onClick={() => copyText(item.content)}>Copy Command</button>
+          <div className="mt-2 space-x-2">
+            <button className="text-sm" onClick={() => startEditing(item)}>Edit</button>
+            <button className="text-sm text-red-600" onClick={() => handleDeleteItem(item.id)}>Delete</button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+
+  const renderOther = (item) => (
+    <div key={item.id} className="p-4 border rounded-lg bg-white shadow-sm">
+      {editingId === item.id ? (
+        renderEditCard(item.id)
+      ) : (
+        <>
+          <div className="font-semibold mb-1">{item.title}</div>
+          <div className="mb-2 break-words">{item.content.length > 100 ? item.content.slice(0, 100) + "..." : item.content}</div>
+          <button className="text-sm text-blue-600" onClick={() => copyText(item.content)}>Copy Content</button>
+          <div className="mt-2 space-x-2">
+            <button className="text-sm" onClick={() => startEditing(item)}>Edit</button>
+            <button className="text-sm text-red-600" onClick={() => handleDeleteItem(item.id)}>Delete</button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+
   return (
-    <div className="max-w-3xl mx-auto">
+    <div className="max-w-5xl mx-auto">
       <div className="flex items-center mt-4 mb-2">
-        <input
-          value={search}
-          onChange={(e) => {
-            setSearch(e.target.value);
-            loadItems(e.target.value);
-          }}
-          placeholder="Search..."
-          className="border p-2 flex-grow mr-2"
-        />
-        <button onClick={handleExport} className="bg-gray-200 px-3 py-2 rounded">Export</button>
+        <input className="border p-2 flex-grow mr-2" placeholder="Search..." value={searchQuery} onChange={handleSearchChange} />
+        <button onClick={handleExportAll} className="bg-gray-200 px-3 py-2 rounded">Export All</button>
       </div>
 
-      <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded mb-6">
-        <input
-          className="w-full border rounded p-2 mb-2"
-          placeholder="Title"
-          value={form.title}
-          onChange={(e) => setForm({ ...form, title: e.target.value })}
-        />
-        <input
-          className="w-full border rounded p-2 mb-2"
-          placeholder="Category"
-          value={form.category}
-          onChange={(e) => setForm({ ...form, category: e.target.value })}
-        />
-        <textarea
-          className="w-full border rounded p-2 mb-2"
-          rows="3"
-          placeholder="Content"
-          value={form.content}
-          onChange={(e) => setForm({ ...form, content: e.target.value })}
-        />
+      <form onSubmit={handleAddItem} className="bg-white shadow p-4 rounded mb-6">
+        <h3 className="text-lg font-semibold mb-2">Add New Item</h3>
+        <input className="w-full border rounded p-2 mb-2" placeholder="Title" value={newTitle} onChange={(e) => setNewTitle(e.target.value)} />
+        <input className="w-full border rounded p-2 mb-2" placeholder="Category" value={newCategory} onChange={(e) => setNewCategory(e.target.value)} />
+        <textarea className="w-full border rounded p-2 mb-2" rows="3" placeholder="Content" value={newContent} onChange={(e) => setNewContent(e.target.value)} />
         <button className="bg-indigo-600 text-white px-4 py-2 rounded">Add Item</button>
       </form>
 
-      <table className="w-full text-left border-collapse">
-        <thead>
-          <tr>
-            <th className="border p-2">Title</th>
-            <th className="border p-2">Category</th>
-            <th className="border p-2">Content</th>
-            <th className="border p-2">Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => (
-            <tr key={item.id}>
-              <td className="border p-2 align-top">{item.title}</td>
-              <td className="border p-2 align-top">{item.category}</td>
-              <td className="border p-2 whitespace-pre-wrap align-top">
-                {item.content.length > 50 ? item.content.slice(0, 50) + "..." : item.content}
-              </td>
-              <td className="border p-2 align-top">
-                <button onClick={() => handleCopy(item.content)} className="mr-2 text-sm text-blue-600">Copy</button>
-                <button onClick={() => handleDelete(item.id)} className="text-sm text-red-600">Delete</button>
-              </td>
-            </tr>
-          ))}
-          {items.length === 0 && (
-            <tr>
-              <td colSpan="4" className="border p-2 text-center italic">No items</td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+      {credentials.length > 0 && (
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Credentials</h2>
+          <div className={gridStyle}>
+            {credentials.map(renderCredential)}
+          </div>
+        </div>
+      )}
+
+      {commands.length > 0 && (
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Commands</h2>
+          <div className={gridStyle}>
+            {commands.map(renderCommand)}
+          </div>
+        </div>
+      )}
+
+      {others.length > 0 && (
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Other Items</h2>
+          <div className={gridStyle}>
+            {others.map(renderOther)}
+          </div>
+        </div>
+      )}
+
+      {items.length === 0 && searchQuery === "" && (
+        <p className="italic">No items yet. Add a new credential, command, or snippet above!</p>
+      )}
+      {items.length === 0 && searchQuery !== "" && (
+        <p className="italic">No items match your search.</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- replace Vault page with new dashboard-style grid layout
- support inline editing, copying, and exporting items

## Testing
- `yarn install` *(fails: 403 due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686fc3646ec08322a49fbbe2aaba6768