### PR TITLE
Move sheet buttons to sprint overview

### DIFF
--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -71,25 +71,6 @@ export default function SprintDashboard() {
     setIsHeaderExpanded(false);
   };
 
-  const handleImport = async () => {
-    if (!sprintId) return;
-    try {
-      await SchedulerAPI.importSprintTasks(sprintId);
-      alert('Imported tasks from sheet');
-    } catch (e) {
-      alert('Import failed');
-    }
-  };
-
-  const handleExport = async () => {
-    if (!sprintId) return;
-    try {
-      await SchedulerAPI.exportSprintTasks(sprintId);
-      alert('Exported tasks to sheet');
-    } catch (e) {
-      alert('Export failed');
-    }
-  };
 
   return (
     <div className="space-y-6">
@@ -175,20 +156,6 @@ export default function SprintDashboard() {
         >
           Sheet
         </button>
-        </div>
-        <div className="flex space-x-2 ml-4">
-          <button
-            onClick={handleImport}
-            className="px-4 py-2 rounded-lg bg-green-500 text-white hover:bg-green-600"
-          >
-            Import from Sheet
-          </button>
-          <button
-            onClick={handleExport}
-            className="px-4 py-2 rounded-lg bg-blue-500 text-white hover:bg-blue-600"
-          >
-            Export to Sheet
-          </button>
         </div>
       </div>
       {activeTab === 'overview' && (

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -668,6 +668,26 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
         setShowAddModal(false);
     };
 
+    const handleImport = async () => {
+        if (!selectedSprintId) return;
+        try {
+            await SchedulerAPI.importSprintTasks(selectedSprintId);
+            alert('Imported tasks from sheet');
+        } catch (e) {
+            alert('Import failed');
+        }
+    };
+
+    const handleExport = async () => {
+        if (!selectedSprintId) return;
+        try {
+            await SchedulerAPI.exportSprintTasks(selectedSprintId);
+            alert('Exported tasks to sheet');
+        } catch (e) {
+            alert('Export failed');
+        }
+    };
+
     return (
         <div className="min-h-screen bg-gradient-to-br from-slate-50 to-sky-100 p-8 font-sans text-gray-800">
             <div className="max-w-8xl mx-auto bg-white rounded-xl shadow-lg p-4">
@@ -675,13 +695,27 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
                     <h1 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-sky-500 flex items-center">
                         <CalendarDaysIcon className="h-7 w-7 mr-2"/>Sprint Task Manager
                     </h1>
-                    <button
-                        onClick={() => setShowAddModal(true)}
-                        className="flex items-center bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
-                    >
-                        <PlusCircleIcon className="h-5 w-5 mr-2" />
-                        Add Task
-                    </button>
+                    <div className="flex space-x-2">
+                        <button
+                            onClick={() => setShowAddModal(true)}
+                            className="flex items-center bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
+                        >
+                            <PlusCircleIcon className="h-5 w-5 mr-2" />
+                            Add Task
+                        </button>
+                        <button
+                            onClick={handleImport}
+                            className="flex items-center bg-green-600 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
+                        >
+                            Import from Sheet
+                        </button>
+                        <button
+                            onClick={handleExport}
+                            className="flex items-center bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
+                        >
+                            Export to Sheet
+                        </button>
+                    </div>
                 </div>
 
                 {/* Tasks Table */}


### PR DESCRIPTION
## Summary
- relocate sheet import/export controls from `SprintDashboard` to `SprintOverview`
- group the import/export buttons with the Add Task control

## Testing
- `yarn build` *(fails: package not in lockfile)*
- `yarn install` *(fails: network 403)*

------
https://chatgpt.com/codex/tasks/task_e_687a050dfee88322bc4fb50a3e3443ae