### PR TITLE
Display tasks on user profile

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -3,7 +3,8 @@ class Api::TasksController < Api::BaseController
 
   # GET /tasks.json
   def index
-    @tasks = Task.order(date: :asc).all
+    @tasks = Task.order(date: :asc)
+    @tasks = @tasks.where(assigned_to: params[:assigned_to]) if params[:assigned_to].present?
     render json: @tasks
   end
 

--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { fetchUserInfo, updateUserInfo, fetchPosts } from "../components/api"; // Adjust the import path as necessary
+import { fetchUserInfo, updateUserInfo, fetchPosts, SchedulerAPI } from "../components/api"; // Adjust the import path as necessary
 
 const Profile = () => {
   const [user, setUser] = useState(null);
   const [posts, setPosts] = useState([]);
+  const [tasks, setTasks] = useState([]);
   const [editMode, setEditMode] = useState(false);
   const [formData, setFormData] = useState({
     first_name: "",
@@ -24,6 +25,8 @@ const Profile = () => {
       });
       const postsResponse = await fetchPosts(data.user.id);
       setPosts(postsResponse.data);
+      const tasksResponse = await SchedulerAPI.getTasks({ assigned_to: data.user.id });
+      setTasks(tasksResponse.data);
     } catch (error) {
       console.error("Error fetching user info:", error);
     }
@@ -157,6 +160,26 @@ const Profile = () => {
                 </div>
               ) : (
                 <p className="text-center text-gray-500 py-8">You haven't posted anything yet.</p>
+              )}
+            </div>
+
+            {/* Tasks Section */}
+            <div className="mt-12">
+              <h2 className="text-2xl font-bold text-gray-700 mb-6">My Tasks</h2>
+              {tasks.length > 0 ? (
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                  {tasks.map((task) => (
+                    <div key={task.id} className="bg-white rounded-xl shadow-md p-5">
+                      <h3 className="text-lg font-semibold text-gray-800 break-all">{task.task_id}</h3>
+                      <p className="text-sm text-gray-500 capitalize">{task.status}</p>
+                      {task.due_date && (
+                        <p className="text-sm text-gray-500">Due {new Date(task.due_date).toLocaleDateString()}</p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-center text-gray-500 py-8">No tasks assigned.</p>
               )}
             </div>
           </div>

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -54,7 +54,7 @@ export const SchedulerAPI = {
   createDeveloper: (data) => api.post("/developers.json", { developer: data }),
 
   // Tasks
-  getTasks: () => api.get("/tasks.json"),
+  getTasks: (params = {}) => api.get("/tasks.json", { params }),
   createTask: (data) => api.post("/tasks.json", { task: data }),
   updateTask: (id, data) => api.patch(`/tasks/${id}.json`, { task: data }),
   deleteTask: (id) => api.delete(`/tasks/${id}.json`),


### PR DESCRIPTION
## Summary
- filter tasks in API by `assigned_to`
- allow `SchedulerAPI.getTasks` to accept query params
- show tasks assigned to the current user on the profile page

## Testing
- `bundle exec rake test` *(fails: ruby-3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871218db930832296ce49d57debf7d1