### PR TITLE
Implement Task Logs for scheduler

### DIFF
--- a/app/controllers/api/task_logs_controller.rb
+++ b/app/controllers/api/task_logs_controller.rb
@@ -1,0 +1,43 @@
+class Api::TaskLogsController < Api::BaseController
+  before_action :set_task_log, only: [:update, :destroy]
+
+  def index
+    task_logs = TaskLog.includes(:task, :developer).order(log_date: :asc)
+    task_logs = task_logs.where(task_id: params[:task_id]) if params[:task_id].present?
+    task_logs = task_logs.where(developer_id: params[:developer_id]) if params[:developer_id].present?
+    task_logs = task_logs.where(log_date: params[:log_date]) if params[:log_date].present?
+    render json: task_logs.as_json(include: { task: {}, developer: {} })
+  end
+
+  def create
+    task_log = TaskLog.new(task_log_params)
+    if task_log.save
+      render json: task_log.as_json(include: { task: {}, developer: {} }), status: :created
+    else
+      render json: { errors: task_log.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @task_log.update(task_log_params)
+      render json: @task_log.as_json(include: { task: {}, developer: {} })
+    else
+      render json: { errors: @task_log.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @task_log.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_task_log
+    @task_log = TaskLog.find(params[:id])
+  end
+
+  def task_log_params
+    params.require(:task_log).permit(:task_id, :developer_id, :log_date, :type, :hours_logged, :status, :created_by, :updated_by)
+  end
+end

--- a/app/javascript/components/Scheduler/AddTaskForm.jsx
+++ b/app/javascript/components/Scheduler/AddTaskForm.jsx
@@ -1,18 +1,17 @@
 import React, { useState, useEffect } from 'react';
 
-export default function AddTaskForm({developers, dates, types, onAddTask, currentSprintId}) {
-  const [formData, setFormData] = useState({ developer_id: '', type: 'Code', date: '', task_id: '', task_url: '', estimated_hours: 1 });
+export default function AddTaskForm({developers, dates, types, tasks, onAddTask}) {
+  const [formData, setFormData] = useState({ developer_id: '', type: 'Code', log_date: '', task_id: '', hours_logged: 1 });
 
   // If dates/devs/types update, reset defaults
   useEffect(() => {
     setFormData(f => ({
       ...f,
-      date: dates[0] || f.date,
+      log_date: dates[0] || f.log_date,
       developer_id: developers[0]?.id ?? f.developer_id,
-      sprint_id: currentSprintId ?? f.sprint_id,
-      estimated_hours: f.estimated_hours ?? 1
+      hours_logged: f.hours_logged ?? 1
     }));
-  }, [dates, developers, types, currentSprintId]);
+  }, [dates, developers, types]);
 
   // Show loading state if developers not fetched yet
   if (!developers.length) {
@@ -22,7 +21,7 @@ export default function AddTaskForm({developers, dates, types, onAddTask, curren
   const handleChange = e => {
     let { name, value } = e.target;
     // Cast numbers for IDs and hours
-    if (['developer_id', 'estimated_hours', 'sprint_id'].includes(name)) {
+    if (['developer_id', 'hours_logged'].includes(name)) {
       value = Number(value);
     }
     setFormData(f => ({ ...f, [name]: value }));
@@ -30,17 +29,15 @@ export default function AddTaskForm({developers, dates, types, onAddTask, curren
 
   const handleSubmit = e => {
     e.preventDefault();
-    const { date, developer_id, type, task_id } = formData;
-    if (!date || !developer_id || !type || !task_id.trim()) return;
+    const { log_date, developer_id, type, task_id } = formData;
+    if (!log_date || !developer_id || !type || !task_id) return;
     onAddTask(formData);
     // reset non-default fields
     setFormData(f => ({
-      date: dates[0] || '',
+      log_date: dates[0] || '',
       developer_id: developers[0]?.id || null,
       task_id: '',
-      task_url: '',
-      estimated_hours: 1,
-      sprint_id: currentSprintId || null
+      hours_logged: 1
     }));
   };
 
@@ -55,8 +52,8 @@ export default function AddTaskForm({developers, dates, types, onAddTask, curren
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">📅 Date</label>
           <select
-            name="date"
-            value={formData.date || ''}
+            name="log_date"
+            value={formData.log_date || ''}
             onChange={handleChange}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
@@ -98,57 +95,39 @@ export default function AddTaskForm({developers, dates, types, onAddTask, curren
           </select>
         </div>
   
-        {/* Estimated Hours */}
+        {/* Logged Hours */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">⏱ Estimated Hours</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">⏱ Hours Logged</label>
           <input
             type="number"
-            name="estimated_hours"
+            name="hours_logged"
             min="0"
             step="0.25"
-            value={formData.estimated_hours}
+            value={formData.hours_logged}
             onChange={handleChange}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         </div>
       </div>
   
-      {/* Row 2: Task URL and Button */}
+      {/* Row 2: Task Selection and Button */}
       <div className="flex flex-col sm:flex-row gap-4 items-end">
-          
+
         {/* Task ID */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">📌 Task ID</label>
-          <input
-            type="text"
+          <label className="block text-sm font-medium text-gray-700 mb-1">📌 Task</label>
+          <select
             name="task_id"
             value={formData.task_id || ''}
-            onChange={(e) => {
-              const input = e.target.value;
-              const match = input.match(/HME-\d+/i); // Regex for extracting Jira ticket
-              handleChange({
-                target: {
-                  name: 'task_id',
-                  value: match ? match[0] : input,
-                },
-              });
-            }}
-            placeholder="e.g., HME-123456"
+            onChange={handleChange}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
             required
-          />
-        </div>
-
-        <div className="flex-grow">
-          <label className="block text-sm font-medium text-gray-700 mb-1">🔗 Task URL</label>
-          <input
-            type="url"
-            name="task_url"
-            value={formData.task_url || ''}
-            onChange={handleChange}
-            placeholder="https://..."
-            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
+          >
+            <option value="">Select Task</option>
+            {tasks.map(t => (
+              <option key={t.id} value={t.id}>{t.task_id}</option>
+            ))}
+          </select>
         </div>
 
         <button
@@ -158,11 +137,6 @@ export default function AddTaskForm({developers, dates, types, onAddTask, curren
           🛠️ Add Task
         </button>
       </div>
-  
-      {/* Hidden Sprint ID */}
-      {currentSprintId && (
-        <input type="hidden" name="sprint_id" value={formData.sprint_id} />
-      )}
     </form>
   );
 }

--- a/app/javascript/components/Scheduler/EditTaskForm.jsx
+++ b/app/javascript/components/Scheduler/EditTaskForm.jsx
@@ -1,31 +1,31 @@
 import React, { useState, useEffect } from 'react';
 
-export default function EditTaskForm({ task, developers, dates, types, onSave, onCancel }) {
+export default function EditTaskForm({ task, developers, dates, types, tasks, onSave, onCancel }) {
   const [formData, setFormData] = useState({
     id: task.id,
-    date: task.date || '',
+    log_date: task.log_date || '',
     developer_id: task.developer_id || developers[0]?.id || '',
     task_id: task.task_id || '',
-    task_url: task.task_url || '',
-    estimated_hours: task.estimated_hours || 1,
-    sprint_id: task.sprint_id || null
+    hours_logged: task.hours_logged || 1,
+    type: task.type || 'Code',
+    status: task.status || 'todo'
   });
 
   useEffect(() => {
     setFormData({
       id: task.id,
-      date: task.date || '',
+      log_date: task.log_date || '',
       developer_id: task.developer_id || developers[0]?.id || '',
       task_id: task.task_id || '',
-      task_url: task.task_url || '',
-      estimated_hours: task.estimated_hours || 1,
-      sprint_id: task.sprint_id || null
+      hours_logged: task.hours_logged || 1,
+      type: task.type || 'Code',
+      status: task.status || 'todo'
     });
   }, [task, developers, types]);
 
   const handleChange = e => {
     let { name, value } = e.target;
-    if (['developer_id', 'estimated_hours', 'sprint_id'].includes(name)) {
+    if (['developer_id', 'hours_logged'].includes(name)) {
       value = Number(value);
     }
     setFormData(f => ({ ...f, [name]: value }));
@@ -33,8 +33,8 @@ export default function EditTaskForm({ task, developers, dates, types, onSave, o
 
   const handleSubmit = e => {
     e.preventDefault();
-    const { date, developer_id, task_id } = formData;
-    if (!date || !developer_id || !task_id.trim()) return;
+    const { log_date, developer_id, task_id } = formData;
+    if (!log_date || !developer_id || !task_id) return;
     onSave(formData);
   };
 
@@ -48,8 +48,8 @@ export default function EditTaskForm({ task, developers, dates, types, onSave, o
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">📅 Date</label>
           <select
-            name="date"
-            value={formData.date}
+            name="log_date"
+            value={formData.log_date}
             onChange={handleChange}
             className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
           >
@@ -91,15 +91,15 @@ export default function EditTaskForm({ task, developers, dates, types, onSave, o
           </select>
         </div>
 
-        {/* Estimated Hours */}
+        {/* Logged Hours */}
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">⏱ Estimated Hours</label>
+          <label className="block text-sm font-medium text-gray-700 mb-1">⏱ Hours Logged</label>
           <input
             type="number"
-            name="estimated_hours"
+            name="hours_logged"
             min="0"
             step="0.25"
-            value={formData.estimated_hours}
+            value={formData.hours_logged}
             onChange={handleChange}
             className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
           />
@@ -111,29 +111,20 @@ export default function EditTaskForm({ task, developers, dates, types, onSave, o
         {/* Task ID */}
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">📌 Task ID</label>
-          <input
-            type="text"
+          <select
             name="task_id"
             value={formData.task_id}
             onChange={handleChange}
-            placeholder="e.g., HME-123456"
-            required
             className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
-          />
+            required
+          >
+            <option value="">Select Task</option>
+            {tasks.map(t => (
+              <option key={t.id} value={t.id}>{t.task_id}</option>
+            ))}
+          </select>
         </div>
 
-        {/* Task URL */}
-        <div className="flex-grow">
-          <label className="block text-sm font-medium text-gray-700 mb-1">🔗 Task URL</label>
-          <input
-            type="url"
-            name="task_url"
-            value={formData.task_url}
-            onChange={handleChange}
-            placeholder="https://..."
-            className="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
 
         {/* Save Button */}
         <button
@@ -143,11 +134,6 @@ export default function EditTaskForm({ task, developers, dates, types, onSave, o
           💾 Save Changes
         </button>
       </div>
-
-      {/* Hidden Sprint ID */}
-      {formData.sprint_id && (
-        <input type="hidden" name="sprint_id" value={formData.sprint_id} />
-      )}
     </form>
   );
 }

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -60,7 +60,13 @@ export const SchedulerAPI = {
   updateTask: (id, data) => api.patch(`/tasks/${id}.json`, { task: data }),
   deleteTask: (id) => api.delete(`/tasks/${id}.json`),
   moveTask: (id, newData) => api.patch(`/tasks/${id}.json`, newData),
-  toggleTaskStatus: (id, status) => api.patch(`/tasks/${id}.json`, { is_struck: status })
+  toggleTaskStatus: (id, status) => api.patch(`/tasks/${id}.json`, { is_struck: status }),
+
+  // Task Logs
+  getTaskLogs: (params = {}) => api.get('/task_logs.json', { params }),
+  createTaskLog: (data) => api.post('/task_logs.json', { task_log: data }),
+  updateTaskLog: (id, data) => api.patch(`/task_logs/${id}.json`, { task_log: data }),
+  deleteTaskLog: (id) => api.delete(`/task_logs/${id}.json`)
 };
 
 // USER ENDPOINTS (existing)

--- a/app/models/task_log.rb
+++ b/app/models/task_log.rb
@@ -1,0 +1,11 @@
+class TaskLog < ApplicationRecord
+  include UserStampable
+
+  belongs_to :task
+  belongs_to :developer
+
+  self.inheritance_column = 'non_existent_type_column'
+
+  validates :task, :developer, :log_date, :hours_logged, presence: true
+  validates :hours_logged, numericality: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     resources :sprints, only: [:index, :create, :update, :destroy]
     resources :developers, only: [:index]
     resources :tasks, only: [:index, :create, :update, :destroy]
+    resources :task_logs, only: [:index, :create, :update, :destroy]
 
     resources :items, only: [:index, :create, :update, :destroy]
 

--- a/db/migrate/20260101000001_create_task_logs.rb
+++ b/db/migrate/20260101000001_create_task_logs.rb
@@ -1,0 +1,18 @@
+class CreateTaskLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :task_logs do |t|
+      t.references :task, null: false, foreign_key: true
+      t.references :developer, null: false, foreign_key: true
+      t.date :log_date, null: false
+      t.string :type, default: 'code'
+      t.decimal :hours_logged, precision: 5, scale: 2, null: false
+      t.string :status, default: 'todo'
+      t.integer :created_by
+      t.integer :updated_by
+
+      t.timestamps
+    end
+
+    add_index :task_logs, :log_date
+  end
+end


### PR DESCRIPTION
## Summary
- create migration and model for `task_logs`
- add `TaskLogsController` and routes
- expose task log endpoints to JS
- update Scheduler components to operate on task logs

## Testing
- `bundle exec rails test` *(fails: ruby version not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6875007f8a40832290a02340a990b8ba