### PR TITLE
Add task title and date fields

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -40,6 +40,12 @@ class Api::TasksController < Api::BaseController
   end
 
   def task_params
-    params.require(:task).permit(:task_id, :task_url, :type, :status, :order, :assigned_to_user, :assigned_to_developer, :created_by, :created_at, :updated_by, :updated_at, :due_date, :estimated_hours, :date, :sprint_id, :developer_id, :is_struck)
+    params.require(:task).permit(
+      :task_id, :task_url, :type, :title, :description,
+      :status, :order, :assigned_to_user, :assigned_to_developer,
+      :created_by, :created_at, :updated_by, :updated_at,
+      :due_date, :date, :start_date, :end_date,
+      :estimated_hours, :sprint_id, :developer_id, :is_struck
+    )
   end
 end

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -167,27 +167,27 @@ const TaskDetailsModal = ({ task, developers, users, onClose, onUpdate }) => {
                             </select>
                         </div>
                         <div>
-                            <label htmlFor="scheduledStartDate" className="block text-sm font-medium text-gray-700 mb-1">
-                                Scheduled Start Date
+                            <label htmlFor="startDate" className="block text-sm font-medium text-gray-700 mb-1">
+                                Start Date
                             </label>
                             <input
                                 type="date"
-                                id="scheduledStartDate"
-                                name="scheduledStartDate"
-                                value={editedTask.scheduledStartDate}
+                                id="startDate"
+                                name="startDate"
+                                value={editedTask.startDate}
                                 onChange={handleChange}
                                 className="mt-1 block w-full p-3 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
                             />
                         </div>
                         <div>
-                            <label htmlFor="scheduledEndDate" className="block text-sm font-medium text-gray-700 mb-1">
-                                Scheduled End Date
+                            <label htmlFor="endDate" className="block text-sm font-medium text-gray-700 mb-1">
+                                End Date
                             </label>
                             <input
                                 type="date"
-                                id="scheduledEndDate"
-                                name="scheduledEndDate"
-                                value={editedTask.scheduledEndDate}
+                                id="endDate"
+                                name="endDate"
+                                value={editedTask.endDate}
                                 onChange={handleChange}
                                 className="mt-1 block w-full p-3 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500"
                             />
@@ -245,8 +245,8 @@ const SprintDashboard = () => {
                 id: t.task_id,
                 dbId: t.id,
                 sprintId: t.sprint_id,
-                title: `${t.type}`,
-                description: '',
+                title: t.title || 'title not added',
+                description: t.description || '',
                 link: t.task_url,
                 estimatedHours: t.estimated_hours,
                 status: t.status === 'done' ? 'Done' : t.status === 'inprogress' ? 'In Progress' : 'To Do',
@@ -254,8 +254,8 @@ const SprintDashboard = () => {
                 assignedUser: t.assigned_to_user,
                 assignedDeveloper: t.assigned_to_developer,
                 order: t.order,
-                scheduledStartDate: t.date,
-                scheduledEndDate: t.due_date || t.date,
+                startDate: t.start_date || t.date,
+                endDate: t.end_date || t.due_date || t.date,
             }));
             setTasks(mapped);
         });
@@ -279,8 +279,18 @@ const SprintDashboard = () => {
         setShowTaskModal(true);
     };
 
-    const handleUpdateTask = (updatedTask) => {
-        setTasks(tasks.map(t => t.id === updatedTask.id ? updatedTask : t));
+    const handleUpdateTask = async (updatedTask) => {
+        try {
+            await SchedulerAPI.updateTask(updatedTask.dbId, {
+                title: updatedTask.title,
+                description: updatedTask.description,
+                start_date: updatedTask.startDate,
+                end_date: updatedTask.endDate
+            });
+            setTasks(tasks.map(t => t.id === updatedTask.id ? { ...updatedTask, title: updatedTask.title || 'title not added' } : t));
+        } catch (e) {
+            console.error('Failed to update task', e);
+        }
         setShowTaskModal(false);
     };
 
@@ -354,10 +364,10 @@ const SprintDashboard = () => {
                                     Assigned To
                                 </th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Scheduled Start
+                                    Start Date
                                 </th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                    Scheduled End
+                                    End Date
                                 </th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider rounded-tr-xl">
                                     Status
@@ -386,10 +396,10 @@ const SprintDashboard = () => {
                                             {getDeveloperNames(task.assignedTo)}
                                         </td>
                                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                            {new Date(task.scheduledStartDate).getDate()}
+                                            {new Date(task.startDate).getDate()}
                                         </td>
                                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                                            {new Date(task.scheduledEndDate).getDate()}
+                                            {new Date(task.endDate).getDate()}
                                         </td>
                                         <td className="px-6 py-4 whitespace-nowrap text-sm">
                                             <span className={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full

--- a/db/migrate/20250715000000_add_title_description_and_dates_to_tasks.rb
+++ b/db/migrate/20250715000000_add_title_description_and_dates_to_tasks.rb
@@ -1,0 +1,8 @@
+class AddTitleDescriptionAndDatesToTasks < ActiveRecord::Migration[7.1]
+  def change
+    add_column :tasks, :title, :string
+    add_column :tasks, :description, :text
+    add_column :tasks, :start_date, :date
+    add_column :tasks, :end_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -98,8 +98,12 @@ ActiveRecord::Schema[7.1].define(version: 2025_07_11_000000) do
     t.string "task_id", null: false
     t.string "task_url"
     t.string "type", null: false
+    t.string "title"
+    t.text "description"
     t.decimal "estimated_hours", precision: 5, scale: 2
     t.date "date", null: false
+    t.date "start_date"
+    t.date "end_date"
     t.bigint "sprint_id"
     t.bigint "developer_id", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
## Summary
- add migration for new title/description and start/end dates
- allow new attributes in TasksController
- display task title and dates in SprintDashboard
- update task details modal to edit new fields

## Testing
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687127547e7c8322ae9d17793e002312