### PR TITLE
Display profile pictures on team page

### DIFF
--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,4 +1,5 @@
 class Api::TeamsController < Api::BaseController
+  include Rails.application.routes.url_helpers
   before_action :set_team, only: [:update, :destroy]
   before_action :authorize_owner!, only: [:create, :update, :destroy]
 
@@ -54,6 +55,8 @@ class Api::TeamsController < Api::BaseController
           id: tu.user_id,
           team_user_id: tu.id,
           name: [tu.user.first_name, tu.user.last_name].compact.join(' '),
+          profile_picture: tu.user.profile_picture.attached? ?
+            rails_blob_url(tu.user.profile_picture, only_path: true) : nil,
           role: tu.role,
           status: tu.status
         }

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -5,8 +5,17 @@ import { AuthContext } from "../context/AuthContext";
 import { FiPlus, FiEdit, FiTrash2, FiUsers, FiSearch, FiX, FiUserPlus, FiChevronRight } from 'react-icons/fi';
 
 // A small utility component for user avatars
-const Avatar = ({ name }) => {
-  const initial = name ? name.charAt(0).toUpperCase() : '?';
+const Avatar = ({ name, src }) => {
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className="w-8 h-8 rounded-full mr-3 object-cover"
+      />
+    );
+  }
+  const initial = name ? name.charAt(0).toUpperCase() : "?";
   return (
     <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-600 flex items-center justify-center font-bold text-sm mr-3">
       {initial}
@@ -245,7 +254,7 @@ const Teams = () => {
                             {selectedTeam.users.map((member) => (
                                 <li key={member.team_user_id} className="flex justify-between items-center">
                                     <div className="flex items-center">
-                                        <Avatar name={member.name} />
+                                        <Avatar name={member.name} src={member.profile_picture} />
                                         <div>
                                             <p className="font-medium text-slate-800">{member.name || "Invited User"}</p>
                                             <p className="text-sm text-slate-500 capitalize">{member.role}</p>


### PR DESCRIPTION
## Summary
- show member profile pictures in teams view when available
- expose profile picture URLs in team API responses

## Testing
- `bin/rails test` *(fails: Tool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688209cb4ed883228bffca6afdb5bdae