### PR TITLE
Fix due date heatmap

### DIFF
--- a/app/javascript/utils/taskUtils.js
+++ b/app/javascript/utils/taskUtils.js
@@ -15,8 +15,12 @@ export function getCompletionData(columns) {
 
 export function getHeatmapData(columns) {
   const today = startOfWeek(new Date(), { weekStartsOn: 1 });
-  const week = Array.from({ length: 7 }, (_, i) => format(addDays(today, i), 'yyyy-MM-dd'));
-  const counts = Object.values(columns).flatMap((col) => col.items.map((t) => t.due)).filter(Boolean);
+  const week = Array.from({ length: 7 }, (_, i) =>
+    format(addDays(today, i), 'yyyy-MM-dd')
+  );
+  const counts = Object.values(columns)
+    .flatMap((col) => col.items.map((t) => t.end_date || t.due))
+    .filter(Boolean);
   return week.map((day) => ({
     date: day,
     count: counts.filter((d) => d === day).length,


### PR DESCRIPTION
## Summary
- include `end_date` when computing heatmap task counts

## Testing
- `bin/rails test` *(fails: ruby not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876539dacd48322bff5eb0ab81fb936