### PR TITLE
Add teams page with CRUD

### DIFF
--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,0 +1,63 @@
+class Api::TeamsController < Api::BaseController
+  before_action :set_team, only: [:update, :destroy]
+  before_action :authorize_admin!, only: [:create, :update, :destroy]
+
+  def index
+    teams = Team.includes(team_users: :user).order(:name)
+    render json: teams.map { |t| serialize_team(t) }
+  end
+
+  def create
+    team = Team.new(team_params)
+    team.owner ||= current_user
+    if team.save
+      render json: serialize_team(team), status: :created
+    else
+      render json: { errors: team.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @team.update(team_params)
+      render json: serialize_team(@team)
+    else
+      render json: { errors: @team.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @team.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_team
+    @team = Team.find(params[:id])
+  end
+
+  def team_params
+    params.require(:team).permit(:name, :description)
+  end
+
+  def authorize_admin!
+    unless current_user&.owner? || current_user&.admin?
+      head :forbidden
+    end
+  end
+
+  def serialize_team(team)
+    {
+      id: team.id,
+      name: team.name,
+      description: team.description,
+      users: team.team_users.map do |tu|
+        {
+          id: tu.user_id,
+          name: [tu.user.first_name, tu.user.last_name].compact.join(' '),
+          role: tu.role
+        }
+      end
+    }
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -12,6 +12,7 @@ import Profile from "../components/Profile";
 import KnowledgeDashboard from "../pages/KnowledgeDashboard";
 import Admin from '../components/Admin/Admin';
 import Users from "../pages/Users";
+import Teams from "../pages/Teams";
 import Contact from "../pages/Contact";
 import Weather from "../pages/Weather";
 import Vault from "../pages/Vault";
@@ -47,6 +48,7 @@ const App = () => {
               <Route path="/vault" element={<PrivateRoute><MainLayout><Vault /></MainLayout></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
               <Route path="/knowledge" element={<PrivateRoute><MainLayout><KnowledgeDashboard /></MainLayout></PrivateRoute>} />
+              <Route path="/teams" element={<PrivateRoute><MainLayout><Teams /></MainLayout></PrivateRoute>} />
               <Route path="/sprint_dashboard" element={<PrivateRoute><MainLayout><SprintDashboard /></MainLayout></PrivateRoute>} />
               <Route path="/users" element={<PrivateRoute ownerOnly><MainLayout><Users /></MainLayout></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><MainLayout><Admin /></MainLayout></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -22,6 +22,7 @@ const Navbar = () => {
                   "weather",
                   "vault",
                   "sprint_dashboard",
+                  "teams",
                   "knowledge",
                   "profile",
                   "contact",

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -99,6 +99,12 @@ export const createItem = (d) => api.post('/items.json', { item: d });
 export const updateItem = (id, d) => api.patch(`/items/${id}.json`, { item: d });
 export const deleteItem = (id) => api.delete(`/items/${id}.json`);
 
+// TEAM ENDPOINTS
+export const fetchTeams = () => api.get('/teams.json');
+export const createTeam = (data) => api.post('/teams.json', { team: data });
+export const updateTeam = (id, data) => api.patch(`/teams/${id}.json`, { team: data });
+export const deleteTeam = (id) => api.delete(`/teams/${id}.json`);
+
 export const getTables = () => api.get('/admin/tables');
 export const getMeta = (table) => api.get(`/admin_meta/${table}`);
 export const getRecords = (table) => api.get(`/admin/${table}`);

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState, useContext } from "react";
+import { fetchTeams, createTeam, updateTeam, deleteTeam } from "../components/api";
+import { AuthContext } from "../context/AuthContext";
+
+const Teams = () => {
+  const { user } = useContext(AuthContext);
+  const canEdit = user?.roles?.some((r) => ["owner", "admin"].includes(r.name));
+
+  const [teams, setTeams] = useState([]);
+  const [search, setSearch] = useState("");
+  const [form, setForm] = useState({ name: "", description: "" });
+  const [editingId, setEditingId] = useState(null);
+
+  const loadTeams = async () => {
+    try {
+      const { data } = await fetchTeams();
+      setTeams(Array.isArray(data) ? data : []);
+    } catch {
+      setTeams([]);
+    }
+  };
+
+  useEffect(() => { loadTeams(); }, []);
+
+  const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    try {
+      if (editingId) {
+        await updateTeam(editingId, form);
+        setEditingId(null);
+      } else {
+        await createTeam(form);
+      }
+      setForm({ name: "", description: "" });
+      loadTeams();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleEdit = (team) => {
+    setEditingId(team.id);
+    setForm({ name: team.name, description: team.description || "" });
+  };
+
+  const handleDeleteTeam = async (id) => {
+    if (!window.confirm("Delete this team?")) return;
+    try {
+      await deleteTeam(id);
+      loadTeams();
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const filtered = teams.filter((t) => {
+    const text = `${t.name} ${t.users.map((u) => u.name).join(" ")}`.toLowerCase();
+    return text.includes(search.toLowerCase());
+  });
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <h1 className="text-3xl font-bold">Teams</h1>
+
+      <div className="flex items-center space-x-2">
+        <input
+          type="text"
+          placeholder="Search teams or members..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="border p-2 flex-grow rounded"
+        />
+      </div>
+
+      {canEdit && (
+        <form onSubmit={handleSubmit} className="space-y-2 bg-white p-4 border rounded">
+          <input
+            name="name"
+            value={form.name}
+            onChange={handleChange}
+            placeholder="Name"
+            required
+            className="border p-2 w-full rounded"
+          />
+          <textarea
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+            placeholder="Description"
+            className="border p-2 w-full rounded"
+          />
+          <button type="submit" className="px-3 py-1 bg-blue-600 text-white rounded">
+            {editingId ? "Update Team" : "Create Team"}
+          </button>
+          {editingId && (
+            <button type="button" onClick={() => { setEditingId(null); setForm({ name: "", description: "" }); }} className="ml-2 px-3 py-1 bg-gray-500 text-white rounded">
+              Cancel
+            </button>
+          )}
+        </form>
+      )}
+
+      <div className="space-y-4">
+        {filtered.map((team) => (
+          <div key={team.id} className="border rounded p-4 bg-white shadow">
+            <div className="flex justify-between items-start">
+              <div>
+                <h2 className="text-xl font-semibold">{team.name}</h2>
+                {team.description && <p className="text-sm text-gray-600">{team.description}</p>}
+              </div>
+              {canEdit && (
+                <div className="space-x-2">
+                  <button onClick={() => handleEdit(team)} className="px-2 py-1 bg-blue-500 text-white rounded">Edit</button>
+                  <button onClick={() => handleDeleteTeam(team.id)} className="px-2 py-1 bg-red-500 text-white rounded">Delete</button>
+                </div>
+              )}
+            </div>
+            <ul className="mt-2 text-sm list-disc pl-5">
+              {team.users.map((u) => (
+                <li key={u.id}>{u.name || "User"} - {u.role}</li>
+              ))}
+            </ul>
+          </div>
+        ))}
+        {filtered.length === 0 && <p>No teams found.</p>}
+      </div>
+    </div>
+  );
+};
+
+export default Teams;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
         post 'import_backlog'
       end
     end
+    resources :teams, only: [:index, :create, :update, :destroy]
     resources :task_logs, only: [:index, :create, :update, :destroy]
 
     resources :items, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- add API controller for teams
- expose teams routes
- support teams API calls in JS client
- implement Teams page for listing, filtering and editing
- link teams page in navbar and router

## Testing
- `bundle exec rails test` *(fails: Tool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882021d22488322a05926c00223098d