### PR TITLE
Add team and role models

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,0 +1,8 @@
+class Project < ApplicationRecord
+  belongs_to :owner, class_name: 'User', optional: true
+
+  has_many :project_users, dependent: :destroy
+  has_many :users, through: :project_users
+
+  validates :name, presence: true
+end

--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -1,0 +1,18 @@
+class ProjectUser < ApplicationRecord
+  belongs_to :project
+  belongs_to :user
+
+  enum role: {
+    owner: 'owner',
+    manager: 'manager',
+    collaborator: 'collaborator',
+    viewer: 'viewer'
+  }, _default: 'collaborator'
+
+  enum status: {
+    invited: 'invited',
+    requested: 'requested',
+    active: 'active',
+    removed: 'removed'
+  }, _default: 'active'
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,6 @@
+class Role < ApplicationRecord
+  has_many :user_roles, dependent: :destroy
+  has_many :users, through: :user_roles
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,0 +1,8 @@
+class Team < ApplicationRecord
+  belongs_to :owner, class_name: 'User', optional: true
+
+  has_many :team_users, dependent: :destroy
+  has_many :users, through: :team_users
+
+  validates :name, presence: true
+end

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -1,0 +1,18 @@
+class TeamUser < ApplicationRecord
+  belongs_to :team
+  belongs_to :user
+
+  enum role: {
+    admin: 'admin',
+    member: 'member',
+    viewer: 'viewer'
+  }, _default: 'member'
+
+  enum status: {
+    invited: 'invited',
+    requested: 'requested',
+    accepted: 'accepted',
+    rejected: 'rejected',
+    pending: 'pending'
+  }, _default: 'pending'
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,12 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :tasks, foreign_key: :assigned_to_user
   has_many :items
+  has_many :team_users, dependent: :destroy
+  has_many :teams, through: :team_users
+  has_many :user_roles, dependent: :destroy
+  has_many :roles, through: :user_roles
+  has_many :project_users, dependent: :destroy
+  has_many :projects, through: :project_users
 
   validates :first_name, presence: true
   validates :last_name, presence: true

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,0 +1,4 @@
+class UserRole < ApplicationRecord
+  belongs_to :user
+  belongs_to :role
+end

--- a/db/migrate/20260901000000_create_teams.rb
+++ b/db/migrate/20260901000000_create_teams.rb
@@ -1,0 +1,11 @@
+class CreateTeams < ActiveRecord::Migration[7.1]
+  def change
+    create_table :teams do |t|
+      t.string :name, null: false
+      t.text :description
+      t.references :owner, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260901000500_create_team_users.rb
+++ b/db/migrate/20260901000500_create_team_users.rb
@@ -1,0 +1,15 @@
+class CreateTeamUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :team_users do |t|
+      t.references :team, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.string :role, null: false, default: "member"
+      t.string :status, null: false, default: "pending"
+
+      t.timestamps
+    end
+
+    add_index :team_users, [:team_id, :user_id], unique: true
+  end
+end

--- a/db/migrate/20260901001000_create_roles.rb
+++ b/db/migrate/20260901001000_create_roles.rb
@@ -1,0 +1,10 @@
+class CreateRoles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :roles do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+
+    add_index :roles, :name, unique: true
+  end
+end

--- a/db/migrate/20260901001500_create_user_roles.rb
+++ b/db/migrate/20260901001500_create_user_roles.rb
@@ -1,0 +1,11 @@
+class CreateUserRoles < ActiveRecord::Migration[7.1]
+  def change
+    create_table :user_roles do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :role, null: false, foreign_key: true
+      t.timestamps
+    end
+
+    add_index :user_roles, [:user_id, :role_id], unique: true
+  end
+end

--- a/db/migrate/20260901002000_create_projects.rb
+++ b/db/migrate/20260901002000_create_projects.rb
@@ -1,0 +1,10 @@
+class CreateProjects < ActiveRecord::Migration[7.1]
+  def change
+    create_table :projects do |t|
+      t.string :name, null: false
+      t.text :description
+      t.references :owner, foreign_key: { to_table: :users }
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260901002500_create_project_users.rb
+++ b/db/migrate/20260901002500_create_project_users.rb
@@ -1,0 +1,15 @@
+class CreateProjectUsers < ActiveRecord::Migration[7.1]
+  def change
+    create_table :project_users do |t|
+      t.references :project, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.string :role, null: false, default: "collaborator"
+      t.string :status, null: false, default: "active"
+
+      t.timestamps
+    end
+
+    add_index :project_users, [:project_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_08_02_000000) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_01_025000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,65 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_02_000000) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "projects", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.bigint "owner_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_projects_on_owner_id"
+  end
+
+  create_table "project_users", force: :cascade do |t|
+    t.bigint "project_id", null: false
+    t.bigint "user_id", null: false
+    t.string "role", default: "collaborator", null: false
+    t.string "status", default: "active", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id", "user_id"], name: "index_project_users_on_project_id_and_user_id", unique: true
+    t.index ["project_id"], name: "index_project_users_on_project_id"
+    t.index ["user_id"], name: "index_project_users_on_user_id"
+  end
+
+  create_table "roles", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_roles_on_name", unique: true
+  end
+
+  create_table "teams", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.bigint "owner_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_teams_on_owner_id"
+  end
+
+  create_table "team_users", force: :cascade do |t|
+    t.bigint "team_id", null: false
+    t.bigint "user_id", null: false
+    t.string "role", default: "member", null: false
+    t.string "status", default: "pending", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
+    t.index ["team_id"], name: "index_team_users_on_team_id"
+    t.index ["user_id"], name: "index_team_users_on_user_id"
+  end
+
+  create_table "user_roles", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "role_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id", "role_id"], name: "index_user_roles_on_user_id_and_role_id", unique: true
+    t.index ["role_id"], name: "index_user_roles_on_role_id"
+    t.index ["user_id"], name: "index_user_roles_on_user_id"
   end
 
   create_table "sprints", force: :cascade do |t|
@@ -160,4 +219,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_08_02_000000) do
   add_foreign_key "task_logs", "tasks"
   add_foreign_key "tasks", "developers"
   add_foreign_key "tasks", "sprints"
+  add_foreign_key "project_users", "projects"
+  add_foreign_key "project_users", "users"
+  add_foreign_key "projects", "users", column: "owner_id"
+  add_foreign_key "team_users", "teams"
+  add_foreign_key "team_users", "users"
+  add_foreign_key "teams", "users", column: "owner_id"
+  add_foreign_key "user_roles", "roles"
+  add_foreign_key "user_roles", "users"
 end


### PR DESCRIPTION
## Summary
- add teams, projects, roles tables and associated join tables
- implement corresponding models with associations
- extend `User` with team/project/role associations

## Testing
- `bundle exec rake -T` *(fails: Missing tool version)*

------
https://chatgpt.com/codex/tasks/task_e_6881f5840a9883228b8d4ee4e4613ddf