### PR TITLE
Remove unused assigned_to_developer column

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -61,7 +61,7 @@ class Api::TasksController < Api::BaseController
     task_data = task_data[:task] if task_data[:task].is_a?(ActionController::Parameters)
     task_data.permit(
       :task_id, :task_url, :type, :title, :description,
-      :status, :order, :assigned_to_user, :assigned_to_developer,
+      :status, :order, :assigned_to_user,
       :created_by, :created_at, :updated_by, :updated_at,
       :start_date, :end_date,
       :estimated_hours, :sprint_id, :developer_id, :is_struck

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -17,7 +17,6 @@ const mapTask = (t) => ({
     status: t.status === 'completed' ? 'Completed' : t.status === 'inprogress' ? 'In Progress' : 'To Do',
     assignedTo: [t.developer_id].filter(Boolean).map(String),
     assignedUser: t.assigned_to_user,
-    assignedDeveloper: t.assigned_to_developer,
     order: t.order,
     startDate: t.start_date || t.date,
     endDate: t.end_date || t.due_date || t.date,

--- a/app/services/task_sheet_service.rb
+++ b/app/services/task_sheet_service.rb
@@ -77,7 +77,6 @@ class TaskSheetService
         assigned_to_user: user&.id,
         created_by: created_by_id,
         updated_by: created_by_id,
-        assigned_to_developer: developer&.id,
         title: title,
         description: task.description.presence || '',
         start_date: start_date,

--- a/db/migrate/20250606124130_add_fields_to_tasks_and_sprints.rb
+++ b/db/migrate/20250606124130_add_fields_to_tasks_and_sprints.rb
@@ -3,7 +3,7 @@ class AddFieldsToTasksAndSprints < ActiveRecord::Migration[7.1]
     # Tasks table
     add_column :tasks, :status, :string, default: "todo"
     add_column :tasks, :order, :integer, default: 0
-    add_column :tasks, :assigned_to, :integer
+    add_column :tasks, :assigned_to_user, :integer
     add_column :tasks, :created_by, :integer
     add_column :tasks, :updated_by, :integer
     add_column :tasks, :due_date, :date

--- a/db/migrate/20250712000001_split_assigned_to_columns.rb
+++ b/db/migrate/20250712000001_split_assigned_to_columns.rb
@@ -1,6 +1,0 @@
-class SplitAssignedToColumns < ActiveRecord::Migration[7.1]
-  def change
-    rename_column :tasks, :assigned_to, :assigned_to_user
-    add_column :tasks, :assigned_to_developer, :integer
-  end
-end

--- a/db/migrate/20260716000000_remove_assigned_to_developer_from_tasks.rb
+++ b/db/migrate/20260716000000_remove_assigned_to_developer_from_tasks.rb
@@ -1,0 +1,7 @@
+class RemoveAssignedToDeveloperFromTasks < ActiveRecord::Migration[7.1]
+  def change
+    if column_exists?(:tasks, :assigned_to_developer)
+      remove_column :tasks, :assigned_to_developer, :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -121,7 +121,6 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_15_000000) do
     t.integer "assigned_to_user"
     t.integer "created_by"
     t.integer "updated_by"
-    t.integer "assigned_to_developer"
     t.string "title"
     t.text "description"
     t.date "start_date"


### PR DESCRIPTION
## Summary
- drop references to unused `assigned_to_developer`
- drop migration that added the column
- add migration to remove the column
- keep `assigned_to_user` in earlier migration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687f4f3129d083228a8fb44f1a972aa2