### PR TITLE
Add Instagram DM webhook server

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ bin/rails assets:precompile
 
 You can also build the Docker image using the provided `Dockerfile`.
 
+## Instagram DM Webhook
+
+To log Instagram DMs from Inrō, this project includes a small Express server.
+Install dependencies with `npm install` and run:
+
+```bash
+npm run webhook
+```
+
+Set `SUPABASE_URL` and `SUPABASE_KEY` in your environment so the webhook can
+update the `fans` table when a DM is received.
+

--- a/inro_webhook_server.js
+++ b/inro_webhook_server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const { createClient } = require('@supabase/supabase-js');
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_KEY;
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const app = express();
+app.use(bodyParser.json());
+
+app.post('/webhook/ig', async (req, res) => {
+  const { ig_handle, message, timestamp } = req.body;
+  try {
+    const { error } = await supabase
+      .from('fans')
+      .update({
+        events: { dm_received: message },
+        last_engaged: new Date(timestamp)
+      })
+      .eq('ig_handle', ig_handle);
+
+    if (error) {
+      console.error('Supabase error:', error);
+      return res.status(500).send('Error');
+    }
+    res.send('Logged IG DM');
+  } catch (err) {
+    console.error('Webhook error:', err);
+    res.status(500).send('Error');
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => console.log(`Listening on port ${PORT}`));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "vite-plugin-ruby": "^5.1.0"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
+    "webhook": "node inro_webhook_server.js"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -41,6 +42,8 @@
     "recharts": "^2.15.3",
     "vite": "^6.2.0",
     "resend": "^0.25.0",
-    "util": "^0.12.5"
+    "util": "^0.12.5",
+    "express": "^4.19.2",
+    "body-parser": "^1.20.2"
   }
 }


### PR DESCRIPTION
## Summary
- implement an Express webhook server to log Instagram DMs to Supabase
- add `express` and `body-parser` deps and npm script
- document how to run the webhook server in README

## Testing
- `npm test` *(fails: Missing script)*
- `bundle exec rake test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878cb4a32d88322a54b6f5ca5e3dd8d