### PR TITLE
Add Google Sheets example page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@
 /public/documents
 /public/uploads
 
+# Google service account credentials
+/config/google_service_account.json
+
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 

--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,10 @@ gem 'bcrypt'
 gem 'stripe'
 gem 'rqrcode'
 
+# Access Google Sheets from Rails
+gem 'google-api-client', '~> 0.54.0'
+gem 'googleauth'
+
 group :production do
   # gem 'pdf_master', path: 'lib/pdf_master'
 end

--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ bin/rails assets:precompile
 
 You can also build the Docker image using the provided `Dockerfile`.
 
+## Google Sheets Integration
+
+The app includes a small example page that reads data from a Google Sheet using
+a service account. To configure it:
+
+1. Add the service account JSON key to `config/google_service_account.json` (the
+   file is ignored by Git).
+2. Edit `SPREADSHEET_ID` in `app/services/google_sheets_reader.rb` to match your
+   sheet ID.
+3. Visit `/sheet` in your browser to see the raw rows rendered in a table. Pass
+   `?sheet=TabName` to view a specific tab.
+

--- a/app/controllers/sheets_controller.rb
+++ b/app/controllers/sheets_controller.rb
@@ -1,0 +1,9 @@
+class SheetsController < ApplicationController
+  def show
+    sheet_name = params[:sheet] || 'Sheet1'
+    reader = GoogleSheetsReader.new(sheet_name)
+    @rows = reader.read_data
+  rescue StandardError => e
+    @error = e.message
+  end
+end

--- a/app/services/google_sheets_reader.rb
+++ b/app/services/google_sheets_reader.rb
@@ -1,0 +1,31 @@
+require 'google/apis/sheets_v4'
+require 'googleauth'
+
+class GoogleSheetsReader
+  SPREADSHEET_ID = 'YOUR_SPREADSHEET_ID'
+
+  def initialize(sheet_name)
+    @sheet_name = sheet_name
+    @service = Google::Apis::SheetsV4::SheetsService.new
+    @service.client_options.application_name = 'Rails Sheet Reader'
+    @service.authorization = authorize
+  end
+
+  def read_data
+    range = "#{@sheet_name}!A1:Z"
+    response = @service.get_spreadsheet_values(SPREADSHEET_ID, range)
+    response.values
+  end
+
+  private
+
+  def authorize
+    scopes = ['https://www.googleapis.com/auth/spreadsheets.readonly']
+    authorizer = Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: File.open(Rails.root.join('config/google_service_account.json')),
+      scope: scopes
+    )
+    authorizer.fetch_access_token!
+    authorizer
+  end
+end

--- a/app/views/sheets/show.html.erb
+++ b/app/views/sheets/show.html.erb
@@ -1,0 +1,15 @@
+<h1>Google Sheet Data</h1>
+
+<% if @error %>
+  <p><%= @error %></p>
+<% else %>
+  <table>
+    <% @rows&.each do |row| %>
+      <tr>
+        <% row.each do |cell| %>
+          <td><%= cell %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </table>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
   post "/encrypt_pdf", to: "pdf_modifiers#encrypt_pdf"
   post "/decrypt_pdf", to: "pdf_modifiers#decrypt_pdf"
 
+  get "/sheet", to: "sheets#show"
+
   namespace :api do
     post 'signup', to: 'auth#signup'
     post 'login', to: 'auth#login'


### PR DESCRIPTION
## Summary
- ignore service account credentials
- add Google Sheets gems
- add GoogleSheetsReader service
- display sheet rows at `/sheet`
- document setup for Google Sheets

## Testing
- `ruby -v` *(fails: version not installed)*
- `bundle --version` *(fails: ruby not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878ea7ae9388322912a66cfa2f024c6