### PR TITLE
Add vault dropdown

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, lazy, Suspense } from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 import { AuthProvider } from "../context/AuthContext";
@@ -19,7 +19,7 @@ import Event from "../pages/Event";
 import Ticket from "../pages/Ticket";
 import Contact from "../pages/Contact";
 import Weather from "../pages/Weather";
-import Vault from "../pages/Vault";
+const Vault = lazy(() => import("../pages/Vault"));
 import Legal from "../pages/Legal";
 import SprintDashboard from "../pages/SprintDashboard";
 
@@ -32,13 +32,15 @@ function MainLayout({ children }) {
   return <main className="pt-20 pb-16 p-6 flex-grow">{children}</main>;
 }
 const App = () => {
+  const [showVault, setShowVault] = useState(false);
+
   return (
     <Router>
       <AuthProvider> {/* ✅ Wrap the entire app with AuthProvider */}
         <div className="flex flex-col min-h-screen">
 
           {/* ✅ Navbar */}
-          <Navbar />
+          <Navbar toggleVault={() => setShowVault(v => !v)} />
 
           {/* ✅ Page Content */}
             <Routes>
@@ -53,7 +55,6 @@ const App = () => {
               {/* 🔐 Protected */}
               <Route path="/" element={<PrivateRoute><MainLayout><PdfPage /></MainLayout></PrivateRoute>} />
               <Route path="/posts" element={<PrivateRoute><MainLayout><PostPage /></MainLayout></PrivateRoute>} />
-              <Route path="/vault" element={<PrivateRoute><MainLayout><Vault /></MainLayout></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
               <Route path="/pdf_editor" element={<PrivateRoute><MainLayout><PdfEditor /></MainLayout></PrivateRoute>} />
               <Route path="/knowledge" element={<PrivateRoute><MainLayout><KnowledgeDashboard /></MainLayout></PrivateRoute>} />
@@ -61,6 +62,22 @@ const App = () => {
               <Route path="/users" element={<PrivateRoute><MainLayout><Users /></MainLayout></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute><MainLayout><Admin /></MainLayout></PrivateRoute>} />
               </Routes>
+
+          {showVault && (
+            <div className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex justify-center items-start pt-20 z-50 overflow-auto">
+              <div className="bg-white w-full max-w-4xl mx-4 my-8 rounded shadow-lg relative">
+                <button
+                  onClick={() => setShowVault(false)}
+                  className="absolute top-2 right-2 text-gray-500"
+                >
+                  &times;
+                </button>
+                <Suspense fallback={<div className='p-4'>Loading...</div>}>
+                  <Vault />
+                </Suspense>
+              </div>
+            </div>
+          )}
 
           {/* ✅ Footer */}
           <Footer />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -1,9 +1,10 @@
 import React, { useContext } from "react";
+import { ChevronDownIcon } from "@heroicons/react/24/outline";
 import { Link, NavLink } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
 import logo from "../images/logo.webp";
 
-const Navbar = () => {
+const Navbar = ({ toggleVault }) => {
   const { user, handleLogout } = useContext(AuthContext);
 
   return (
@@ -17,7 +18,7 @@ const Navbar = () => {
           <nav className="flex items-center gap-6">
             {user ? (
               <>
-                {["posts", "Event", "weather", "vault", "sprint_dashboard", "pdf_editor", "knowledge", "profile", "users", "admin", "contact"].map((route) => (
+                {["posts", "Event", "weather", "sprint_dashboard", "pdf_editor", "knowledge", "profile", "users", "admin", "contact"].map((route) => (
                   <NavLink
                     key={route}
                     to={`/${route}`}
@@ -30,6 +31,13 @@ const Navbar = () => {
                     {route.charAt(0).toUpperCase() + route.slice(1).replace("_", " ")}
                   </NavLink>
                 ))}
+
+                <button
+                  onClick={toggleVault}
+                  className="flex items-center text-gray-700 font-medium hover:text-indigo-600 transition"
+                >
+                  Vault <ChevronDownIcon className="h-4 w-4 ml-1" />
+                </button>
 
                 <button
                   onClick={handleLogout}


### PR DESCRIPTION
## Summary
- expose vault everywhere via dropdown in navbar
- lazy load vault component on demand
- refactor navigation links accordingly

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e503bd3083229ebfe7a0976a5ba7