### PR TITLE
Update scheduler form

### DIFF
--- a/app/javascript/components/Scheduler/AddTaskForm.jsx
+++ b/app/javascript/components/Scheduler/AddTaskForm.jsx
@@ -125,7 +125,9 @@ export default function AddTaskForm({developers, dates, types, tasks, onAddTask}
           >
             <option value="">Select Task</option>
             {tasks.map(t => (
-              <option key={t.id} value={t.id}>{t.task_id}</option>
+              <option key={t.id} value={t.id}>
+                {t.task_id}{t.task_url ? ` - ${t.task_url}` : ''}
+              </option>
             ))}
           </select>
         </div>
@@ -134,7 +136,7 @@ export default function AddTaskForm({developers, dates, types, tasks, onAddTask}
           type="submit"
           className="bg-blue-600 text-white px-6 py-2 rounded-lg shadow hover:bg-blue-700 transition"
         >
-          🛠️ Add Task
+          🛠️ Add Log
         </button>
       </div>
     </form>

--- a/app/javascript/components/Scheduler/Scheduler.jsx
+++ b/app/javascript/components/Scheduler/Scheduler.jsx
@@ -255,10 +255,11 @@ function Scheduler({ sprintId }) {
   }, [sprintId]);
 
   useEffect(() => {
+    const params = sprintId ? { sprint_id: sprintId } : {};
     Promise.all([
       SchedulerAPI.getDevelopers(),
-      SchedulerAPI.getTaskLogs(),
-      SchedulerAPI.getTasks()
+      SchedulerAPI.getTaskLogs(params),
+      SchedulerAPI.getTasks(params)
     ])
       .then(([devRes, logRes, taskRes]) => {
         setDevelopers(devRes.data);
@@ -270,7 +271,7 @@ function Scheduler({ sprintId }) {
         setError("Could not load developers or tasks");
         setLoading(l => ({ ...l, developers: false, tasks: false }));
       });
-  }, []);
+  }, [sprintId]);
   
   const getWeekdaysInRange = useCallback((start, end) => {
     const datesArr = [];
@@ -607,7 +608,7 @@ function Scheduler({ sprintId }) {
         </main>
       </div>
 
-      <Modal isOpen={isAddTaskModalOpen} onClose={() => setIsAddTaskModalOpen(false)} title="✨ Add New Task">
+      <Modal isOpen={isAddTaskModalOpen} onClose={() => setIsAddTaskModalOpen(false)} title="✨ Add Log">
         <AddTaskForm
           developers={developers}
           dates={dates}


### PR DESCRIPTION
## Summary
- show sprint-specific tasks when logging
- rename "Add New Task" modal to "Add Log"
- list task url beside each task in dropdown

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875055a328c8322aa1f86c71ed8f14f