### PR TITLE
Fix vault layout and add collapsible sections

### DIFF
--- a/app/javascript/pages/Vault.jsx
+++ b/app/javascript/pages/Vault.jsx
@@ -27,6 +27,10 @@ const Vault = () => {
   const [editContent, setEditContent] = useState("");
   const [openMenuId, setOpenMenuId] = useState(null);
   const [copiedKey, setCopiedKey] = useState(null);
+  const [showCredentials, setShowCredentials] = useState(false);
+  const [showCommands, setShowCommands] = useState(false);
+  const [showTokens, setShowTokens] = useState(false);
+  const [showOthers, setShowOthers] = useState(false);
 
   useEffect(() => {
     loadItems();
@@ -179,7 +183,7 @@ const Vault = () => {
             </div>
           </div>
           <div className="flex items-center mb-1">
-            <span className="flex-grow">Username: {item.title}</span>
+            <span className="flex-grow break-all">Username: {item.title}</span>
             <button
               className="ml-2 p-1 text-gray-500 hover:text-blue-600 rounded-full hover:bg-gray-100 transition-colors relative"
               onClick={() => copyText(`title-${item.id}`, item.title)}
@@ -192,7 +196,7 @@ const Vault = () => {
             </button>
           </div>
           <div className="flex items-center">
-            <span className="flex-grow">Password: <span className="tracking-widest">••••••••</span></span>
+            <span className="flex-grow break-all">Password: <span className="tracking-widest">••••••••</span></span>
             <button
               className="ml-2 p-1 text-gray-500 hover:text-blue-600 rounded-full hover:bg-gray-100 transition-colors relative"
               onClick={() => copyText(`content-${item.id}`, item.content)}
@@ -324,7 +328,7 @@ const Vault = () => {
             </div>
           </div>
           <div className="flex items-start">
-            <div className="flex-grow break-words">{item.content.length > 100 ? item.content.slice(0, 100) + "..." : item.content}</div>
+            <div className="flex-grow break-words whitespace-pre-wrap">{item.content.length > 100 ? item.content.slice(0, 100) + "..." : item.content}</div>
             <button
               className="ml-2 p-1 text-gray-500 hover:text-blue-600 rounded-full hover:bg-gray-100 transition-colors relative"
               onClick={() => copyText(`content-${item.id}`, item.content)}
@@ -361,24 +365,38 @@ const Vault = () => {
           <div className="rounded-lg overflow-hidden shadow">
             <div className="bg-blue-500 text-white px-3 py-2 flex justify-between items-center">
               <span>Credentials</span>
-              <button onClick={() => openModal('Credential')} className="font-bold">+</button>
+              <div className="space-x-2">
+                <button onClick={() => setShowCredentials((v) => !v)} className="text-sm underline">
+                  {showCredentials ? 'Hide' : 'Expand'}
+                </button>
+                <button onClick={() => openModal('Credential')} className="font-bold">+</button>
+              </div>
             </div>
-            <div className="p-4 space-y-4">
-              {credentials.map(renderCredential)}
-              {credentials.length === 0 && <p className="italic text-sm">No credentials</p>}
-            </div>
+            {showCredentials && (
+              <div className="p-4 space-y-4">
+                {credentials.map(renderCredential)}
+                {credentials.length === 0 && <p className="italic text-sm">No credentials</p>}
+              </div>
+            )}
           </div>
         </div>
         <div className="md:col-span-2">
           <div className="rounded-lg overflow-hidden shadow">
             <div className="bg-green-500 text-white px-3 py-2 flex justify-between items-center">
               <span>Commands</span>
-              <button onClick={() => openModal('Command')} className="font-bold">+</button>
+              <div className="space-x-2">
+                <button onClick={() => setShowCommands((v) => !v)} className="text-sm underline">
+                  {showCommands ? 'Hide' : 'Expand'}
+                </button>
+                <button onClick={() => openModal('Command')} className="font-bold">+</button>
+              </div>
             </div>
-            <div className="p-4 space-y-4">
-              {commands.map(renderCommand)}
-              {commands.length === 0 && <p className="italic text-sm">No commands</p>}
-            </div>
+            {showCommands && (
+              <div className="p-4 space-y-4">
+                {commands.map(renderCommand)}
+                {commands.length === 0 && <p className="italic text-sm">No commands</p>}
+              </div>
+            )}
           </div>
         </div>
       </div>
@@ -386,23 +404,37 @@ const Vault = () => {
       <div className="rounded-lg overflow-hidden shadow">
         <div className="bg-orange-500 text-white px-3 py-2 flex justify-between items-center">
           <span>Tokens</span>
-          <button onClick={() => openModal('Token')} className="font-bold">+</button>
+          <div className="space-x-2">
+            <button onClick={() => setShowTokens((v) => !v)} className="text-sm underline">
+              {showTokens ? 'Hide' : 'Expand'}
+            </button>
+            <button onClick={() => openModal('Token')} className="font-bold">+</button>
+          </div>
         </div>
-        <div className="p-4 space-y-4">
-          {tokens.map(renderToken)}
-          {tokens.length === 0 && <p className="italic text-sm">No tokens</p>}
-        </div>
+        {showTokens && (
+          <div className="p-4 space-y-4">
+            {tokens.map(renderToken)}
+            {tokens.length === 0 && <p className="italic text-sm">No tokens</p>}
+          </div>
+        )}
       </div>
 
       {others.length > 0 && (
         <div className="rounded-lg overflow-hidden shadow">
           <div className="bg-purple-500 text-white px-3 py-2 flex justify-between items-center">
             <span>Other Items</span>
-            <button onClick={() => openModal('')} className="font-bold">+</button>
+            <div className="space-x-2">
+              <button onClick={() => setShowOthers((v) => !v)} className="text-sm underline">
+                {showOthers ? 'Hide' : 'Expand'}
+              </button>
+              <button onClick={() => openModal('')} className="font-bold">+</button>
+            </div>
           </div>
-          <div className="p-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {others.map(renderOther)}
-          </div>
+          {showOthers && (
+            <div className="p-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {others.map(renderOther)}
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- fix text overflow in Vault credentials
- show collapsible sections for credentials, commands, tokens, and others

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6882279746f883229c99dae2b2813b2a