### PR TITLE
Add spinner and toast feedback

### DIFF
--- a/app/javascript/components/TodoBoard/TaskForm.jsx
+++ b/app/javascript/components/TodoBoard/TaskForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { toast } from 'react-hot-toast';
 
 const TaskForm = ({ onAddTask, onCancel }) => {
   const [formData, setFormData] = useState({
@@ -16,7 +17,7 @@ const TaskForm = ({ onAddTask, onCancel }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (!formData.title) return alert('Title is required.');
+    if (!formData.title) return toast.error('Title is required.');
     onAddTask(formData);
     setFormData({ title: '', type: '', status: 'todo', assigned_to_user: '', end_date: '' });
   };

--- a/app/javascript/components/ui/SpinnerOverlay.jsx
+++ b/app/javascript/components/ui/SpinnerOverlay.jsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export default function SpinnerOverlay() {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500"></div>
+    </div>
+  );
+}

--- a/app/javascript/pages/Event.jsx
+++ b/app/javascript/pages/Event.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { bookEvent } from "../components/api";
+import { Toaster, toast } from "react-hot-toast";
 
 const Event = () => {
   const handleBook = async () => {
@@ -7,12 +8,13 @@ const Event = () => {
       const { data } = await bookEvent();
       window.location.href = data.url; // Redirect to Stripe Checkout
     } catch {
-      alert("Unable to start checkout. Please try again.");
+      toast.error("Unable to start checkout. Please try again.");
     }
   };
 
   return (
     <div className="max-w-2xl mx-auto p-8">
+      <Toaster position="top-right" />
       <h1 className="text-3xl font-bold mb-4">Tech Conference 2024</h1>
       <p className="mb-2">Join us for an exciting day of talks and workshops about the latest in technology.</p>
       <ul className="mb-4">

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { SchedulerAPI, getUsers } from '../components/api';
+import { Toaster, toast } from 'react-hot-toast';
+import SpinnerOverlay from '../components/ui/SpinnerOverlay';
 import { FiX } from 'react-icons/fi';
 import { CalendarDaysIcon, PlusCircleIcon, FunnelIcon } from '@heroicons/react/24/outline';
 import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
@@ -463,6 +465,7 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
     const [selectedSprintId, setSelectedSprintId] = useState(sprintId || null);
     const [showUserFilter, setShowUserFilter] = useState(false);
     const [filterUsers, setFilterUsers] = useState([]);
+    const [processing, setProcessing] = useState(false);
 
     useEffect(() => {
         if (sprintId) setSelectedSprintId(sprintId);
@@ -683,25 +686,31 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
     const handleImport = async () => {
         if (!selectedSprintId) return;
         try {
+            setProcessing(true);
             await SchedulerAPI.importSprintTasks(selectedSprintId);
-            alert('Imported tasks from sheet');
+            toast.success('Imported tasks from sheet');
         } catch (e) {
-            alert('Import failed');
+            toast.error('Import failed');
         }
+        setProcessing(false);
     };
 
     const handleExport = async () => {
         if (!selectedSprintId) return;
         try {
+            setProcessing(true);
             await SchedulerAPI.exportSprintTasks(selectedSprintId);
-            alert('Exported tasks to sheet');
+            toast.success('Exported tasks to sheet');
         } catch (e) {
-            alert('Export failed');
+            toast.error('Export failed');
         }
+        setProcessing(false);
     };
 
     return (
         <div className="min-h-screen bg-gradient-to-br from-slate-50 to-sky-100 p-8 font-sans text-gray-800">
+            <Toaster position="top-right" />
+            {processing && <SpinnerOverlay />}
             <div className="max-w-8xl mx-auto bg-white rounded-xl shadow-lg p-4">
                 <div className="flex justify-between items-center mb-4">
                     <h1 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-sky-500 flex items-center">

--- a/app/javascript/pages/Vault.jsx
+++ b/app/javascript/pages/Vault.jsx
@@ -121,7 +121,7 @@ const Vault = () => {
   };
 
   const handleExportAll = () => {
-    if (items.length === 0) return alert("No items to export.");
+    if (items.length === 0) return toast.error("No items to export.");
     const dataStr = JSON.stringify(items, null, 2);
     const blob = new Blob([dataStr], { type: "application/json" });
     const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- add reusable `SpinnerOverlay` component
- show toast messages and spinner for sprint import/export
- replace alerts with toast across the app

## Testing
- `npm install` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a5652a708832285d1239b0f136e54