### PR TITLE
Add scheduler export to sheet

### DIFF
--- a/app/controllers/api/sprints_controller.rb
+++ b/app/controllers/api/sprints_controller.rb
@@ -61,6 +61,17 @@ class Api::SprintsController < Api::BaseController
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
+  def export_logs
+    sprint = Sprint.find(params[:id])
+    logs = TaskLog.joins(:task).where(tasks: { sprint_id: sprint.id }).includes(:task, :developer)
+    sheet_name = "#{sprint.name} Scheduler"
+    service = SchedulerSheetService.new(sheet_name)
+    service.export_logs(logs)
+    head :no_content
+  rescue StandardError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   private
   def sprint_params
     params.require(:sprint).permit(:name, :start_date, :end_date)

--- a/app/javascript/components/Scheduler/Scheduler.jsx
+++ b/app/javascript/components/Scheduler/Scheduler.jsx
@@ -339,6 +339,16 @@ function Scheduler({ sprintId }) {
     }
   };
 
+  const handleExportScheduler = async () => {
+    if (!sprint) return;
+    try {
+      await SchedulerAPI.exportSprintLogs(sprint.id);
+      alert('Exported logs to sheet');
+    } catch (e) {
+      alert('Export failed');
+    }
+  };
+
   const handleTaskUpdate = useCallback((updatedTask) => {
     setTasks(prevTasks => {
       if (updatedTask.deleted) {
@@ -479,13 +489,22 @@ function Scheduler({ sprintId }) {
                   <h1 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-sky-500 flex items-center">
                     <TableCellsIcon className="h-6 w-6 mr-2 text-sky-600"/> Sprint Logs
                   </h1>
-                  <button
-                    onClick={() => setIsAddTaskModalOpen(true)}
-                    className="flex items-center bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105"
+                  <div className="flex space-x-2">
+                    <button
+                      onClick={() => setIsAddTaskModalOpen(true)}
+                      className="flex items-center bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105"
                     >
-                    <PlusCircleIcon className="h-5 w-5 mr-2" />
-                    Add Log
-                  </button>
+                      <PlusCircleIcon className="h-5 w-5 mr-2" />
+                      Add Log
+                    </button>
+                    <button
+                      onClick={handleExportScheduler}
+                      className="flex items-center bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105"
+                    >
+                      <TableCellsIcon className="h-5 w-5 mr-2" />
+                      Export to Scheduler Sheet
+                    </button>
+                  </div>
                 </div>
               </div>
             </header>

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -68,7 +68,8 @@ export const SchedulerAPI = {
   updateTaskLog: (id, data) => api.patch(`/task_logs/${id}.json`, { task_log: data }),
   deleteTaskLog: (id) => api.delete(`/task_logs/${id}.json`),
   importSprintTasks: (id) => api.post(`/sprints/${id}/import_tasks`),
-  exportSprintTasks: (id) => api.post(`/sprints/${id}/export_tasks`)
+  exportSprintTasks: (id) => api.post(`/sprints/${id}/export_tasks`),
+  exportSprintLogs: (id) => api.post(`/sprints/${id}/export_logs`)
 };
 
 // USER ENDPOINTS (existing)

--- a/app/services/scheduler_sheet_service.rb
+++ b/app/services/scheduler_sheet_service.rb
@@ -1,0 +1,60 @@
+require 'google/apis/sheets_v4'
+require 'googleauth'
+
+class SchedulerSheetService
+  SPREADSHEET_ID = GoogleSheetsReader::SPREADSHEET_ID
+
+  def initialize(sheet_name)
+    @sheet_name = sheet_name
+    @service = Google::Apis::SheetsV4::SheetsService.new
+    @service.client_options.application_name = 'Rails Scheduler Sheet'
+    @service.authorization = authorize
+  end
+
+  def export_logs(logs)
+    developers = logs.map(&:developer).uniq.sort_by(&:name)
+    dates = logs.map(&:log_date).uniq.sort
+    matrix = {}
+    dates.each { |d| matrix[d] = Hash.new { |h, k| h[k] = [] } }
+
+    logs.each do |log|
+      matrix[log.log_date][log.developer.name] << "#{log.task.task_id} (#{log.hours_logged}h)"
+    end
+
+    values = [['Date'] + developers.map(&:name)]
+    dates.each do |date|
+      row = [date.to_s]
+      developers.each do |dev|
+        row << matrix[date][dev.name].join("\n")
+      end
+      values << row
+    end
+
+    write_sheet(values)
+  end
+
+  private
+
+  def authorize
+    scopes = ['https://www.googleapis.com/auth/spreadsheets']
+    Google::Auth::ServiceAccountCredentials.make_creds(
+      json_key_io: File.open(Rails.root.join('config/google_service_account.json')),
+      scope: scopes
+    ).tap(&:fetch_access_token!)
+  end
+
+  def write_sheet(values)
+    clear_sheet
+    value_range = Google::Apis::SheetsV4::ValueRange.new(values: values)
+    @service.update_spreadsheet_value(
+      SPREADSHEET_ID,
+      "#{@sheet_name}!A1",
+      value_range,
+      value_input_option: 'RAW'
+    )
+  end
+
+  def clear_sheet
+    @service.clear_values(SPREADSHEET_ID, "#{@sheet_name}!A1:Z")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,7 @@ Rails.application.routes.draw do
       member do
         post 'import_tasks'
         post 'export_tasks'
+        post 'export_logs'
       end
     end
     resources :developers, only: [:index]


### PR DESCRIPTION
## Summary
- allow exporting scheduler data to Google Sheets
- add new endpoint `export_logs` in Sprints API
- create `SchedulerSheetService` to build scheduler sheet
- add export button in Scheduler UI
- expose `exportSprintLogs` in JavaScript API
- wire up new route

## Testing
- `yarn build` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879f9966b1c832285e071008b144197