### PR TITLE
Fix task drag/drop update

### DIFF
--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -99,7 +99,7 @@ export default function TodoBoard({ sprintId, onSprintChange }) {
   
   const handleUpdateTask = async (colId, taskId, updates) => {
      try {
-        const { data } = await SchedulerAPI.updateTask(taskId, { task: updates });
+        const { data } = await SchedulerAPI.updateTask(taskId, updates);
         setColumns(prev => ({
             ...prev,
             [colId]: { ...prev[colId], items: prev[colId].items.map(t => t.id === data.id ? data : t) }

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -580,7 +580,7 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
         const updates = [...sourceList, ...destList];
         await Promise.all(updates.map(t => {
             const devId = t.assignedTo?.[0] ? Number(t.assignedTo[0]) : null;
-            return SchedulerAPI.updateTask(t.dbId, { task: { developer_id: devId, order: t.order } });
+            return SchedulerAPI.updateTask(t.dbId, { developer_id: devId, order: t.order });
         }));
     };
 


### PR DESCRIPTION
## Summary
- fix double nested task params from the UI
- reorder tasks within sprint and developer on update
- allow nested params in TasksController

## Testing
- `bundle exec rake` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876712043308322bda127f3d1eb29ec