### PR TITLE
Improve build script for Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ docker compose up
 ### Deploying to Render
 
 Render requires precompiling the Vite assets during the build phase. Use the
-included script as your **Build Command**:
+included script as your **Build Command**. It installs dependencies and
+precompiles assets, so it's safe to reuse in container builds like Docker:
 
 ```bash
 ./bin/render-build

--- a/bin/render-build
+++ b/bin/render-build
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
-set -e
+set -euo pipefail
 
-bundle install --without development test
-yarn install --frozen-lockfile
+# Default to production environment if RAILS_ENV is not provided
+RAILS_ENV=${RAILS_ENV:-production}
 
-RAILS_ENV=production bin/vite build
+# Install Ruby gems in deployment mode
+bundle config set --local deployment 'true'
+bundle config set --local without 'development test'
+bundle install
+
+# Install JavaScript packages without updating lock file
+yarn install --frozen-lockfile --production=true
+
+# Compile assets for production
+bin/vite build
 bundle exec rails assets:precompile


### PR DESCRIPTION
## Summary
- make `bin/render-build` Docker-friendly
- clarify docs about using the build script in container environments

## Testing
- `bundle exec rails --version` *(fails: Missing tool version)*

------
https://chatgpt.com/codex/tasks/task_e_6880ea1a73c08322a8aefbfd875ec19a