### PR TITLE
Add project-sprint hierarchy

### DIFF
--- a/app/controllers/api/sprints_controller.rb
+++ b/app/controllers/api/sprints_controller.rb
@@ -6,6 +6,7 @@ class Api::SprintsController < Api::BaseController
       render json: sprint
     else
       sprints = Sprint.order(created_at: :desc)
+      sprints = sprints.where(project_id: params[:project_id]) if params[:project_id].present?
       render json: sprints
     end
   end
@@ -74,6 +75,6 @@ class Api::SprintsController < Api::BaseController
 
   private
   def sprint_params
-    params.require(:sprint).permit(:name, :start_date, :end_date)
+    params.require(:sprint).permit(:name, :start_date, :end_date, :project_id)
   end
 end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -51,7 +51,7 @@ const App = () => {
               <Route path="/knowledge" element={<PrivateRoute><MainLayout><KnowledgeDashboard /></MainLayout></PrivateRoute>} />
               <Route path="/projects" element={<PrivateRoute><MainLayout><Projects /></MainLayout></PrivateRoute>} />
               <Route path="/teams" element={<PrivateRoute><MainLayout><Teams /></MainLayout></PrivateRoute>} />
-              <Route path="/sprint_dashboard" element={<PrivateRoute><MainLayout><SprintDashboard /></MainLayout></PrivateRoute>} />
+              <Route path="/projects/:projectId/dashboard" element={<PrivateRoute><MainLayout><SprintDashboard /></MainLayout></PrivateRoute>} />
               <Route path="/users" element={<PrivateRoute ownerOnly><MainLayout><Users /></MainLayout></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><MainLayout><Admin /></MainLayout></PrivateRoute>} />
               </Routes>

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -1,10 +1,20 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Link, NavLink } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
+import { fetchProjects } from "./api";
 import logo from "../images/logo.webp";
 
 const Navbar = () => {
   const { user, handleLogout } = useContext(AuthContext);
+  const [projects, setProjects] = useState([]);
+
+  useEffect(() => {
+    if (!user) { setProjects([]); return; }
+    fetchProjects().then(({ data }) => {
+      const list = Array.isArray(data) ? data.filter(p => p.users.some(u => u.id === user.id)) : [];
+      setProjects(list);
+    });
+  }, [user]);
 
   return (
     <header className="bg-white shadow-md fixed top-0 w-full z-50">
@@ -21,7 +31,6 @@ const Navbar = () => {
                   "posts",
                   "weather",
                   "vault",
-                  "sprint_dashboard",
                   "projects",
                   "teams",
                   "knowledge",
@@ -46,6 +55,22 @@ const Navbar = () => {
                       {route.charAt(0).toUpperCase() + route.slice(1).replace("_", " ")}
                     </NavLink>
                   ))}
+
+                {projects.map((p) => (
+                  <NavLink
+                    key={`project-${p.id}`}
+                    to={`/projects/${p.id}/dashboard`}
+                    className={({ isActive }) =>
+                      `relative pb-1 text-gray-700 font-medium hover:text-indigo-600 transition ${
+                        isActive
+                          ? "after:absolute after:bottom-0 after:left-0 after:w-full after:h-0.5 after:bg-indigo-500"
+                          : ""
+                      }`
+                    }
+                  >
+                    {p.name} Dashboard
+                  </NavLink>
+                ))}
 
                 <button
                   onClick={handleLogout}

--- a/app/javascript/components/Scheduler/SprintManager.jsx
+++ b/app/javascript/components/Scheduler/SprintManager.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { FiEdit2, FiTrash2, FiPlus, FiX, FiCalendar, FiChevronLeft, FiChevronRight, FiAlertTriangle } from 'react-icons/fi';
 import { motion, AnimatePresence } from 'framer-motion';
 
-export default function SprintManager({ onSprintChange }) {
+export default function SprintManager({ onSprintChange, projectId }) {
   const [sprints, setSprints] = useState([]);
   const [currentSprint, setCurrentSprint] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -12,9 +12,10 @@ export default function SprintManager({ onSprintChange }) {
   const [deleteCandidate, setDeleteCandidate] = useState(null);
   const timelineRef = useRef(null);
 
-  // Load all sprints when component mounts
+  // Load all sprints when component mounts or project changes
   useEffect(() => {
-    fetch('/api/sprints.json')
+    const query = projectId ? `?project_id=${projectId}` : '';
+    fetch(`/api/sprints.json${query}`)
       .then(res => res.json())
       .then(data => {
         const sortedData = data?.sort((a, b) => new Date(a.start_date) - new Date(b.start_date)) || [];
@@ -33,7 +34,7 @@ export default function SprintManager({ onSprintChange }) {
       })
       .catch(err => console.error("Error fetching sprints:", err))
       .finally(() => setLoading(false));
-  }, []);
+  }, [projectId]);
 
   // Scroll to active sprint on load or change
   useEffect(() => {
@@ -53,7 +54,7 @@ export default function SprintManager({ onSprintChange }) {
     setIsSubmitting(true);
     const method = formData.id ? 'PATCH' : 'POST';
     const url = formData.id ? `/api/sprints/${formData.id}.json` : '/api/sprints.json';
-    const payload = { sprint: { name: formData.name, start_date: formData.start_date, end_date: formData.end_date } };
+    const payload = { sprint: { name: formData.name, start_date: formData.start_date, end_date: formData.end_date, project_id: projectId } };
 
     fetch(url, {
       method,

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -46,8 +46,10 @@ api.interceptors.response.use(
 export const SchedulerAPI = {
   // Sprints
   getLastSprint: () => api.get("/sprints/last.json"),
-  getSprints: () => api.get("/sprints.json"),
-  createSprint: (data) => api.post("/sprints.json", { sprint: data }),
+  getSprints: (projectId) =>
+    api.get("/sprints.json", { params: projectId ? { project_id: projectId } : {} }),
+  createSprint: (projectId, data) =>
+    api.post("/sprints.json", { sprint: { ...data, project_id: projectId } }),
   updateSprint: (id, data) => api.put(`/sprints/${id}.json`, { sprint: data }),
 
   // Developers

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
 import { CalendarDaysIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import SprintOverview from './SprintOverview';
 import Scheduler from '../components/Scheduler/Scheduler';
@@ -24,6 +25,7 @@ const formatDateRange = (start, end) => {
 };
 
 export default function SprintDashboard() {
+  const { projectId } = useParams();
   const [activeTab, setActiveTab] = useState('overview');
   const [sprintId, setSprintId] = useState(null);
   const [sprint, setSprint] = useState(null);
@@ -32,7 +34,8 @@ export default function SprintDashboard() {
 
   // Load all sprints on mount and select the current one
   useEffect(() => {
-    fetch('/api/sprints.json')
+    const query = projectId ? `?project_id=${projectId}` : '';
+    fetch(`/api/sprints.json${query}`)
       .then(res => res.json())
       .then(data => {
         setSprints(data || []);
@@ -49,7 +52,7 @@ export default function SprintDashboard() {
           }
         }
       });
-  }, []);
+  }, [projectId]);
 
   const isCurrentSprint = (s) => {
     if (!s) return false;
@@ -155,7 +158,7 @@ export default function SprintDashboard() {
           </div>
         </div>
         <div className={`mt-4 border-t border-gray-200 pt-4 ${isHeaderExpanded ? '' : 'hidden'}`}>
-          <SprintManager onSprintChange={handleSprintChange} />
+          <SprintManager onSprintChange={handleSprintChange} projectId={projectId} />
         </div>
       </header>
       {activeTab === 'overview' && (

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -3,6 +3,7 @@ class Project < ApplicationRecord
 
   has_many :project_users, dependent: :destroy
   has_many :users, through: :project_users
+  has_many :sprints, dependent: :destroy
 
   validates :name, presence: true
 end

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -1,3 +1,4 @@
 class Sprint < ApplicationRecord
   include UserStampable
+  belongs_to :project
 end

--- a/db/migrate/20260901004000_add_project_ref_to_sprints.rb
+++ b/db/migrate/20260901004000_add_project_ref_to_sprints.rb
@@ -1,0 +1,6 @@
+class AddProjectRefToSprints < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :sprints, :project_id, :integer
+    add_reference :sprints, :project, null: false, foreign_key: true
+  end
+end


### PR DESCRIPTION
## Summary
- relate projects to sprints
- filter sprints by project
- expose project dashboards in React navbar
- add project dashboard route
- adjust frontend sprint manager to include project id
- migration to add project reference on sprints

## Testing
- `bin/rails db:migrate` *(fails: Missing tool version ruby@3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68821caf54608322bff0ea9fde840e88