### PR TITLE
Custom confirmation redirect

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,9 @@
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  protected
+
+  # Redirect to /login after email confirmation and show a message.
+  def after_confirmation_path_for(resource_name, resource)
+    flash[:notice] = 'Your email has been confirmed. Please log in.'
+    '/login?confirmed=1'
+  end
+end

--- a/app/javascript/pages/Login.jsx
+++ b/app/javascript/pages/Login.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from "react";
 import { AuthContext } from "../context/AuthContext";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { auth, getRedirectResult } from "../firebaseConfig";
 import { Toaster, toast } from "react-hot-toast";
 
@@ -8,6 +8,7 @@ const Login = () => {
   const { handleLogin, handleGoogleLogin } = useContext(AuthContext);
   const [formData, setFormData] = useState({ email: "", password: "" });
   const [error, setError] = useState(null);
+  const [searchParams] = useSearchParams();
 
   const navigate = useNavigate();
 
@@ -31,12 +32,18 @@ const Login = () => {
   };
 
   useEffect(() => {
-    getRedirectResult(auth).then((result) => {
-      if (result?.user) {
-        console.log("Redirect Login Success:", result.user);
-      }
-    }).catch(console.error);
-  }, []);
+    if (searchParams.get("confirmed")) {
+      toast.success("Email confirmed. Please log in.");
+    }
+
+    getRedirectResult(auth)
+      .then((result) => {
+        if (result?.user) {
+          console.log("Redirect Login Success:", result.user);
+        }
+      })
+      .catch(console.error);
+  }, [searchParams]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { confirmations: 'users/confirmations' }
   mount ActiveStorage::Engine => "/rails/active_storage"
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
## Summary
- send Devise confirmations to a custom controller
- redirect to `/login` with a query flag after confirming
- show a toast on the login page when `confirmed` flag is present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881d4e1d1108322aae27319e8223527