### PR TITLE
Add SMTP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SMTP_ADDRESS=smtp.example.com
+SMTP_PORT=587
+SMTP_DOMAIN=example.com
+SMTP_USERNAME=your_username
+SMTP_PASSWORD=your_password

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb
+!/.env.example
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/README.md
+++ b/README.md
@@ -21,13 +21,20 @@ Ensure these versions are available on your machine or use the provided `Dockerf
 
    This script runs `bundle install`, `yarn install`, prepares the database and clears logs.
 
-2. Create and migrate the database:
+2. Copy `.env.example` to `.env` and fill in your SMTP credentials:
+
+   ```bash
+   cp .env.example .env
+   # edit .env with your mail server details
+   ```
+
+3. Create and migrate the database:
 
    ```bash
    bin/rails db:create db:migrate
    ```
 
-3. Start the application in development:
+4. Start the application in development:
 
    ```bash
    bin/dev

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,6 +41,18 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Configure SMTP using environment variables so mail can be tested locally
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_ADDRESS", "localhost"),
+    port: ENV.fetch("SMTP_PORT", 1025).to_i,
+    domain: ENV.fetch("SMTP_DOMAIN", "localhost"),
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,18 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  # Deliver emails via SMTP using credentials stored in environment variables
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_ADDRESS"),
+    port: ENV.fetch("SMTP_PORT", 587).to_i,
+    domain: ENV.fetch("SMTP_DOMAIN"),
+    user_name: ENV.fetch("SMTP_USERNAME"),
+    password: ENV.fetch("SMTP_PASSWORD"),
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
## Summary
- configure SMTP delivery using env vars in development and production
- provide `.env.example` for mail credentials
- document setup for creating `.env`
- track `.env.example` in git

## Testing
- `bin/rails about` *(fails: `ruby` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5a39b654832291dda5ac4196e96a