### PR TITLE
Add PDF reset and download controls

### DIFF
--- a/app/javascript/components/FormComponent.jsx
+++ b/app/javascript/components/FormComponent.jsx
@@ -44,8 +44,8 @@ const FormComponent = ({ setActiveForm, setPdfUpdated, formFields = [], endpoint
         <FaArrowLeft className="mr-2" /> Back
       </button>
 
-      <h2 className="text-lg font-bold mb-2">{title}</h2>
-      <form onSubmit={handleSubmit} className="space-y-2">
+      <h2 className="text-lg font-bold mb-4">{title}</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
         {formFields.map((field, index) => (
           <input
             key={index}
@@ -54,11 +54,11 @@ const FormComponent = ({ setActiveForm, setPdfUpdated, formFields = [], endpoint
             placeholder={field.placeholder}
             value={formData[field.name] || ""}
             onChange={handleChange}
-            className="w-full p-2 border rounded"
+            className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         ))}
         <input type="hidden" name="pdf_path" value={pdfPath} />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded w-full">Submit</button>
+        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded w-full hover:bg-blue-700">Submit</button>
       </form>
     </motion.div>
   );

--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -60,6 +60,24 @@ const PdfPage = () => {
     localStorage.removeItem("pdfUrl");
   };
 
+  const handleResetPdf = async () => {
+    try {
+      const response = await fetch("/reset_pdf", {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
+        },
+      });
+      if (response.ok) setPdfUpdated((prev) => !prev);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const handleDownloadPdf = () => {
+    window.open("/download_pdf", "_blank");
+  };
+
   return (
     <div className="flex flex-col min-h-screen items-center bg-gray-100 p-6">
       {/* Upload Section */}
@@ -131,13 +149,26 @@ const PdfPage = () => {
           <div className="w-3/5 items-center">
             <PdfViewer pdfUrl={`${pdfUrl}?updated=${pdfUpdated}`} />
 
-            {/* Remove PDF Button */}
-            <button
-              className="bg-red-500 text-white px-6 py-2 mt-4 rounded shadow hover:bg-red-600 w-full max-w-xs"
-              onClick={handleRemovePdf}
-            >
-              Remove PDF
-            </button>
+            <div className="flex gap-4 mt-4">
+              <button
+                className="bg-yellow-500 text-white px-4 py-2 rounded shadow hover:bg-yellow-600 flex-1"
+                onClick={handleResetPdf}
+              >
+                Reset
+              </button>
+              <button
+                className="bg-blue-500 text-white px-4 py-2 rounded shadow hover:bg-blue-600 flex-1"
+                onClick={handleDownloadPdf}
+              >
+                Download
+              </button>
+              <button
+                className="bg-red-500 text-white px-4 py-2 rounded shadow hover:bg-red-600 flex-1"
+                onClick={handleRemovePdf}
+              >
+                Remove
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
 
   # PDF
   post "/upload_pdf", to: "pdfs#upload_pdf"
+  post "/reset_pdf", to: "pdfs#reset"
+  get  "/download_pdf", to: "pdfs#download"
 
   post "/api/update_pdf", to: "pdf_modifiers#update_pdf"
 


### PR DESCRIPTION
## Summary
- allow PDF reset and download via new routes
- show Reset/Download buttons on PDF page
- enhance PDF form styling

## Testing
- `bin/rails routes | head -n 20` *(fails: Missing tool version)*

------
https://chatgpt.com/codex/tasks/task_e_688087963ee88322ae51384ee56aadca