### PR TITLE
Fix signup without profile picture

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -75,7 +75,9 @@ class Api::AuthController < Api::BaseController
   private
 
   def user_params
-    params.require(:auth).permit(:first_name, :last_name, :date_of_birth, :email, :password, :uid, :profile_picture)
+    permitted = params.require(:auth).permit(:first_name, :last_name, :date_of_birth, :email, :password, :uid, :profile_picture)
+    permitted.delete(:profile_picture) if permitted[:profile_picture] == "null"
+    permitted
   end
 
   def verify_firebase_token(token)


### PR DESCRIPTION
## Summary
- sanitize profile picture parameter so string `"null"` isn't treated as an attachment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881d49608808322b8d3af8667feb3b1