### PR TITLE
Add migration to update tasks and sprints

### DIFF
--- a/db/migrate/20260101010000_update_tasks_and_sprints.rb
+++ b/db/migrate/20260101010000_update_tasks_and_sprints.rb
@@ -1,0 +1,29 @@
+class UpdateTasksAndSprints < ActiveRecord::Migration[7.1]
+  def change
+    if column_exists?(:tasks, :date)
+      remove_column :tasks, :date, :date
+    end
+
+    if column_exists?(:tasks, :is_struck)
+      remove_column :tasks, :is_struck, :boolean
+    end
+
+    if column_exists?(:tasks, :due_date)
+      remove_column :tasks, :due_date, :date
+    end
+
+    if column_exists?(:sprints, :description)
+      remove_column :sprints, :description, :text
+    end
+
+    if column_exists?(:sprints, :order)
+      remove_column :sprints, :order, :integer
+    end
+
+    unless column_exists?(:sprints, :created_at) && column_exists?(:sprints, :updated_at)
+      add_timestamps :sprints, null: true
+      change_column_null :sprints, :created_at, false
+      change_column_null :sprints, :updated_at, false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- remove obsolete date, is_struck, and due_date from tasks
- drop description and order from sprints
- ensure timestamps exist for sprints

## Testing
- `bundle exec rake db:migrate:status` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687514a104788322b8b37dc30d824f5b