### PR TITLE
Add team selection and member management

### DIFF
--- a/app/controllers/api/team_users_controller.rb
+++ b/app/controllers/api/team_users_controller.rb
@@ -1,0 +1,50 @@
+class Api::TeamUsersController < Api::BaseController
+  before_action :authorize_admin!
+  before_action :set_team_user, only: [:update, :destroy]
+
+  def create
+    team_user = TeamUser.new(team_user_params)
+    if team_user.save
+      render json: serialize_team_user(team_user), status: :created
+    else
+      render json: { errors: team_user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @team_user.update(team_user_params)
+      render json: serialize_team_user(@team_user)
+    else
+      render json: { errors: @team_user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @team_user.destroy
+    head :no_content
+  end
+
+  private
+
+  def authorize_admin!
+    head :forbidden unless current_user&.admin?
+  end
+
+  def set_team_user
+    @team_user = TeamUser.find(params[:id])
+  end
+
+  def team_user_params
+    params.require(:team_user).permit(:team_id, :user_id, :role, :status)
+  end
+
+  def serialize_team_user(tu)
+    {
+      id: tu.id,
+      team_id: tu.team_id,
+      user_id: tu.user_id,
+      role: tu.role,
+      status: tu.status
+    }
+  end
+end

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -104,6 +104,9 @@ export const fetchTeams = () => api.get('/teams.json');
 export const createTeam = (data) => api.post('/teams.json', { team: data });
 export const updateTeam = (id, data) => api.patch(`/teams/${id}.json`, { team: data });
 export const deleteTeam = (id) => api.delete(`/teams/${id}.json`);
+export const addTeamUser = (data) => api.post('/team_users.json', { team_user: data });
+export const updateTeamUser = (id, data) => api.patch(`/team_users/${id}.json`, { team_user: data });
+export const deleteTeamUser = (id) => api.delete(`/team_users/${id}.json`);
 
 export const getTables = () => api.get('/admin/tables');
 export const getMeta = (table) => api.get(`/admin_meta/${table}`);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
       end
     end
     resources :teams, only: [:index, :create, :update, :destroy]
+    resources :team_users, only: [:create, :update, :destroy]
     resources :task_logs, only: [:index, :create, :update, :destroy]
 
     resources :items, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- restrict team CRUD routes to owner role
- expose team membership id via API and add TeamUsers controller for admins
- add JS API helpers for team member CRUD
- enhance Teams page to select current user's team and manage members
- register routes for new controller

## Testing
- `npm -v`
- `bin/rails routes | grep team_users` *(fails: Missing tool version: core:ruby@3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68820425833c8322be4301f93e8add18