### PR TITLE
Add status field to users

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -37,6 +37,8 @@ class Api::AuthController < Api::BaseController
       return render json: { error: "Email not verified" }, status: :unauthorized unless user.confirmed?
     end
 
+    return render json: { error: "Account locked" }, status: :unauthorized if user.locked?
+
     set_jwt_cookie!(user)
     render json: { message: "Login successful", user: user, exp: 15.minutes.from_now.to_i }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, :confirmable
 
+  enum status: { new: "new", active: "active", locked: "locked" }, _default: "new"
+
+  after_confirmation :activate!
+
   has_one_attached :profile_picture
   has_many :posts, dependent: :destroy
   has_many :tasks, foreign_key: :assigned_to_user
@@ -17,4 +21,10 @@ class User < ApplicationRecord
   # This is a class attribute that will store the current user for the current request.
   # It needs to be thread-safe.
   cattr_accessor :current_user
+
+  private
+
+  def activate!
+    update_column(:status, "active")
+  end
 end

--- a/db/migrate/20260802000000_add_status_to_users.rb
+++ b/db/migrate/20260802000000_add_status_to_users.rb
@@ -1,0 +1,5 @@
+class AddStatusToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :status, :string, default: "new", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_07_16_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_08_02_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -142,6 +142,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_07_16_000000) do
     t.string "first_name"
     t.string "last_name"
     t.date "date_of_birth"
+    t.string "status", default: "new", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
## Summary
- add status column to users table
- update the schema accordingly
- manage user status via Devise callbacks
- prevent locked accounts from logging in

## Testing
- `bundle exec rails test` *(fails: Tool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881d553c6908322b9ea4dd063f6edd4