### PR TITLE
Implement modal task form and show board counts

### DIFF
--- a/app/javascript/components/TodoBoard/KanbanColumn.jsx
+++ b/app/javascript/components/TodoBoard/KanbanColumn.jsx
@@ -12,7 +12,10 @@ const KanbanColumn = ({ columnId, column, tasks, onDelete, onUpdate }) => {
           ref={provided.innerRef}
           {...provided.droppableProps}
         >
-          <h2 className="text-xl font-semibold mb-4 text-gray-800">{column.name}</h2>
+          <h2 className="text-xl font-semibold mb-4 text-gray-800">
+            {column.name}
+            <span className="text-sm text-gray-600 ml-2">({tasks.length})</span>
+          </h2>
           {tasks.length === 0 && <p className="text-sm italic text-gray-500">No matching tasks.</p>}
           
           {tasks.map((item, index) => (

--- a/app/javascript/components/TodoBoard/TaskForm.jsx
+++ b/app/javascript/components/TodoBoard/TaskForm.jsx
@@ -1,75 +1,99 @@
 import React, { useState } from 'react';
 
-const TaskForm = ({ onAddTask }) => {
-  const [title, setTitle] = useState("");
-  const [type, setType] = useState("");
-  const [status, setStatus] = useState("todo");
-  const [assignedToUser, setAssignedToUser] = useState("");
-  const [endDate, setEndDate] = useState("");
+const TaskForm = ({ onAddTask, onCancel }) => {
+  const [formData, setFormData] = useState({
+    title: '',
+    type: '',
+    status: 'todo',
+    assigned_to_user: '',
+    end_date: ''
+  });
 
-  const handleSubmit = () => {
-    if (!title) {
-      alert("Title is required.");
-      return;
-    }
-    const newTask = {
-      title,
-      type,
-      status,
-      assigned_to_user: assignedToUser,
-      end_date: endDate,
-    };
-    onAddTask(newTask);
-    // Clear form
-    setTitle("");
-    setType("");
-    setStatus("todo");
-    setAssignedToUser("");
-    setEndDate("");
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (!formData.title) return alert('Title is required.');
+    onAddTask(formData);
+    setFormData({ title: '', type: '', status: 'todo', assigned_to_user: '', end_date: '' });
   };
 
   return (
-    <div className="mb-4 flex flex-col sm:flex-row flex-wrap gap-4">
-      <input
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        placeholder="Title"
-        className="border px-3 py-2 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 transition-all sm:w-1/3"
-      />
-      <input
-        value={type}
-        onChange={(e) => setType(e.target.value)}
-        placeholder="Type"
-        className="border px-3 py-2 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 transition-all sm:w-1/3"
-      />
-      <select
-        value={status}
-        onChange={(e) => setStatus(e.target.value)}
-        className="border px-3 py-2 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 transition-all sm:w-1/3"
-      >
-        <option value="todo">To Do</option>
-        <option value="inprogress">In Progress</option>
-        <option value="done">Done</option>
-      </select>
-      <input
-        value={assignedToUser}
-        onChange={(e) => setAssignedToUser(e.target.value)}
-        placeholder="Assigned User ID"
-        className="border px-3 py-2 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 transition-all sm:w-1/3"
-      />
-      <input
-        type="date"
-        value={endDate}
-        onChange={(e) => setEndDate(e.target.value)}
-        className="border px-3 py-2 rounded-lg shadow-md focus:ring-2 focus:ring-blue-400 transition-all sm:w-1/3"
-      />
-      <button
-        onClick={handleSubmit}
-        className="bg-blue-600 text-white px-6 py-2 rounded-lg shadow-lg hover:bg-blue-700 transition-all"
-      >
-        Add Task
-      </button>
-    </div>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+          <input
+            name="title"
+            value={formData.title}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-blue-400"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Type</label>
+          <input
+            name="type"
+            value={formData.type}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Status</label>
+          <select
+            name="status"
+            value={formData.status}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-blue-400"
+          >
+            <option value="todo">To Do</option>
+            <option value="inprogress">In Progress</option>
+            <option value="done">Done</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Assigned User ID</label>
+          <input
+            name="assigned_to_user"
+            value={formData.assigned_to_user}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <label className="block text-sm font-medium text-gray-700 mb-1">End Date</label>
+          <input
+            type="date"
+            name="end_date"
+            value={formData.end_date}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+      </div>
+      <div className="flex justify-end gap-3 pt-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 bg-gray-100 rounded-lg hover:bg-gray-200 text-gray-700"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg shadow hover:bg-blue-700"
+        >
+          Add Task
+        </button>
+      </div>
+    </form>
   );
 };
 

--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -8,6 +8,24 @@ import TaskForm from "./TaskForm";
 import KanbanColumn from "./KanbanColumn";
 import Heatmap from "./Heatmap";
 import ProgressPieChart from "./ProgressPieChart";
+import { XCircleIcon } from '@heroicons/react/24/outline';
+
+function Modal({ isOpen, onClose, title, children }) {
+  if (!isOpen) return null;
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex justify-center items-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-2xl w-full max-w-xl transform transition-all scale-95 opacity-0 animate-modalShow">
+        <div className="flex justify-between items-center p-4 border-b border-gray-200">
+          <h3 className="text-lg font-semibold text-gray-800">{title}</h3>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 p-1 rounded-full hover:bg-gray-100">
+            <XCircleIcon className="h-6 w-6" />
+          </button>
+        </div>
+        <div className="p-6">{children}</div>
+      </div>
+    </div>
+  );
+}
 
 const initialData = {
   todo: { name: "To Do", color: "bg-blue-100", items: [] },
@@ -166,12 +184,14 @@ export default function TodoBoard({ sprintId, onSprintChange }) {
         <div className="flex items-center gap-4">
           <h1 className="text-3xl font-semibold text-blue-700 tracking-tight">MyForm Task Control Center</h1>
         </div>
-        <button onClick={() => setShowForm(prev => !prev)} className="bg-indigo-600 text-white px-4 py-2 rounded-lg shadow hover:bg-indigo-700 transition-all">
-          {showForm ? 'Close Form' : '+ New Task'}
+        <button onClick={() => setShowForm(true)} className="bg-indigo-600 text-white px-4 py-2 rounded-lg shadow hover:bg-indigo-700 transition-all">
+          + New Task
         </button>
       </div>
-      
-      {showForm && <TaskForm onAddTask={handleAddTask} />}
+
+      <Modal isOpen={showForm} onClose={() => setShowForm(false)} title="Add Task">
+        <TaskForm onAddTask={handleAddTask} onCancel={() => setShowForm(false)} />
+      </Modal>
 
       <div className="grid md:grid-cols-2 gap-4 mb-6">
         <Heatmap columns={columns} />
@@ -199,6 +219,17 @@ export default function TodoBoard({ sprintId, onSprintChange }) {
             ))}
         </div>
       </DragDropContext>
+      <style>{`
+        @keyframes modalShow {
+          to {
+            opacity: 1;
+            transform: scale(1);
+          }
+        }
+        .animate-modalShow {
+          animation: modalShow 0.3s ease-out forwards;
+        }
+      `}</style>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance TodoBoard UI with modal form
- improve TaskForm design and allow cancellation
- show item counts in Kanban column headers

## Testing
- `bundle exec rake test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68779cef19c08322af17415016f452aa