### PR TITLE
Remove unused notes/quotes tables

### DIFF
--- a/db/migrate/20260715000000_drop_unused_tables.rb
+++ b/db/migrate/20260715000000_drop_unused_tables.rb
@@ -1,0 +1,6 @@
+class DropUnusedTables < ActiveRecord::Migration[7.1]
+  def change
+    drop_table :notes, if_exists: true
+    drop_table :quotes, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,15 +67,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_01_010000) do
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
-  create_table "notes", force: :cascade do |t|
-    t.string "title", null: false
-    t.text "body", null: false
-    t.bigint "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_notes_on_user_id"
-  end
-
   create_table "posts", force: :cascade do |t|
     t.string "message"
     t.string "image"
@@ -83,13 +74,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_01_010000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
-  end
-
-  create_table "quotes", force: :cascade do |t|
-    t.string "content"
-    t.string "author"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
   end
 
   create_table "sprints", force: :cascade do |t|
@@ -166,7 +150,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_01_010000) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
-  add_foreign_key "notes", "users"
   add_foreign_key "posts", "users"
   add_foreign_key "task_logs", "developers"
   add_foreign_key "task_logs", "tasks"


### PR DESCRIPTION
## Summary
- remove leftover `notes` and `quotes` tables from schema
- add migration to drop `notes` and `quotes`

## Testing
- `bin/rails test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687665911ca48322b03ac1d82d07b6c3