### PR TITLE
Fix sprint dashboard when changing projects

### DIFF
--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -43,8 +43,12 @@ export default function SprintDashboard() {
     });
   }, [projectId]);
 
-  // Load all sprints on mount and select the current one
+  // Load sprints when project changes and select the active one
   useEffect(() => {
+    setSprint(null);
+    setSprintId(null);
+    setSprints([]);
+
     const query = projectId ? `?project_id=${projectId}` : '';
     fetch(`/api/sprints.json${query}`)
       .then(res => res.json())
@@ -57,9 +61,10 @@ export default function SprintDashboard() {
             const end = new Date(s.end_date);
             return today >= start && today <= end;
           });
-          if (current) {
-            setSprint(current);
-            setSprintId(current.id);
+          const selected = current || data[0];
+          if (selected) {
+            setSprint(selected);
+            setSprintId(selected.id);
           }
         }
       });


### PR DESCRIPTION
## Summary
- clear sprint state when projectId changes
- select active or first sprint from newly loaded project

## Testing
- `grep -n "does not include" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_68822a0d3de88322b8f93f58d5221f2a