### PR TITLE
Add combined legal page

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -22,6 +22,7 @@ import Ticket from "../pages/Ticket";
 import Contact from "../pages/Contact";
 import Weather from "../pages/Weather";
 import Vault from "../pages/Vault";
+import Legal from "../pages/Legal";
 
 
 function AuthLayout({ children }) {
@@ -46,8 +47,11 @@ const App = () => {
               <Route path="/login" element={<AuthLayout><Login /></AuthLayout>} />
               <Route path="/event" element={<MainLayout><Event /></MainLayout>} />
               <Route path="/contact" element={<MainLayout><Contact /></MainLayout>} />
-                <Route path="/weather" element={<MainLayout><Weather /></MainLayout>} />
-                <Route path="/ticket" element={<MainLayout><Ticket /></MainLayout>} />
+              <Route path="/weather" element={<MainLayout><Weather /></MainLayout>} />
+              <Route path="/ticket" element={<MainLayout><Ticket /></MainLayout>} />
+              <Route path="/legal" element={<MainLayout><Legal /></MainLayout>} />
+              <Route path="/privacy" element={<MainLayout><Legal /></MainLayout>} />
+              <Route path="/terms" element={<MainLayout><Legal /></MainLayout>} />
 
               {/* 🔐 Protected */}
               <Route path="/" element={<PrivateRoute><MainLayout><PdfPage /></MainLayout></PrivateRoute>} />

--- a/app/javascript/components/Footer.jsx
+++ b/app/javascript/components/Footer.jsx
@@ -9,11 +9,8 @@ const Footer = () => {
           &copy; {new Date().getFullYear()} <span className="text-indigo-700 font-medium">MyApp</span>. All rights reserved.
         </p>
         <div className="flex mt-2 md:mt-0 space-x-4">
-          <Link to="/privacy" className="hover:text-indigo-600 transition">
-            Privacy Policy
-          </Link>
-          <Link to="/terms" className="hover:text-indigo-600 transition">
-            Terms
+          <Link to="/legal" className="hover:text-indigo-600 transition">
+            Privacy & Terms
           </Link>
           <Link to="/contact" className="hover:text-indigo-600 transition">
             Contact

--- a/app/javascript/pages/Legal.jsx
+++ b/app/javascript/pages/Legal.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+const Legal = () => (
+  <div className="max-w-4xl mx-auto p-8 bg-white shadow rounded-lg">
+    <h1 className="text-3xl font-bold text-center text-indigo-700 mb-8">Privacy & Terms</h1>
+    <section className="mb-8">
+      <h2 className="text-2xl font-semibold mb-2">Privacy Policy</h2>
+      <p className="text-gray-700 leading-relaxed">
+        We value your privacy and only collect the minimum information required to provide our services. Any data you share with us will never be sold and is used solely to improve your experience.
+      </p>
+    </section>
+    <section>
+      <h2 className="text-2xl font-semibold mb-2">Terms of Service</h2>
+      <p className="text-gray-700 leading-relaxed">
+        By using this application you agree to use it responsibly and comply with all applicable laws. We reserve the right to update these terms at any time.
+      </p>
+    </section>
+  </div>
+);
+
+export default Legal;


### PR DESCRIPTION
## Summary
- combine privacy policy and terms of service into one page
- update footer link
- route `/legal`, `/privacy`, and `/terms` to new legal page

## Testing
- `npm test` *(fails: Missing script)*
- `bin/rails test` *(fails: Ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6870dca19a68832292eedb661e8be7af