### PR TITLE
Restrict project board access to members

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
 import { AuthProvider } from "../context/AuthContext";
 import PrivateRoute from "../components/PrivateRoute";
+import ProjectMemberRoute from "../components/ProjectMemberRoute";
 
 import Navbar from "../components/Navbar";
 import Footer from "./Footer";
@@ -51,7 +52,7 @@ const App = () => {
               <Route path="/knowledge" element={<PrivateRoute><MainLayout><KnowledgeDashboard /></MainLayout></PrivateRoute>} />
               <Route path="/projects" element={<PrivateRoute><MainLayout><Projects /></MainLayout></PrivateRoute>} />
               <Route path="/teams" element={<PrivateRoute><MainLayout><Teams /></MainLayout></PrivateRoute>} />
-              <Route path="/projects/:projectId/dashboard" element={<PrivateRoute><MainLayout><SprintDashboard /></MainLayout></PrivateRoute>} />
+              <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><MainLayout><SprintDashboard /></MainLayout></ProjectMemberRoute>} />
               <Route path="/users" element={<PrivateRoute ownerOnly><MainLayout><Users /></MainLayout></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><MainLayout><Admin /></MainLayout></PrivateRoute>} />
               </Routes>

--- a/app/javascript/components/ProjectMemberRoute.jsx
+++ b/app/javascript/components/ProjectMemberRoute.jsx
@@ -1,0 +1,36 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useParams, useLocation } from "react-router-dom";
+import { AuthContext } from "../context/AuthContext";
+import { fetchProjects } from "./api";
+import AuthPage from "../pages/AuthPage";
+
+const ProjectMemberRoute = ({ children }) => {
+  const { projectId } = useParams();
+  const location = useLocation();
+  const mode = location.state?.mode || "login";
+  const { isAuthenticated, initializing, user } = useContext(AuthContext);
+  const [isMember, setIsMember] = useState(null);
+
+  useEffect(() => {
+    if (!isAuthenticated || !projectId) return;
+    let mounted = true;
+    fetchProjects()
+      .then(({ data }) => {
+        const projects = Array.isArray(data) ? data : [];
+        const project = projects.find((p) => p.id === Number(projectId));
+        const member = project?.users?.some((u) => u.id === user?.id);
+        if (mounted) setIsMember(!!member);
+      })
+      .catch(() => mounted && setIsMember(false));
+    return () => {
+      mounted = false;
+    };
+  }, [projectId, isAuthenticated, user]);
+
+  if (initializing || isMember === null) return <div>Loading…</div>;
+  if (!isAuthenticated) return <AuthPage mode={mode} />;
+  if (!isMember) return <div className="p-4">Unauthorized</div>;
+  return children;
+};
+
+export default ProjectMemberRoute;


### PR DESCRIPTION
## Summary
- add `ProjectMemberRoute` to verify access to project dashboards
- use the new route for `/projects/:projectId/dashboard`

## Testing
- `npm run build` *(fails: `esbuild` not found)*
- `bundle exec rake test` *(fails: missing Ruby toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_688224b060708322a28d5f8e66186ca8