### PR TITLE
Fix confirmation email template

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -75,7 +75,7 @@ class Api::AuthController < Api::BaseController
   private
 
   def user_params
-    params.require(:auth).permit(:first_name, :last_name, :date_of_birth, :email, :password, :uid)
+    params.require(:auth).permit(:first_name, :last_name, :date_of_birth, :email, :password, :uid, :profile_picture)
   end
 
   def verify_firebase_token(token)

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,3 @@
+<p>Welcome <%= @resource.first_name %>,</p>
+<p>You can confirm your account email through the link below:</p>
+<p><%= link_to 'Confirm my account', user_confirmation_url(confirmation_token: @token) %></p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,6 +52,7 @@ Rails.application.configure do
     authentication: :plain,
     enable_starttls_auto: true
   }
+  config.action_mailer.default_url_options = { host: "http://localhost:5000" }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,6 +78,7 @@ Rails.application.configure do
     authentication: :plain,
     enable_starttls_auto: true
   }
+  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "example.com") }
   
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
## Summary
- allow profile_picture in user params
- add a custom confirmation template that uses `user_confirmation_url`
- configure mailer URL host in dev & prod environments

## Testing
- `mise install` *(fails: No such file or directory due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6881cd0e2cc4832289076ac87910aa85