### PR TITLE
Filter tasks by selected sprint

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -5,6 +5,7 @@ class Api::TasksController < Api::BaseController
   def index
     @tasks = Task.order(date: :asc)
     @tasks = @tasks.where(assigned_to_user: params[:assigned_to_user]) if params[:assigned_to_user].present?
+    @tasks = @tasks.where(sprint_id: params[:sprint_id]) if params[:sprint_id].present?
     render json: @tasks
   end
 

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -240,7 +240,17 @@ const SprintDashboard = () => {
     useEffect(() => {
         SchedulerAPI.getDevelopers().then(res => setDevelopers(res.data));
         getUsers().then(res => setUsers(Array.isArray(res.data) ? res.data : []));
-        SchedulerAPI.getTasks().then(res => {
+        fetch('/api/sprints.json')
+            .then(res => res.json())
+            .then(data => {
+                setSprints(data);
+                if (data.length) setSelectedSprintId(data[0].id);
+            });
+    }, []);
+
+    useEffect(() => {
+        if (selectedSprintId === null) return;
+        SchedulerAPI.getTasks({ sprint_id: selectedSprintId }).then(res => {
             const mapped = res.data.map(t => ({
                 id: t.task_id,
                 dbId: t.id,
@@ -259,13 +269,7 @@ const SprintDashboard = () => {
             }));
             setTasks(mapped);
         });
-        fetch('/api/sprints.json')
-            .then(res => res.json())
-            .then(data => {
-                setSprints(data);
-                if (data.length) setSelectedSprintId(data[0].id);
-            });
-    }, []);
+    }, [selectedSprintId]);
 
     const filteredTasks = tasks.filter(task => task.sprintId === selectedSprintId);
 


### PR DESCRIPTION
## Summary
- filter tasks API by `sprint_id`
- load tasks for the selected sprint in `SprintDashboard`

## Testing
- `bin/rails test` *(fails: ruby-3.3.0 not installed)*
- `bundle exec rake test` *(fails: ruby-3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68712af172e08322a3433b10f13e9679