### PR TITLE
Add profile pictures to Projects page

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -1,4 +1,5 @@
 class Api::ProjectsController < Api::BaseController
+  include Rails.application.routes.url_helpers
   before_action :set_project, only: [:update, :destroy]
   before_action :authorize_owner!, only: [:create, :update, :destroy]
 
@@ -54,6 +55,8 @@ class Api::ProjectsController < Api::BaseController
           id: pu.user_id,
           project_user_id: pu.id,
           name: [pu.user.first_name, pu.user.last_name].compact.join(' '),
+          profile_picture: pu.user.profile_picture.attached? ?
+            rails_blob_url(pu.user.profile_picture, only_path: true) : nil,
           role: pu.role,
           status: pu.status
         }

--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -5,8 +5,17 @@ import { AuthContext } from "../context/AuthContext";
 import { FiPlus, FiEdit, FiTrash2, FiUsers, FiSearch, FiX, FiUserPlus, FiChevronRight } from 'react-icons/fi';
 
 // A small utility component for user avatars
-const Avatar = ({ name }) => {
-  const initial = name ? name.charAt(0).toUpperCase() : '?';
+const Avatar = ({ name, src }) => {
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className="w-8 h-8 rounded-full mr-3 object-cover"
+      />
+    );
+  }
+  const initial = name ? name.charAt(0).toUpperCase() : "?";
   return (
     <div className="w-8 h-8 rounded-full bg-slate-200 text-slate-600 flex items-center justify-center font-bold text-sm mr-3">
       {initial}
@@ -262,7 +271,7 @@ const Projects = () => {
                             {selectedProject.users.map((member) => (
                                 <li key={member.project_user_id} className="flex justify-between items-center">
                                     <div className="flex items-center">
-                                        <Avatar name={member.name} />
+                                        <Avatar name={member.name} src={member.profile_picture} />
                                         <div>
                                             <p className="font-medium text-slate-800">{member.name || "Invited User"}</p>
                                             <p className="text-sm text-slate-500 capitalize">{member.role}</p>


### PR DESCRIPTION
## Summary
- show profile pictures in project membership lists
- return member profile_picture URLs from projects API

## Testing
- `node -v`
- `mise install` *(fails: No such file or directory, unable to install tools)*

------
https://chatgpt.com/codex/tasks/task_e_68820ccff3e88322996797c09724b55b