### PR TITLE
Show auth forms at root

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,9 +1,9 @@
 class Users::ConfirmationsController < Devise::ConfirmationsController
   protected
 
-  # Redirect to /login after email confirmation and show a message.
+  # Redirect to the root login page after email confirmation and show a message.
   def after_confirmation_path_for(resource_name, resource)
     flash[:notice] = 'Your email has been confirmed. Please log in.'
-    '/login?confirmed=1'
+    '/?confirmed=1'
   end
 end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -7,8 +7,6 @@ import PrivateRoute from "../components/PrivateRoute";
 import Navbar from "../components/Navbar";
 import Footer from "./Footer";
 import PdfPage from "./PdfPage";
-import Signup from "../pages/Signup";
-import Login from "../pages/Login";
 import PostPage from "../pages/PostPage";
 import Profile from "../components/Profile";
 import KnowledgeDashboard from "../pages/KnowledgeDashboard";
@@ -41,8 +39,6 @@ const App = () => {
 
           {/* ✅ Page Content */}
             <Routes>
-              <Route path="/signup" element={<AuthLayout><Signup /></AuthLayout>} />
-              <Route path="/login" element={<AuthLayout><Login /></AuthLayout>} />
               <Route path="/event" element={<MainLayout><Event /></MainLayout>} />
               <Route path="/contact" element={<MainLayout><Contact /></MainLayout>} />
               <Route path="/weather" element={<MainLayout><Weather /></MainLayout>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -40,10 +40,18 @@ const Navbar = () => {
               </>
             ) : (
               <>
-                <NavLink to="/login" className="text-gray-700 font-medium hover:text-indigo-600 transition">
+                <NavLink
+                  to="/"
+                  state={{ mode: "login" }}
+                  className="text-gray-700 font-medium hover:text-indigo-600 transition"
+                >
                   Login
                 </NavLink>
-                <NavLink to="/signup" className="text-gray-700 font-medium hover:text-indigo-600 transition">
+                <NavLink
+                  to="/"
+                  state={{ mode: "signup" }}
+                  className="text-gray-700 font-medium hover:text-indigo-600 transition"
+                >
                   Sign Up
                 </NavLink>
               </>

--- a/app/javascript/components/PrivateRoute.jsx
+++ b/app/javascript/components/PrivateRoute.jsx
@@ -1,12 +1,15 @@
 import React, { useContext } from "react";
-import { Navigate } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
+import AuthPage from "../pages/AuthPage";
 
 const PrivateRoute = ({ children }) => {
   const { isAuthenticated, initializing } = useContext(AuthContext);
+  const location = useLocation();
+  const mode = location.state?.mode || "login";
 
   if (initializing) return <div>Loading…</div>;
-  return isAuthenticated ? children : <Navigate to="/login" replace />;
+  return isAuthenticated ? children : <AuthPage mode={mode} />;
 };
 
 export default PrivateRoute;

--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -44,7 +44,7 @@ export function AuthProvider({ children }) {
         scheduleRefresh(data.exp);
       } catch {
         setUser(null);
-        navigate("/login");
+        navigate("/", { state: { mode: "login" } });
       }
     }, ms);
   }, [navigate]);
@@ -84,7 +84,7 @@ export function AuthProvider({ children }) {
     await api.delete("/logout");
     setUser(null);
     clearTimeout(refreshTimer.current);
-    navigate("/login");
+    navigate("/", { state: { mode: "login" } });
   };
 
   const value = {

--- a/app/javascript/pages/AuthPage.jsx
+++ b/app/javascript/pages/AuthPage.jsx
@@ -1,0 +1,15 @@
+import React, { useState } from "react";
+import Login from "./Login";
+import Signup from "./Signup";
+
+function AuthPage({ mode = "login" }) {
+  const [current, setCurrent] = useState(mode);
+
+  return current === "signup" ? (
+    <Signup switchToLogin={() => setCurrent("login")} />
+  ) : (
+    <Login switchToSignup={() => setCurrent("signup")} />
+  );
+}
+
+export default AuthPage;

--- a/app/javascript/pages/Login.jsx
+++ b/app/javascript/pages/Login.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useContext, useEffect } from "react";
 import { AuthContext } from "../context/AuthContext";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { auth, getRedirectResult } from "../firebaseConfig";
 import { Toaster, toast } from "react-hot-toast";
 
-const Login = () => {
+const Login = ({ switchToSignup }) => {
   const { handleLogin, handleGoogleLogin } = useContext(AuthContext);
   const [formData, setFormData] = useState({ email: "", password: "" });
   const [error, setError] = useState(null);
@@ -110,9 +110,13 @@ const Login = () => {
   
         <p className="mt-6 text-center text-gray-600">
           Don't have an account?{" "}
-          <Link to="/signup" className="text-blue-500 hover:text-blue-600 font-medium transition-colors">
+          <button
+            type="button"
+            onClick={switchToSignup}
+            className="text-blue-500 hover:text-blue-600 font-medium transition-colors"
+          >
             Sign Up
-          </Link>
+          </button>
         </p>
       </div>
     </div>

--- a/app/javascript/pages/Signup.jsx
+++ b/app/javascript/pages/Signup.jsx
@@ -1,10 +1,10 @@
 import React, { useState, useContext } from "react";
 import { AuthContext } from "../context/AuthContext";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import submitForm from "../utils/formSubmit";
 import { Toaster, toast } from "react-hot-toast";
 
-const Signup = () => {
+const Signup = ({ switchToLogin }) => {
   const { handleSignup, handleGoogleLogin } = useContext(AuthContext);
   const [formData, setFormData] = useState({
     first_name: "",
@@ -38,7 +38,8 @@ const Signup = () => {
 
     try {
       await submitForm("/api/signup", "POST", submissionData);
-      navigate("/login")
+      if (switchToLogin) switchToLogin();
+      else navigate("/", { state: { mode: "login" } });
       toast.success("Account created. Please log in.");
     } catch (err) {
       const msg = err.response?.data?.errors?.join(", ") || "Signup failed. Please try again.";
@@ -151,12 +152,13 @@ const Signup = () => {
 
         <p className="mt-6 text-center text-gray-600">
           Already have an account?{" "}
-          <Link 
-            to="/login" 
+          <button
+            type="button"
+            onClick={switchToLogin}
             className="text-blue-500 hover:text-blue-600 font-medium transition-colors"
           >
             Log in
-          </Link>
+          </button>
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- create `AuthPage` for login/signup
- display `AuthPage` as fallback in `PrivateRoute`
- drop explicit `/login` and `/signup` routes
- switch navbar links to use root with location state
- update signup and login pages to work without dedicated routes
- adjust logout and confirmation redirects

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d8850cec8322b9f98132daf98799