### PR TITLE
Unify sprint selector

### DIFF
--- a/app/javascript/components/Scheduler/Scheduler.jsx
+++ b/app/javascript/components/Scheduler/Scheduler.jsx
@@ -6,7 +6,6 @@ import { SchedulerAPI } from '../api';
 // Assuming these are your existing form components
 import AddTaskForm from '../Scheduler/AddTaskForm';
 import EditTaskForm from '../Scheduler/EditTaskForm';
-import SprintManager from '../Scheduler/SprintManager';
 
 import {
   PlusCircleIcon,
@@ -17,8 +16,6 @@ import {
   XCircleIcon,
   Bars3Icon, // Drag Handle
   CalendarDaysIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
   UserGroupIcon,
   TableCellsIcon,
   ExclamationTriangleIcon,
@@ -222,7 +219,6 @@ function Scheduler({ sprintId }) {
   const [tasks, setTasks] = useState([]);
   const types = useMemo(() => ['Code', 'Code review', 'Dev to QA', 'Planning', 'Testing', 'Bug Fixing'], []);
 
-  const [isHeaderExpanded, setIsHeaderExpanded] = useState(false); // New state for header expansion
   const [loading, setLoading] = useState({sprint: true, developers: true, tasks: true});
   const [error, setError] = useState(null);
   
@@ -454,9 +450,8 @@ function Scheduler({ sprintId }) {
   
   if (!sprint) {
     return (
-      <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-4">
-          <SprintManager onSprintChange={(updatedSprint) => setSprint(updatedSprint)} />
-          {!loading.sprint && <p className="mt-4 text-gray-600">No active sprint found or failed to load. Please select or create a sprint.</p>}
+      <div className="min-h-screen flex items-center justify-center text-gray-600">
+        {!loading.sprint && <p>No active sprint selected.</p>}
       </div>
     );
   }
@@ -473,28 +468,7 @@ function Scheduler({ sprintId }) {
             <h1 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-sky-500 flex items-center">
               <CalendarDaysIcon className="h-7 w-7 mr-2"/>Sprint Task Manager
             </h1>
-
-            {/* Collapsible area for sprint details */}
-            <div className="flex items-center space-x-3 cursor-pointer" onClick={() => setIsHeaderExpanded(!isHeaderExpanded)}>
-              {sprint && (
-                <p className="text-sm text-gray-600">
-                  Current Sprint: <span className="font-semibold">{sprint.name || `Sprint ending ${formatDate(sprint.end_date)}`}</span>
-                </p>
-              )}
-              {isHeaderExpanded ? (
-                <ChevronUpIcon className="h-5 w-5 text-gray-500" />
-              ) : (
-                <ChevronDownIcon className="h-5 w-5 text-gray-500" />
-              )}
-            </div>
           </div>
-
-          {/* Expanded content area - conditionally rendered */}
-          {isHeaderExpanded && (
-            <div className="mt-4 border-t border-gray-200 pt-4">
-              <SprintManager onSprintChange={(updatedSprint) => setSprint(updatedSprint)} currentSprint={sprint} />
-            </div>
-          )}
         </div>
       </header>
 

--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -165,19 +165,6 @@ export default function TodoBoard({ sprintId, onSprintChange }) {
       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 mb-6">
         <div className="flex items-center gap-4">
           <h1 className="text-3xl font-semibold text-blue-700 tracking-tight">MyForm Task Control Center</h1>
-          <select
-            className="border px-2 py-1 rounded-md"
-            value={selectedSprintId || ''}
-            onChange={e => {
-              const val = Number(e.target.value);
-              setSelectedSprintId(val);
-              onSprintChange && onSprintChange(val);
-            }}
-          >
-            {sprints.map(s => (
-              <option key={s.id} value={s.id}>{s.name}</option>
-            ))}
-          </select>
         </div>
         <button onClick={() => setShowForm(prev => !prev)} className="bg-indigo-600 text-white px-4 py-2 rounded-lg shadow hover:bg-indigo-700 transition-all">
           {showForm ? 'Close Form' : '+ New Task'}

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { CalendarDaysIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import SprintOverview from './SprintOverview';
 import Scheduler from '../components/Scheduler/Scheduler';
 import TodoBoard from '../components/TodoBoard/TodoBoard';
@@ -7,24 +8,54 @@ import SprintManager from '../components/Scheduler/SprintManager';
 export default function SprintDashboard() {
   const [activeTab, setActiveTab] = useState('overview');
   const [sprintId, setSprintId] = useState(null);
+  const [sprint, setSprint] = useState(null);
+  const [isHeaderExpanded, setIsHeaderExpanded] = useState(false);
+
+  const handleSprintChange = (s) => {
+    setSprint(s);
+    setSprintId(s?.id || null);
+  };
 
   return (
     <div className="space-y-6">
-      <h1 className="text-3xl font-bold text-center mb-4">Sprint Dashboard</h1>
-      <SprintManager onSprintChange={s => setSprintId(s?.id)} />
+      <header className="bg-white shadow-sm p-4">
+        <div className="flex justify-between items-center">
+          <h1 className="text-2xl font-bold text-gray-800 flex items-center">
+            <CalendarDaysIcon className="h-7 w-7 mr-2 text-blue-600"/>
+            Sprint Task Manager
+          </h1>
+          <div className="flex items-center space-x-3 cursor-pointer" onClick={() => setIsHeaderExpanded(!isHeaderExpanded)}>
+            {sprint && (
+              <p className="text-sm text-gray-600">
+                Current Sprint: <span className="font-semibold">{sprint.name}</span>
+              </p>
+            )}
+            {isHeaderExpanded ? (
+              <ChevronUpIcon className="h-5 w-5 text-gray-500" />
+            ) : (
+              <ChevronDownIcon className="h-5 w-5 text-gray-500" />
+            )}
+          </div>
+        </div>
+        {isHeaderExpanded && (
+          <div className="mt-4 border-t border-gray-200 pt-4">
+            <SprintManager onSprintChange={handleSprintChange} />
+          </div>
+        )}
+      </header>
       <div className="flex justify-center space-x-4 my-4">
         <button className={`px-4 py-2 rounded-md ${activeTab==='overview'?'bg-indigo-600 text-white':'bg-gray-200'}`} onClick={() => setActiveTab('overview')}>Overview</button>
         <button className={`px-4 py-2 rounded-md ${activeTab==='scheduler'?'bg-indigo-600 text-white':'bg-gray-200'}`} onClick={() => setActiveTab('scheduler')}>Scheduler</button>
         <button className={`px-4 py-2 rounded-md ${activeTab==='todo'?'bg-indigo-600 text-white':'bg-gray-200'}`} onClick={() => setActiveTab('todo')}>Todo</button>
       </div>
       {activeTab === 'overview' && (
-        <SprintOverview sprintId={sprintId} onSprintChange={setSprintId} />
+        <SprintOverview sprintId={sprintId} onSprintChange={handleSprintChange} />
       )}
       {activeTab === 'scheduler' && (
         <Scheduler sprintId={sprintId} />
       )}
       {activeTab === 'todo' && (
-        <TodoBoard sprintId={sprintId} onSprintChange={setSprintId} />
+        <TodoBoard sprintId={sprintId} onSprintChange={handleSprintChange} />
       )}
     </div>
   );

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -331,28 +331,6 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
                     Sprint Management Dashboard
                 </h1>
 
-                {/* Sprint Selector */}
-                <div className="mb-8 flex flex-col md:flex-row items-center justify-center space-y-4 md:space-y-0 md:space-x-4">
-                    <label htmlFor="sprint-select" className="text-lg font-semibold text-gray-700">
-                        Select Sprint:
-                    </label>
-                    <select
-                        id="sprint-select"
-                        className="p-3 border border-gray-300 rounded-lg shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-lg"
-                        value={selectedSprintId || ''}
-                        onChange={(e) => {
-                            const val = Number(e.target.value);
-                            setSelectedSprintId(val);
-                            if(onSprintChange) onSprintChange(val);
-                        }}
-                    >
-                        {sprints.map((sprint) => (
-                            <option key={sprint.id} value={sprint.id}>
-                                {sprint.name} ({sprint.start_date} to {sprint.end_date})
-                            </option>
-                        ))}
-                    </select>
-                </div>
 
                 {/* Current Sprint Overview */}
                 {selectedSprintId && (


### PR DESCRIPTION
## Summary
- add sprint manager dropdown header to `SprintDashboard`
- remove in-page sprint selector from `SprintOverview` and `TodoBoard`
- drop sprint manager UI from `Scheduler`

## Testing
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6874cf8913888322ab7c9788014b3eb7