### PR TITLE
Implement role-based restrictions

### DIFF
--- a/app/controllers/api/admin_controller.rb
+++ b/app/controllers/api/admin_controller.rb
@@ -1,4 +1,5 @@
-class Api::AdminController < ApplicationController
+class Api::AdminController < Api::BaseController
+  before_action :authorize_owner!
   before_action :set_model, except: [:tables]
   
   def tables
@@ -88,5 +89,9 @@ class Api::AdminController < ApplicationController
 
   def record_params
     params.require(:record).permit(@model.column_names.map(&:to_sym))
+  end
+
+  def authorize_owner!
+    head :forbidden unless current_user&.owner?
   end
 end

--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -43,7 +43,11 @@ class Api::AuthController < Api::BaseController
     return render json: { error: "Account locked" }, status: :unauthorized if user.locked?
 
     set_jwt_cookie!(user)
-    render json: { message: "Login successful", user: user, exp: 15.minutes.from_now.to_i }
+    render json: {
+      message: "Login successful",
+      user: user.as_json(include: { roles: { only: [:name] } }),
+      exp: 15.minutes.from_now.to_i
+    }
   end
 
   def refresh
@@ -52,7 +56,10 @@ class Api::AuthController < Api::BaseController
 
     if payload && (user = User.find_by(id: payload["user_id"]))
       set_jwt_cookie!(user)
-      render json: { user: user, exp: 15.minutes.from_now.to_i }
+      render json: {
+        user: user.as_json(include: { roles: { only: [:name] } }),
+        exp: 15.minutes.from_now.to_i
+      }
     else
       render json: { error: "Unauthorized" }, status: :unauthorized
     end
@@ -66,7 +73,10 @@ class Api::AuthController < Api::BaseController
 
   def view_profile
     profile_picture_url = rails_blob_url(current_user.profile_picture, only_path: true) if current_user&.profile_picture&.attached?
-    render json: { user: current_user.as_json.merge(profile_picture: profile_picture_url) }
+    render json: {
+      user: current_user.as_json(include: { roles: { only: [:name] } })
+                      .merge(profile_picture: profile_picture_url)
+    }
   end
 
   def update_profile

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,5 +1,6 @@
 class Api::UsersController < Api::BaseController
   include Rails.application.routes.url_helpers
+  before_action :authorize_owner!
   before_action :set_user, only: [:update, :destroy, :update_profile]
 
   # GET /api/users.json
@@ -52,5 +53,9 @@ class Api::UsersController < Api::BaseController
       profile_picture: user.profile_picture.attached? ?
         rails_blob_url(user.profile_picture, only_path: true) : nil
     }
+  end
+
+  def authorize_owner!
+    head :forbidden unless current_user&.owner?
   end
 end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -48,8 +48,8 @@ const App = () => {
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
               <Route path="/knowledge" element={<PrivateRoute><MainLayout><KnowledgeDashboard /></MainLayout></PrivateRoute>} />
               <Route path="/sprint_dashboard" element={<PrivateRoute><MainLayout><SprintDashboard /></MainLayout></PrivateRoute>} />
-              <Route path="/users" element={<PrivateRoute><MainLayout><Users /></MainLayout></PrivateRoute>} />
-              <Route path="/admin" element={<PrivateRoute><MainLayout><Admin /></MainLayout></PrivateRoute>} />
+              <Route path="/users" element={<PrivateRoute ownerOnly><MainLayout><Users /></MainLayout></PrivateRoute>} />
+              <Route path="/admin" element={<PrivateRoute ownerOnly><MainLayout><Admin /></MainLayout></PrivateRoute>} />
               </Routes>
 
           {/* ✅ Footer */}

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -17,19 +17,33 @@ const Navbar = () => {
           <nav className="flex items-center gap-6">
             {user ? (
               <>
-                {["posts", "weather", "vault", "sprint_dashboard", "knowledge", "profile", "users", "admin", "contact"].map((route) => (
-                  <NavLink
-                    key={route}
-                    to={`/${route}`}
-                    className={({ isActive }) =>
-                      `relative pb-1 text-gray-700 font-medium hover:text-indigo-600 transition ${
-                        isActive ? "after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-indigo-500" : ""
-                      }`
-                    }
-                  >
-                    {route.charAt(0).toUpperCase() + route.slice(1).replace("_", " ")}
-                  </NavLink>
-                ))}
+                {[
+                  "posts",
+                  "weather",
+                  "vault",
+                  "sprint_dashboard",
+                  "knowledge",
+                  "profile",
+                  "contact",
+                  user.roles?.some((r) => r.name === "owner") && "users",
+                  user.roles?.some((r) => r.name === "owner") && "admin",
+                ]
+                  .filter(Boolean)
+                  .map((route) => (
+                    <NavLink
+                      key={route}
+                      to={`/${route}`}
+                      className={({ isActive }) =>
+                        `relative pb-1 text-gray-700 font-medium hover:text-indigo-600 transition ${
+                          isActive
+                            ? "after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-indigo-500"
+                            : ""
+                        }`
+                      }
+                    >
+                      {route.charAt(0).toUpperCase() + route.slice(1).replace("_", " ")}
+                    </NavLink>
+                  ))}
 
                 <button
                   onClick={handleLogout}

--- a/app/javascript/components/PrivateRoute.jsx
+++ b/app/javascript/components/PrivateRoute.jsx
@@ -3,13 +3,17 @@ import { useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
 import AuthPage from "../pages/AuthPage";
 
-const PrivateRoute = ({ children }) => {
-  const { isAuthenticated, initializing } = useContext(AuthContext);
+const PrivateRoute = ({ children, ownerOnly = false }) => {
+  const { isAuthenticated, initializing, user } = useContext(AuthContext);
   const location = useLocation();
   const mode = location.state?.mode || "login";
 
   if (initializing) return <div>Loading…</div>;
-  return isAuthenticated ? children : <AuthPage mode={mode} />;
+  if (!isAuthenticated) return <AuthPage mode={mode} />;
+  if (ownerOnly && !user?.roles?.some((r) => r.name === "owner")) {
+    return <div className="p-4">Unauthorized</div>;
+  }
+  return children;
 };
 
 export default PrivateRoute;

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,6 +1,8 @@
 class Role < ApplicationRecord
+  NAMES = %w[owner admin member].freeze
+
   has_many :user_roles, dependent: :destroy
   has_many :users, through: :user_roles
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: true, inclusion: { in: NAMES }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,9 +22,31 @@ class User < ApplicationRecord
 
   cattr_accessor :current_user
 
+  after_create :assign_default_role
+
+  def has_role?(name)
+    roles.exists?(name: name.to_s)
+  end
+
+  def owner?
+    has_role?(:owner)
+  end
+
+  def admin?
+    has_role?(:admin)
+  end
+
+  def member?
+    has_role?(:member)
+  end
+
   private
 
   def after_confirmation
     update_column(:status, "active")
+  end
+
+  def assign_default_role
+    roles << Role.find_by(name: 'member') if roles.empty?
   end
 end

--- a/db/migrate/20260901003000_add_default_roles.rb
+++ b/db/migrate/20260901003000_add_default_roles.rb
@@ -1,0 +1,11 @@
+class AddDefaultRoles < ActiveRecord::Migration[7.1]
+  def up
+    %w[owner admin member].each do |name|
+      Role.find_or_create_by!(name: name)
+    end
+  end
+
+  def down
+    Role.where(name: %w[owner admin member]).delete_all
+  end
+end


### PR DESCRIPTION
## Summary
- define allowed role names and set default roles via migration
- expose role info via auth responses
- add role helper methods on `User` with default assignment
- restrict admin API and user management to owners only
- add `ownerOnly` protection in PrivateRoute
- hide admin & user links from non-owners and protect routes

## Testing
- `bin/rails test` *(fails: Missing tool version: core:ruby@3.3.0)*
- `bin/rails db:migrate` *(fails: Missing tool version: core:ruby@3.3.0)*


------
https://chatgpt.com/codex/tasks/task_e_6881f9d80db4832286bd216c3fd6a42a