### PR TITLE
Add loading spinner for login and signup

### DIFF
--- a/app/javascript/pages/Login.jsx
+++ b/app/javascript/pages/Login.jsx
@@ -3,11 +3,13 @@ import { AuthContext } from "../context/AuthContext";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { auth, getRedirectResult } from "../firebaseConfig";
 import { Toaster, toast } from "react-hot-toast";
+import SpinnerOverlay from "../components/ui/SpinnerOverlay";
 
 const Login = () => {
   const { handleLogin, handleGoogleLogin } = useContext(AuthContext);
   const [formData, setFormData] = useState({ email: "", password: "" });
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
   const [searchParams] = useSearchParams();
 
   const navigate = useNavigate();
@@ -19,6 +21,7 @@ const Login = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
+    setLoading(true);
 
     try {
       await handleLogin({ auth: formData });
@@ -28,6 +31,8 @@ const Login = () => {
       const msg = "Invalid email or password. Please try again.";
       setError(msg);
       toast.error(msg);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -48,6 +53,7 @@ const Login = () => {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <Toaster position="top-right" />
+      {loading && <SpinnerOverlay />}
       <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-2xl transition-transform transform hover:scale-[1.01] border border-gray-100">
         <h2 className="text-3xl font-bold text-center text-gray-800 mb-8">Welcome Back</h2>
 
@@ -99,9 +105,17 @@ const Login = () => {
         </div>
 
         {/* Google Login Button */}
-        <button 
-          onClick={handleGoogleLogin} 
-          className="w-full bg-red-500 hover:bg-red-600 text-white py-2.5 rounded-lg font-medium transition-all flex items-center justify-center gap-2 shadow-md">
+        <button
+          onClick={async () => {
+            setLoading(true);
+            try {
+              await handleGoogleLogin();
+            } finally {
+              setLoading(false);
+            }
+          }}
+          className="w-full bg-red-500 hover:bg-red-600 text-white py-2.5 rounded-lg font-medium transition-all flex items-center justify-center gap-2 shadow-md"
+        >
           <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
             <path fill="currentColor" d="M12.545 10.239v3.821h5.445c-.712 2.315-2.647 3.972-5.445 3.972a6.033 6.033 0 110-12.064c1.835 0 3.456.705 4.691 1.942l3.099-3.101A10.113 10.113 0 0012.545 2C7.021 2 2.545 6.477 2.545 12s4.476 10 10 10c5.523 0 10-4.477 10-10a10.1 10.1 0 00-.167-1.785l-9.833-.006z"/>
           </svg>

--- a/app/javascript/pages/Signup.jsx
+++ b/app/javascript/pages/Signup.jsx
@@ -3,6 +3,7 @@ import { AuthContext } from "../context/AuthContext";
 import { Link, useNavigate } from "react-router-dom";
 import submitForm from "../utils/formSubmit";
 import { Toaster, toast } from "react-hot-toast";
+import SpinnerOverlay from "../components/ui/SpinnerOverlay";
 
 const Signup = () => {
   const { handleSignup, handleGoogleLogin } = useContext(AuthContext);
@@ -14,6 +15,7 @@ const Signup = () => {
     profile_picture: null,
   });
   const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
 
   const handleChange = (e) => {
@@ -28,6 +30,7 @@ const Signup = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError(null);
+    setLoading(true);
 
     const submissionData = new FormData();
     submissionData.append("auth[first_name]", formData.first_name);
@@ -44,12 +47,15 @@ const Signup = () => {
       const msg = err.response?.data?.errors?.join(", ") || "Signup failed. Please try again.";
       setError(msg);
       toast.error(msg);
+    } finally {
+      setLoading(false);
     }
   };
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100">
       <Toaster position="top-right" />
+      {loading && <SpinnerOverlay />}
       <div className="w-full max-w-md p-8 bg-white rounded-xl shadow-2xl transition-transform transform hover:scale-[1.01] border border-gray-100">
         <h2 className="text-3xl font-bold text-center text-gray-800 mb-8">Create Account</h2>
 
@@ -139,8 +145,15 @@ const Signup = () => {
         </div>
 
         {/* Google Signup Button */}
-        <button 
-          onClick={handleGoogleLogin}
+        <button
+          onClick={async () => {
+            setLoading(true);
+            try {
+              await handleGoogleLogin();
+            } finally {
+              setLoading(false);
+            }
+          }}
           className="w-full bg-red-500 hover:bg-red-600 text-white py-2.5 rounded-lg font-medium transition-all flex items-center justify-center gap-2 shadow-md"
         >
           <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary
- show a blocking spinner while login request is in progress
- show a blocking spinner while signup request is in progress

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6881d8e041608322aee62071e6754d4c