### PR TITLE
Fix util.inherits polyfill

### DIFF
--- a/app/javascript/entrypoints/application.jsx
+++ b/app/javascript/entrypoints/application.jsx
@@ -16,6 +16,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "../components/App";
 import "../stylesheets/application.css";
+import { inherits } from 'util';
+
+// Expose util.inherits for libraries expecting the Node util module
+if (typeof window !== 'undefined') {
+  window.util = { inherits };
+}
 
 
 const rootElement = document.getElementById("root");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "esbuild": "^0.25.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1",
-    "vite-plugin-ruby": "^5.1.0"
+    "vite-plugin-ruby": "^5.1.0",
+    "vite-plugin-node-polyfills": "^0.20.0"
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"
@@ -41,6 +42,7 @@
     "@supabase/supabase-js": "^2.43.5",
     "vite": "^6.2.0",
     "resend": "^0.25.0",
-    "twilio": "^4.19.0"
+    "twilio": "^4.19.0",
+    "util": "^0.12.5"
   }
 }

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,9 +1,10 @@
 // vite.config.mts
 import { defineConfig } from 'vite';
 import RubyPlugin from 'vite-plugin-ruby';
+import nodePolyfills from 'vite-plugin-node-polyfills';
 
 export default defineConfig({
-  plugins: [RubyPlugin()],
+  plugins: [RubyPlugin(), nodePolyfills()],
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- add vite-plugin-node-polyfills plugin
- expose util.inherits for browser modules
- include `util` package

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6878ab2b24c08322b932fac7f3de6b25