### PR TITLE
Split assigned_to column

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -39,6 +39,6 @@ class Api::TasksController < Api::BaseController
   end
 
   def task_params
-    params.require(:task).permit(:task_id, :task_url, :type, :status, :order, :assigned_to, :created_by, :created_at, :updated_by, :updated_at, :due_date, :estimated_hours, :date, :sprint_id, :developer_id, :is_struck)
+    params.require(:task).permit(:task_id, :task_url, :type, :status, :order, :assigned_to_user, :assigned_to_developer, :created_by, :created_at, :updated_by, :updated_at, :due_date, :estimated_hours, :date, :sprint_id, :developer_id, :is_struck)
   end
 end

--- a/app/javascript/components/TodoBoard/TaskCard.jsx
+++ b/app/javascript/components/TodoBoard/TaskCard.jsx
@@ -10,14 +10,14 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
       content: item.task_id,
       due: item.due || '',
       tags: (item.tags || []).join(', '),
-      assignedTo: item.assignedTo || '',
+      assigned_to_user: item.assigned_to_user || '',
       recurring: item.recurring || ''
   });
 
   const handleSave = () => {
     const updates = {
         ...editDetails,
-        tags: editDetails.tags.split(',').map(t=>t.trim())
+        tags: editDetails.tags.split(',').map(t => t.trim())
     };
     onUpdate(columnId, item.id, updates);
     setIsEditing(false);
@@ -28,7 +28,7 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
       <input value={editDetails.content} onChange={(e) => setEditDetails(prev => ({ ...prev, content: e.target.value }))} placeholder="Task content" className="border p-2 rounded" />
       <input type="date" value={editDetails.due} onChange={(e) => setEditDetails(prev => ({ ...prev, due: e.target.value }))} className="border p-2 rounded" />
       <input value={editDetails.tags} onChange={(e) => setEditDetails(prev => ({ ...prev, tags: e.target.value }))} placeholder="Comma-separated tags" className="border p-2 rounded" />
-      <input value={editDetails.assignedTo} onChange={(e) => setEditDetails(prev => ({ ...prev, assignedTo: e.target.value }))} placeholder="Assigned To" className="border p-2 rounded" />
+      <input value={editDetails.assigned_to_user} onChange={(e) => setEditDetails(prev => ({ ...prev, assigned_to_user: e.target.value }))} placeholder="Assigned To" className="border p-2 rounded" />
       <select value={editDetails.recurring} onChange={(e) => setEditDetails(prev => ({ ...prev, recurring: e.target.value }))} className="border p-2 rounded">
         <option value="">One-time</option>
         <option value="daily">Daily</option>
@@ -56,7 +56,7 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
             </div>
         )}
         {item.createdBy && <div className="text-xs text-gray-600 mt-1">Created by: {item.createdBy}</div>}
-        {item.assignedTo && <div className="text-xs text-gray-600">Assigned to: {item.assignedTo}</div>}
+        {item.assigned_to_user && <div className="text-xs text-gray-600">Assigned to: {item.assigned_to_user}</div>}
     </div>
   );
 

--- a/app/javascript/components/TodoBoard/TaskForm.jsx
+++ b/app/javascript/components/TodoBoard/TaskForm.jsx
@@ -19,7 +19,7 @@ const TaskForm = ({ onAddTask }) => {
       content,
       due: dueDate,
       tags: tags.split(',').map(t => t.trim()),
-      assigned_to: assignedTo,
+      assigned_to_user: assignedTo,
       recurring,
       status: 'todo'
     };

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -126,7 +126,7 @@ const TaskDetailsModal = ({ task, developers, onClose, onUpdate }) => {
                         </div>
                         <div>
                             <label htmlFor="assignedTo" className="block text-sm font-medium text-gray-700 mb-1">
-                                Assigned To
+                                Assigned To Developer
                             </label>
                             <select
                                 id="assignedTo"
@@ -142,6 +142,19 @@ const TaskDetailsModal = ({ task, developers, onClose, onUpdate }) => {
                                     </option>
                                 ))}
                             </select>
+                        </div>
+                        <div>
+                            <label htmlFor="assignedUser" className="block text-sm font-medium text-gray-700 mb-1">
+                                Assigned User ID
+                            </label>
+                            <input
+                                type="number"
+                                id="assignedUser"
+                                name="assignedUser"
+                                value={editedTask.assignedUser || ''}
+                                onChange={handleChange}
+                                className="mt-1 block w-full p-3 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
+                            />
                         </div>
                         <div>
                             <label htmlFor="scheduledStartDate" className="block text-sm font-medium text-gray-700 mb-1">
@@ -226,6 +239,8 @@ const SprintDashboard = () => {
                 estimatedHours: t.estimated_hours,
                 status: t.status === 'done' ? 'Done' : t.status === 'inprogress' ? 'In Progress' : 'To Do',
                 assignedTo: [t.developer_id].filter(Boolean).map(String),
+                assignedUser: t.assigned_to_user,
+                assignedDeveloper: t.assigned_to_developer,
                 order: t.order,
                 scheduledStartDate: t.date,
                 scheduledEndDate: t.due_date || t.date,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   has_one_attached :profile_picture
   has_many :posts
-  has_many :tasks, foreign_key: :assigned_to
+  has_many :tasks, foreign_key: :assigned_to_user
   has_many :items
 
   # This is a class attribute that will store the current user for the current request.

--- a/db/migrate/20250712000001_split_assigned_to_columns.rb
+++ b/db/migrate/20250712000001_split_assigned_to_columns.rb
@@ -1,0 +1,6 @@
+class SplitAssignedToColumns < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :tasks, :assigned_to, :assigned_to_user
+    add_column :tasks, :assigned_to_developer, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -107,7 +107,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_11_000000) do
     t.boolean "is_struck", default: false
     t.string "status", default: "todo"
     t.integer "order", default: 0
-    t.integer "assigned_to"
+    t.integer "assigned_to_user"
+    t.integer "assigned_to_developer"
     t.integer "created_by"
     t.integer "updated_by"
     t.date "due_date"


### PR DESCRIPTION
## Summary
- rename `tasks.assigned_to` to `assigned_to_user`
- allow `assigned_to_user` and new `assigned_to_developer` params
- update association in `User` model
- update Todo board code for new user field
- display assigned user id in sprint dashboard modal
- add migration to split fields

## Testing
- `bin/rails test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68712274c7088322a49d0662c1815406