### PR TITLE
Add member details to team view

### DIFF
--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -55,6 +55,7 @@ class Api::TeamsController < Api::BaseController
           id: tu.user_id,
           team_user_id: tu.id,
           name: [tu.user.first_name, tu.user.last_name].compact.join(' '),
+          email: tu.user.email,
           profile_picture: tu.user.profile_picture.attached? ?
             rails_blob_url(tu.user.profile_picture, only_path: true) : nil,
           role: tu.role,

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -67,6 +67,13 @@ const Teams = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (teams.length > 0 && !selectedTeamId) {
+      const userTeam = teams.find((t) => t.users.some((u) => u.id === user?.id));
+      setSelectedTeamId(userTeam ? userTeam.id : teams[0].id);
+    }
+  }, [teams, selectedTeamId, user]);
+
   // Event Handlers
   const handleFormChange = (e) => setTeamForm({ ...teamForm, [e.target.name]: e.target.value });
   const handleRoleChange = (e) => setMemberForm({ ...memberForm, role: e.target.value });
@@ -265,6 +272,10 @@ const Teams = () => {
                                         <div>
                                             <p className="font-medium text-slate-800">{member.name || "Invited User"}</p>
                                             <p className="text-sm text-slate-500 capitalize">{member.role}</p>
+                                            {member.email && (
+                                              <p className="text-sm text-slate-500">Email: {member.email}</p>
+                                            )}
+                                            <p className="text-sm text-slate-500">Department: ROR</p>
                                         </div>
                                     </div>
                                     {canManageMembers && user.id !== member.id && (
@@ -294,6 +305,10 @@ const Teams = () => {
                             </form>
                         )}
                     </div>
+                </div>
+            ) : isLoading ? (
+                <div className="text-center h-full flex flex-col items-center justify-center mt-[-5rem]">
+                    <p className="text-slate-500">Loading...</p>
                 </div>
             ) : (
                 // Empty State for Main Content


### PR DESCRIPTION
## Summary
- include user email in team API response
- show member emails and a placeholder department in the Teams page
- auto-select the first team when the page loads
- display a loading state before teams are loaded

## Testing
- `bundle exec rake test` *(fails: missing Ruby)*

------
https://chatgpt.com/codex/tasks/task_e_68820deb7c5483229caf02e6dd67f8e6