### PR TITLE
Add sprint filtering to TodoBoard

### DIFF
--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -46,6 +46,7 @@ api.interceptors.response.use(
 export const SchedulerAPI = {
   // Sprints
   getLastSprint: () => api.get("/sprints/last.json"),
+  getSprints: () => api.get("/sprints.json"),
   createSprint: (data) => api.post("/sprints.json", { sprint: data }),
   updateSprint: (id, data) => api.put(`/sprints/${id}.json`, { sprint: data }),
 


### PR DESCRIPTION
## Summary
- add API helper to list sprints
- display sprint selector in TodoBoard
- filter tasks by selected sprint and list them below the board

## Testing
- `bin/rails test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6874bfd6787483229f84aab287997faa