### PR TITLE
Remove scheduler/todo routes

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -11,10 +11,8 @@ import Signup from "../pages/Signup";
 import Login from "../pages/Login";
 import PostPage from "../pages/PostPage";
 import Profile from "../components/Profile";
-import TodoBoard from "../components/TodoBoard/TodoBoard";
 import PdfEditor from '../pages/PdfEditor';
 import KnowledgeDashboard from "../pages/KnowledgeDashboard";
-import Scheduler from '../components/Scheduler/Scheduler';
 import Admin from '../components/Admin/Admin';
 import Users from "../pages/Users";
 import Event from "../pages/Event";
@@ -57,10 +55,8 @@ const App = () => {
               <Route path="/posts" element={<PrivateRoute><MainLayout><PostPage /></MainLayout></PrivateRoute>} />
               <Route path="/vault" element={<PrivateRoute><MainLayout><Vault /></MainLayout></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
-              <Route path="/todo" element={<PrivateRoute><MainLayout><TodoBoard /></MainLayout></PrivateRoute>} />
               <Route path="/pdf_editor" element={<PrivateRoute><MainLayout><PdfEditor /></MainLayout></PrivateRoute>} />
               <Route path="/knowledge" element={<PrivateRoute><MainLayout><KnowledgeDashboard /></MainLayout></PrivateRoute>} />
-              <Route path="/scheduler" element={<PrivateRoute><MainLayout><Scheduler /></MainLayout></PrivateRoute>} />
               <Route path="/sprint_dashboard" element={<PrivateRoute><MainLayout><SprintDashboard /></MainLayout></PrivateRoute>} />
               <Route path="/users" element={<PrivateRoute><MainLayout><Users /></MainLayout></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute><MainLayout><Admin /></MainLayout></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -17,7 +17,7 @@ const Navbar = () => {
           <nav className="flex items-center gap-6">
             {user ? (
               <>
-                {["posts", "Event", "weather", "vault", "sprint_dashboard", "scheduler", "todo", "pdf_editor", "knowledge", "profile", "users", "admin", "contact"].map((route) => (
+                {["posts", "Event", "weather", "vault", "sprint_dashboard", "pdf_editor", "knowledge", "profile", "users", "admin", "contact"].map((route) => (
                   <NavLink
                     key={route}
                     to={`/${route}`}


### PR DESCRIPTION
## Summary
- remove the standalone scheduler and todo routes
- drop scheduler and todo options from the navigation menu

## Testing
- `npm test` *(fails: Missing script)*
- `bundle exec rake test` *(fails: ruby-3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6874d4c7502c8322b049489768f93c79