### PR TITLE
Move Twilio SMS logic to Rails API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem 'jwt'
 gem 'bcrypt'
 gem 'stripe'
 gem 'rqrcode'
+gem 'twilio-ruby'
 
 group :production do
   # gem 'pdf_master', path: 'lib/pdf_master'

--- a/app/controllers/api/twilio_controller.rb
+++ b/app/controllers/api/twilio_controller.rb
@@ -1,0 +1,15 @@
+class Api::TwilioController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
+  def send_sms
+    client = Twilio::REST::Client.new(ENV['TWILIO_ACCOUNT_SID'], ENV['TWILIO_AUTH_TOKEN'])
+    message = client.messages.create(
+      from: ENV['TWILIO_FROM'],
+      to: params[:to],
+      body: params[:body] || 'Hey! Your drop is ready.'
+    )
+    render json: { status: 'sent', sid: message.sid }
+  rescue StandardError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+end

--- a/app/javascript/utils/notifications.js
+++ b/app/javascript/utils/notifications.js
@@ -1,9 +1,7 @@
 import { Resend } from 'resend';
-import twilio from 'twilio';
+import axios from 'axios';
 
 const resend = new Resend(process.env.RESEND_API_KEY || 'RESEND_API_KEY');
-const twilioClient = twilio(process.env.TWILIO_ACCOUNT_SID || 'ACxxxxxxxx', process.env.TWILIO_AUTH_TOKEN || 'your_auth_token');
-const twilioFrom = process.env.TWILIO_FROM || '+1234567890';
 
 export async function sendEmail(to) {
   return resend.emails.send({
@@ -15,9 +13,6 @@ export async function sendEmail(to) {
 }
 
 export async function sendSMS(to) {
-  return twilioClient.messages.create({
-    body: 'Hey! Your drop is ready.',
-    from: twilioFrom,
-    to
-  });
+  const response = await axios.post('/api/send_sms', { to });
+  return response.data;
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,7 @@ Rails.application.routes.draw do
     get 'english_tense', to: 'english_tenses#show'
     get 'english_phrase', to: 'english_phrases#show'
     get 'weather', to: 'weather#show'
+    post 'send_sms', to: 'twilio#send_sms'
 
     resources :users, only: [:index, :update, :destroy]
     resources :posts, only: [:index, :create, :update, :destroy]

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@supabase/supabase-js": "^2.43.5",
     "vite": "^6.2.0",
     "resend": "^0.25.0",
-    "twilio": "^4.19.0",
     "util": "^0.12.5"
   }
 }


### PR DESCRIPTION
## Summary
- add `twilio-ruby` gem
- call a new API endpoint instead of using Twilio's Node SDK in the browser
- expose POST `/api/send_sms` route
- add `Api::TwilioController` to deliver SMS via Twilio
- drop `twilio` from frontend dependencies

## Testing
- `bin/rails test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878b785c3988322985ca30322a8de58