### PR TITLE
Add status colors on profile tasks

### DIFF
--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { fetchUserInfo, updateUserInfo, fetchPosts, SchedulerAPI } from "../components/api"; // Adjust the import path as necessary
+import { getStatusClasses } from '/utils/taskUtils';
 
 const Profile = () => {
   const [user, setUser] = useState(null);
@@ -171,7 +172,7 @@ const Profile = () => {
                   {tasks.map((task) => (
                     <div key={task.id} className="bg-white rounded-xl shadow-md p-5">
                       <h3 className="text-lg font-semibold text-gray-800 break-all">{task.task_id}</h3>
-                      <p className="text-sm text-gray-500 capitalize">{task.status}</p>
+                      <span className={`text-sm px-2 py-1 rounded-full font-medium capitalize ${getStatusClasses(task.status)}`}>{task.status}</span>
                       {task.due_date && (
                         <p className="text-sm text-gray-500">Due {new Date(task.due_date).toLocaleDateString()}</p>
                       )}

--- a/app/javascript/utils/taskUtils.js
+++ b/app/javascript/utils/taskUtils.js
@@ -28,3 +28,10 @@ export const getDueColor = (due) => {
     const today = new Date().toISOString().split("T")[0];
     return due < today ? "text-red-600" : due === today ? "text-green-600" : "text-gray-500";
 };
+
+export const getStatusClasses = (status) => {
+    const normalized = (status || '').toLowerCase();
+    if (normalized === 'done') return 'bg-green-100 text-green-800';
+    if (normalized === 'inprogress' || normalized === 'in progress') return 'bg-yellow-100 text-yellow-800';
+    return 'bg-blue-100 text-blue-800';
+};


### PR DESCRIPTION
## Summary
- colorize task status on profile page using new helper
- add `getStatusClasses` helper for color mapping

## Testing
- `bundle exec rake test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68712a6264b48322b4f0be62455e68c8