### PR TITLE
Fix last sprint query per project

### DIFF
--- a/app/controllers/api/sprints_controller.rb
+++ b/app/controllers/api/sprints_controller.rb
@@ -12,7 +12,12 @@ class Api::SprintsController < Api::BaseController
   end
 
   def last
-    sprint = Sprint.where("start_date <= ? AND end_date >= ?", Date.today, Date.today).first || Sprint.order(start_date: :desc).first
+    sprints = Sprint.all
+    sprints = sprints.where(project_id: params[:project_id]) if params[:project_id].present?
+
+    sprint = sprints.where("start_date <= ? AND end_date >= ?", Date.today, Date.today).first ||
+             sprints.order(start_date: :desc).first
+
     render json: sprint
   end
 

--- a/app/javascript/components/Scheduler/Scheduler.jsx
+++ b/app/javascript/components/Scheduler/Scheduler.jsx
@@ -217,7 +217,7 @@ function TaskCell({ date, devId, tasksInCell, setEditingTask, handleTaskUpdate, 
   );
 }
 
-function Scheduler({ sprintId }) {
+function Scheduler({ sprintId, projectId }) {
   const [sprint, setSprint] = useState(null);
   const [developers, setDevelopers] = useState([]);
   const [tasks, setTasks] = useState([]); // will hold task logs
@@ -242,7 +242,7 @@ function Scheduler({ sprintId }) {
 
   useEffect(() => {
     if (sprintId) {
-      SchedulerAPI.getSprints()
+      SchedulerAPI.getSprints(projectId)
         .then(res => {
           const found = res.data.find(s => s.id === sprintId);
           if (found) setSprint(found);
@@ -250,14 +250,14 @@ function Scheduler({ sprintId }) {
         .catch(() => setError("Could not load sprint"))
         .finally(() => setLoading(l => ({ ...l, sprint: false })));
     } else {
-      SchedulerAPI.getLastSprint()
+      SchedulerAPI.getLastSprint(projectId)
         .then(res => { setSprint(res.data); setLoading(l => ({ ...l, sprint: false })); })
         .catch(() => {
           setError("Could not load sprint");
           setLoading(l => ({ ...l, sprint: false }));
         });
     }
-  }, [sprintId]);
+  }, [sprintId, projectId]);
 
   useEffect(() => {
     const params = sprintId ? { sprint_id: sprintId } : {};

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -45,7 +45,8 @@ api.interceptors.response.use(
 // SCHEDULER ENDPOINTS
 export const SchedulerAPI = {
   // Sprints
-  getLastSprint: () => api.get("/sprints/last.json"),
+  getLastSprint: (projectId) =>
+    api.get("/sprints/last.json", { params: projectId ? { project_id: projectId } : {} }),
   getSprints: (projectId) =>
     api.get("/sprints.json", { params: projectId ? { project_id: projectId } : {} }),
   createSprint: (projectId, data) =>

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -189,7 +189,7 @@ export default function SprintDashboard() {
         <SprintOverview projectId={projectId} sprintId={sprintId} onSprintChange={handleSprintChange} />
       )}
       {activeTab === 'scheduler' && (
-        sprintId ? <Scheduler sprintId={sprintId} /> : <p className="p-4">No sprint selected</p>
+        sprintId ? <Scheduler sprintId={sprintId} projectId={projectId} /> : <p className="p-4">No sprint selected</p>
       )}
       {activeTab === 'todo' && (
         sprintId ? <TodoBoard sprintId={sprintId} onSprintChange={handleSprintChange} /> : <p className="p-4">No sprint selected</p>


### PR DESCRIPTION
## Summary
- scope the `last` sprint lookup to a specific project
- allow API client to request last sprint by `project_id`
- support `projectId` in Scheduler component
- pass `projectId` from SprintDashboard to Scheduler

## Testing
- `git status --porcelain`

------
https://chatgpt.com/codex/tasks/task_e_6882333d0f888322b4a372f273b3e937