### PR TITLE
Fix drag-and-drop order race

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -61,10 +61,15 @@ class Api::TasksController < Api::BaseController
   end
 
   def reorder_group(sprint_id, developer_id)
-    tasks = Task.where(sprint_id: sprint_id, developer_id: developer_id).order(:order, :id)
-    tasks.each_with_index do |t, idx|
-      new_order = idx + 1
-      t.update_column(:order, new_order) if t.order != new_order
+    Task.transaction do
+      tasks = Task.where(sprint_id: sprint_id, developer_id: developer_id)
+                   .order(:order, :id)
+                   .lock
+
+      tasks.each_with_index do |t, idx|
+        new_order = idx + 1
+        t.update_column(:order, new_order) if t.order != new_order
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- lock tasks when reordering to avoid race conditions during drag-and-drop

## Testing
- `bundle exec rake test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68767416daf08322b98d030cf7df7de0