### PR TITLE
Add sprint task sheet import/export

### DIFF
--- a/app/controllers/api/sprints_controller.rb
+++ b/app/controllers/api/sprints_controller.rb
@@ -42,6 +42,25 @@ class Api::SprintsController < Api::BaseController
     end
   end
 
+  def import_tasks
+    sprint = Sprint.find(params[:id])
+    service = TaskSheetService.new(sprint.name)
+    service.import_tasks(sprint_id: sprint.id, created_by_id: current_user.id)
+    head :no_content
+  rescue StandardError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
+  def export_tasks
+    sprint = Sprint.find(params[:id])
+    tasks = Task.where(sprint_id: sprint.id).order(:order)
+    service = TaskSheetService.new(sprint.name)
+    service.export_tasks(tasks)
+    head :no_content
+  rescue StandardError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   private
   def sprint_params
     params.require(:sprint).permit(:name, :start_date, :end_date)

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -66,7 +66,9 @@ export const SchedulerAPI = {
   getTaskLogs: (params = {}) => api.get('/task_logs.json', { params }),
   createTaskLog: (data) => api.post('/task_logs.json', { task_log: data }),
   updateTaskLog: (id, data) => api.patch(`/task_logs/${id}.json`, { task_log: data }),
-  deleteTaskLog: (id) => api.delete(`/task_logs/${id}.json`)
+  deleteTaskLog: (id) => api.delete(`/task_logs/${id}.json`),
+  importSprintTasks: (id) => api.post(`/sprints/${id}/import_tasks`),
+  exportSprintTasks: (id) => api.post(`/sprints/${id}/export_tasks`)
 };
 
 // USER ENDPOINTS (existing)

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -71,6 +71,26 @@ export default function SprintDashboard() {
     setIsHeaderExpanded(false);
   };
 
+  const handleImport = async () => {
+    if (!sprintId) return;
+    try {
+      await SchedulerAPI.importSprintTasks(sprintId);
+      alert('Imported tasks from sheet');
+    } catch (e) {
+      alert('Import failed');
+    }
+  };
+
+  const handleExport = async () => {
+    if (!sprintId) return;
+    try {
+      await SchedulerAPI.exportSprintTasks(sprintId);
+      alert('Exported tasks to sheet');
+    } catch (e) {
+      alert('Export failed');
+    }
+  };
+
   return (
     <div className="space-y-6">
       <header className="bg-white shadow-sm p-2">
@@ -113,7 +133,7 @@ export default function SprintDashboard() {
         </div>
       </header>
       {/* Tab Navigation */}
-      <div className="flex justify-center mb-8">
+      <div className="flex justify-between items-center mb-8">
         <div className="flex bg-white rounded-full p-1 shadow-md border border-gray-100">
           <button
             className={`px-6 py-3 rounded-full text-lg font-medium transition-all duration-300 ease-in-out
@@ -155,6 +175,21 @@ export default function SprintDashboard() {
         >
           Sheet
         </button>
+        </div>
+        <div className="flex space-x-2 ml-4">
+          <button
+            onClick={handleImport}
+            className="px-4 py-2 rounded-lg bg-green-500 text-white hover:bg-green-600"
+          >
+            Import from Sheet
+          </button>
+          <button
+            onClick={handleExport}
+            className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600"
+          >
+            Export to Sheet
+          </button>
+        </div>
       </div>
       </div>
       {activeTab === 'overview' && (

--- a/app/services/task_sheet_service.rb
+++ b/app/services/task_sheet_service.rb
@@ -1,0 +1,129 @@
+require 'google/apis/sheets_v4'
+require 'googleauth'
+require 'date'
+
+class TaskSheetService
+  SPREADSHEET_ID = GoogleSheetsReader::SPREADSHEET_ID
+
+  def initialize(sheet_name)
+    @sheet_name = sheet_name
+    @service = Google::Apis::SheetsV4::SheetsService.new
+    @service.client_options.application_name = 'Rails Task Sheet'
+    @service.authorization = authorize
+  end
+
+  def import_tasks(sprint_id:, created_by_id:)
+    data = read_sheet
+    import_tasks_from_sheet(data, sprint_id: sprint_id, created_by_id: created_by_id)
+  end
+
+  def export_tasks(tasks)
+    write_tasks_to_sheet(tasks)
+  end
+
+  private
+
+  def authorize
+    scopes = ['https://www.googleapis.com/auth/spreadsheets']
+    Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: File.open(Rails.root.join('config/google_service_account.json')),
+      scope: scopes
+    ).tap(&:fetch_access_token!)
+  end
+
+  def read_sheet
+    range = "#{@sheet_name}!A1:Z"
+    response = @service.get_spreadsheet_values(SPREADSHEET_ID, range)
+    response.values || []
+  end
+
+  def parse_date(value)
+    return nil if value.blank?
+    Date.parse(value.to_s) rescue nil
+  end
+
+  def map_status(value)
+    val = value.to_s.downcase
+    return 'completed' if val.include?('completed')
+    return 'todo' if val.include?('todo')
+    val
+  end
+
+  def import_tasks_from_sheet(sheet_data, sprint_id:, created_by_id:)
+    sheet_data[1..].each do |row|
+      next if row.compact.empty?
+
+      task_id = row[1]
+      title = row[2]
+      estimated_hours = row[3].to_f
+      developer_name = row[4]
+      user_name = row[5]
+      start_date = parse_date(row[6])
+      end_date = parse_date(row[7])
+      status = map_status(row[8])
+      order = row[0].to_i
+
+      developer = Developer.find_by(name: developer_name)
+      user = User.find_by(first_name: user_name)
+
+      task = Task.find_or_initialize_by(task_id: task_id)
+
+      task.assign_attributes(
+        task_url: "https://resmedsaas.atlassian.net/browse/#{task_id}",
+        type: 'Code',
+        estimated_hours: estimated_hours,
+        sprint_id: sprint_id,
+        developer_id: developer&.id,
+        assigned_to_user: user&.id,
+        created_by: created_by_id,
+        updated_by: created_by_id,
+        assigned_to_developer: developer&.id,
+        title: title,
+        description: task.description.presence || '',
+        start_date: start_date,
+        end_date: end_date,
+        status: status,
+        order: order
+      )
+
+      task.save!
+    end
+  end
+
+  def write_tasks_to_sheet(tasks)
+    clear_sheet
+
+    values = [[
+      'Order', 'Task ID', 'Task Title', 'Est. Hours',
+      'Assigned To Developer', 'Assigned User', 'Start Date', 'End Date', 'Status'
+    ]]
+
+    tasks.each_with_index do |task, index|
+      values << [
+        index + 1,
+        task.task_id,
+        task.title,
+        task.estimated_hours.to_i,
+        task.developer&.name.to_s,
+        task.assigned_user&.first_name.to_s,
+        task.start_date&.day,
+        task.end_date&.day,
+        task.status.capitalize
+      ]
+    end
+
+    value_range = Google::Apis::SheetsV4::ValueRange.new(values: values)
+
+    @service.update_spreadsheet_value(
+      SPREADSHEET_ID,
+      "#{@sheet_name}!A1",
+      value_range,
+      value_input_option: 'RAW'
+    )
+  end
+
+  def clear_sheet
+    @service.clear_values(SPREADSHEET_ID, "#{@sheet_name}!A1:Z")
+  end
+end
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,12 @@ Rails.application.routes.draw do
 
     resources :users, only: [:index, :update, :destroy]
     resources :posts, only: [:index, :create, :update, :destroy]
-    resources :sprints, only: [:index, :create, :update, :destroy]
+    resources :sprints, only: [:index, :create, :update, :destroy] do
+      member do
+        post 'import_tasks'
+        post 'export_tasks'
+      end
+    end
     resources :developers, only: [:index]
     resources :tasks, only: [:index, :create, :update, :destroy]
     resources :task_logs, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- add `TaskSheetService` to sync tasks with Google Sheets
- provide routes and controller actions for importing and exporting sprint tasks
- expose new API helpers in the frontend
- update sprint dashboard UI with import/export buttons

## Testing
- `bundle exec rails test` *(fails: rbenv: version `ruby-3.3.0` is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68790020e7ec8322b403b5934f305883