### PR TITLE
Add BASE_URL env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ SMTP_PORT=587
 SMTP_DOMAIN=example.com
 SMTP_USERNAME=your_username
 SMTP_PASSWORD=your_password
-APP_HOST=localhost:5000
+BASE_URL=http://localhost:5000
 
 # Rails encryption key
 RAILS_MASTER_KEY=

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
     authentication: :plain,
     enable_starttls_auto: true
   }
-  config.action_mailer.default_url_options = { host: "http://localhost:5000" }
+  config.action_mailer.default_url_options = { host: ENV.fetch("BASE_URL", "http://localhost:5000") }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
@@ -85,6 +85,6 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
 
-  Rails.application.routes.default_url_options[:host] = "http://localhost:5000"
+  Rails.application.routes.default_url_options[:host] = ENV.fetch("BASE_URL", "http://localhost:5000")
 
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
     authentication: :plain,
     enable_starttls_auto: true
   }
-  config.action_mailer.default_url_options = { host: ENV.fetch("APP_HOST", "example.com") }
+  config.action_mailer.default_url_options = { host: ENV.fetch("BASE_URL", "example.com") }
   
 
   # Ignore bad email addresses and do not raise email delivery errors.
@@ -95,7 +95,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  Rails.application.routes.default_url_options[:host] = ENV.fetch("APP_HOST", "example.com")
+  Rails.application.routes.default_url_options[:host] = ENV.fetch("BASE_URL", "example.com")
 
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [


### PR DESCRIPTION
## Summary
- introduce `BASE_URL` environment variable in `.env.example`
- use `BASE_URL` in development and production configs

## Testing
- `bin/rails --version` *(fails: Missing tool version ruby@3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68821241c810832284675503027a7d1d