### PR TITLE
Add backlog sheet import

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -42,6 +42,14 @@ class Api::TasksController < Api::BaseController
     head :no_content
   end
 
+  def import_backlog
+    service = TaskSheetService.new('Backlog')
+    service.import_tasks(sprint_id: nil, created_by_id: current_user.id)
+    head :no_content
+  rescue StandardError => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   private
 
   def set_task

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -68,6 +68,7 @@ export const SchedulerAPI = {
   updateTaskLog: (id, data) => api.patch(`/task_logs/${id}.json`, { task_log: data }),
   deleteTaskLog: (id) => api.delete(`/task_logs/${id}.json`),
   importSprintTasks: (id) => api.post(`/sprints/${id}/import_tasks`),
+  importBacklogTasks: () => api.post('/tasks/import_backlog'),
   exportSprintTasks: (id) => api.post(`/sprints/${id}/export_tasks`),
   exportSprintLogs: (id) => api.post(`/sprints/${id}/export_logs`)
 };

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -764,6 +764,20 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
         setProcessing(false);
     };
 
+    const handleBacklogImport = async () => {
+        try {
+            setProcessing(true);
+            await SchedulerAPI.importBacklogTasks();
+            toast.success('Imported backlog from sheet');
+            const res = await SchedulerAPI.getTasks();
+            const mapped = res.data.filter(t => !t.sprint_id).map(mapTask);
+            setBacklogTasks(mapped);
+        } catch (e) {
+            toast.error('Import failed');
+        }
+        setProcessing(false);
+    };
+
     const handleExport = async () => {
         if (!selectedSprintId) return;
         try {
@@ -951,6 +965,12 @@ const SprintOverview = ({ sprintId, onSprintChange }) => {
                         >
                             <PlusCircleIcon className="h-5 w-5 mr-2" />
                             Add Task
+                        </button>
+                        <button
+                            onClick={handleBacklogImport}
+                            className="flex items-center bg-green-500 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
+                        >
+                            Import Backlog
                         </button>
                     </div>
                 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,11 @@ Rails.application.routes.draw do
       end
     end
     resources :developers, only: [:index]
-    resources :tasks, only: [:index, :create, :update, :destroy]
+    resources :tasks, only: [:index, :create, :update, :destroy] do
+      collection do
+        post 'import_backlog'
+      end
+    end
     resources :task_logs, only: [:index, :create, :update, :destroy]
 
     resources :items, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- allow importing backlog tasks from Google Sheets
- expose new route and controller action for backlog imports
- add API wrapper and UI button for backlog import

## Testing
- `bin/rails test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687e4f9b45948322a71c7ba31068a2fe