### PR TITLE
Add raw toggle for AtharvaSystemMail

### DIFF
--- a/app/javascript/pages/AtharvaSystemMail.jsx
+++ b/app/javascript/pages/AtharvaSystemMail.jsx
@@ -1,11 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 
-const AtharvaSystemMail = () => (
-  <div className="p-4">
-    <h1 className="text-2xl font-bold mb-4">Atharva System Mail - Add me to aslack channel</h1>
-    <pre className="whitespace-pre-wrap text-sm">
-{`
-Based on the document titled "Atharva System Mail - Add me to aslack channel", it outlines a project roadmap for a system combining:
+const instructions = `Based on the document titled "Atharva System Mail - Add me to aslack channel", it outlines a project roadmap for a system combining:
 
 Claude AI
 Supabase (as a backend/CRM)
@@ -161,9 +156,19 @@ Automation JSON:
   "action": "send_email",
   "delay_days": 3
 }
-`}
-    </pre>
-  </div>
-);
+`;
+
+const AtharvaSystemMail = () => {
+  const [showRaw, setShowRaw] = useState(false);
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Atharva System Mail - Add me to aslack channel</h1>
+      <button className="mb-4 px-3 py-1 border rounded" onClick={() => setShowRaw(!showRaw)}>
+        {showRaw ? "Hide raw" : "Show raw"}
+      </button>
+      {showRaw && <pre className="whitespace-pre-wrap text-sm">{instructions}</pre>}
+    </div>
+  );
+};
 
 export default AtharvaSystemMail;

--- a/app/views/pages/atharva_system_mail.html.erb
+++ b/app/views/pages/atharva_system_mail.html.erb
@@ -1,5 +1,6 @@
 <h1>Atharva System Mail - Add me to aslack channel</h1>
-<pre>
+<button id="toggle-raw" class="mb-4 px-3 py-1 border rounded">Show raw</button>
+<pre id="instructions" style="display:none;">
 Based on the document titled "Atharva System Mail - Add me to aslack channel", it outlines a project roadmap for a system combining:
 
 Claude AI
@@ -138,7 +139,7 @@ app.post('/webhook/ig', async (req, res) => {
   const { ig_handle, message } = req.body;
 
   await supabase.from("fans").update({
-    events: Supabase.raw(`jsonb_set(events, '{dm_received}', to_jsonb(now()))`),
+    events: Supabase.raw(\`jsonb_set(events, '{dm_received}', to_jsonb(now()))\`),
     last_engaged: new Date()
   }).eq("ig_handle", ig_handle);
 
@@ -157,3 +158,18 @@ Automation JSON:
   "delay_days": 3
 }
 </pre>
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    const btn = document.getElementById("toggle-raw");
+    const pre = document.getElementById("instructions");
+    btn.addEventListener("click", () => {
+      if (pre.style.display === "none") {
+        pre.style.display = "block";
+        btn.textContent = "Hide raw";
+      } else {
+        pre.style.display = "none";
+        btn.textContent = "Show raw";
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
## Summary
- toggle raw output on the Atharva System Mail React page
- add matching toggle on the ERB fallback view

## Testing
- `bundle exec rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878a537f1f48322b41119f7b9a70817