### PR TITLE
Add personal filter to heatmap

### DIFF
--- a/app/javascript/components/TodoBoard/Heatmap.jsx
+++ b/app/javascript/components/TodoBoard/Heatmap.jsx
@@ -1,14 +1,43 @@
 // src/components/Heatmap.js
-import React from 'react';
+import React, { useContext, useState } from 'react';
 import { format, parseISO } from 'date-fns';
 import { getHeatmapData } from '/utils/taskUtils';
+import { AuthContext } from '../../context/AuthContext';
 
 const Heatmap = ({ columns }) => {
-  const data = getHeatmapData(columns);
+  const { user } = useContext(AuthContext);
+  const [view, setView] = useState('all');
+
+  const filteredColumns =
+    view === 'my' && user
+      ? Object.fromEntries(
+          Object.entries(columns).map(([k, col]) => [k, { ...col, items: col.items.filter(t => t.assigned_to_user === user.id) }])
+        )
+      : columns;
+
+  const data = getHeatmapData(filteredColumns);
 
   return (
     <div className="bg-white p-6 shadow-md rounded-lg">
       <h3 className="font-semibold mb-3">Due Date Heatmap</h3>
+      <div className="mb-3 flex space-x-2">
+        <button
+          className={`px-3 py-1 rounded-md text-sm font-medium ${
+            view === 'all' ? 'bg-blue-500 text-white' : 'bg-gray-200'
+          }`}
+          onClick={() => setView('all')}
+        >
+          All Tasks
+        </button>
+        <button
+          className={`px-3 py-1 rounded-md text-sm font-medium ${
+            view === 'my' ? 'bg-blue-500 text-white' : 'bg-gray-200'
+          }`}
+          onClick={() => setView('my')}
+        >
+          My Tasks
+        </button>
+      </div>
       <div className="flex gap-2">
         {data.map((d, i) => (
           <div


### PR DESCRIPTION
## Summary
- allow viewing only current user's tasks in the Due Date Heatmap
- toggle between All Tasks and My Tasks

## Testing
- `npm run build` *(fails: `esbuild: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6879f4698b3c8322af98f14fd239f18f