### PR TITLE
Update task log relations

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -5,6 +5,8 @@ class Task < ApplicationRecord
   belongs_to :developer
   belongs_to :assigned_user, class_name: 'User', foreign_key: :assigned_to_user, optional: true
 
+  has_many :task_logs, dependent: :destroy
+
   # This tells ActiveRecord NOT to use the 'type' column for Single Table Inheritance.
   self.inheritance_column = 'non_existent_type_column'
 

--- a/app/models/task_log.rb
+++ b/app/models/task_log.rb
@@ -8,4 +8,18 @@ class TaskLog < ApplicationRecord
 
   validates :task, :developer, :log_date, :hours_logged, presence: true
   validates :hours_logged, numericality: true
+
+  after_save :sync_task_dates, if: -> { type == 'code' }
+
+  private
+
+  def sync_task_dates
+    return unless task
+
+    code_logs = task.task_logs.where(type: 'code')
+    task.update(
+      start_date: code_logs.minimum(:log_date),
+      end_date: code_logs.maximum(:log_date)
+    )
+  end
 end


### PR DESCRIPTION
## Summary
- destroy task logs when tasks are removed
- automatically sync start and end dates based on code task logs

## Testing
- `ruby -c app/models/task.rb`
- `ruby -c app/models/task_log.rb`
- `bundle exec rake -T` *(fails: RubyVersionMismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687780d0dc88832282778c3f10cfd387