### PR TITLE
Add docker compose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ bin/rails assets:precompile
 
 You can also build the Docker image using the provided `Dockerfile`.
 
+### Running with Docker Compose
+
+To run the app and a PostgreSQL database locally, use the included
+`docker-compose.yml`:
+
+```bash
+docker compose build
+docker compose up
+```
+
+The web service loads environment variables from `.env`. The database service
+stores its data in the `db-data` volume.
+
 ## Google Sheets Integration
 
 The app includes a small example page that reads data from a Google Sheet using

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,14 +8,14 @@ development:
   database: pdf_master_development
   username: postgres
   password: postgres
-  host: localhost
+  host: <%= ENV.fetch('DB_HOST', 'localhost') %>
 
 test:
   <<: *default
   database: pdf_master_test
   username: postgres
   password: postgres
-  host: localhost
+  host: <%= ENV.fetch('DB_HOST', 'localhost') %>
 
 production:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:16
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+
+  web:
+    build: .
+    env_file:
+      - .env
+    environment:
+      DB_HOST: db
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
- make DB host configurable via `DB_HOST`
- add `docker-compose.yml` to run Rails and Postgres
- document Docker Compose usage in README

## Testing
- `bundle exec rake -T` *(fails: ruby-3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687f7cbda98c8322a9c3ca526f8d0de0