### PR TITLE
Fix backtick in AtharvaSystemMail instructions

### DIFF
--- a/app/javascript/pages/AtharvaSystemMail.jsx
+++ b/app/javascript/pages/AtharvaSystemMail.jsx
@@ -143,7 +143,7 @@ app.post('/webhook/ig', async (req, res) => {
   const { ig_handle, message } = req.body;
 
   await supabase.from("fans").update({
-    events: Supabase.raw(`jsonb_set(events, '{dm_received}', to_jsonb(now()))`),
+    events: Supabase.raw(\`jsonb_set(events, '{dm_received}', to_jsonb(now()))\`),
     last_engaged: new Date()
   }).eq("ig_handle", ig_handle);
 


### PR DESCRIPTION
## Summary
- escape inner backtick in `AtharvaSystemMail.jsx`

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878a40c3f0c83229373b66a17586761