### PR TITLE
Add Render build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ docker compose build
 docker compose up
 ```
 
+### Deploying to Render
+
+Render requires precompiling the Vite assets during the build phase. Use the
+included script as your **Build Command**:
+
+```bash
+./bin/render-build
+```
+
+Then set the **Start Command** to launch Rails:
+
+```bash
+bundle exec rails server
+```
+
 The web service loads environment variables from `.env`. The database service
 stores its data in the `db-data` volume.
 

--- a/bin/render-build
+++ b/bin/render-build
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+bundle install --without development test
+yarn install --frozen-lockfile
+
+RAILS_ENV=production bin/vite build
+bundle exec rails assets:precompile


### PR DESCRIPTION
## Summary
- add `bin/render-build` for production deployments
- document Render deployment steps in README

## Testing
- `bundle exec rake -T` *(fails: Missing tool version)*

------
https://chatgpt.com/codex/tasks/task_e_6880e5f858d483229482edc529fbc374