### PR TITLE
Add project schedule and sheet fields

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -38,7 +38,14 @@ class Api::ProjectsController < Api::BaseController
   end
 
   def project_params
-    params.require(:project).permit(:name, :description)
+    params.require(:project).permit(
+      :name,
+      :description,
+      :start_date,
+      :end_date,
+      :sheet_integration_enabled,
+      :sheet_id
+    )
   end
 
   def authorize_owner!
@@ -50,6 +57,11 @@ class Api::ProjectsController < Api::BaseController
       id: project.id,
       name: project.name,
       description: project.description,
+      start_date: project.start_date,
+      end_date: project.end_date,
+      status: project.status,
+      sheet_integration_enabled: project.sheet_integration_enabled,
+      sheet_id: project.sheet_id,
       users: project.project_users.map do |pu|
         {
           id: pu.user_id,

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,5 +5,27 @@ class Project < ApplicationRecord
   has_many :users, through: :project_users
   has_many :sprints, dependent: :destroy
 
+  enum status: {
+    upcoming: 'upcoming',
+    running: 'running',
+    completed: 'completed'
+  }, _default: 'running'
+
   validates :name, presence: true
+
+  before_save :set_status_from_dates
+
+  private
+
+  def set_status_from_dates
+    return self.status = 'running' if start_date.blank?
+
+    if end_date.present? && Date.current > end_date
+      self.status = 'completed'
+    elsif Date.current < start_date
+      self.status = 'upcoming'
+    else
+      self.status = 'running'
+    end
+  end
 end

--- a/db/migrate/20260901005000_add_fields_to_projects.rb
+++ b/db/migrate/20260901005000_add_fields_to_projects.rb
@@ -1,0 +1,11 @@
+class AddFieldsToProjects < ActiveRecord::Migration[7.1]
+  def change
+    change_table :projects, bulk: true do |t|
+      t.date :start_date
+      t.date :end_date
+      t.string :status, default: 'running'
+      t.boolean :sheet_integration_enabled, default: false
+      t.string :sheet_id
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add migration for project start/end dates, status, and sheet settings
- compute project status based on the dates
- expose new project fields via API

## Testing
- `bin/rails db:migrate --dry-run` *(fails: `ruby` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883878d872c832292ea4eb1ef966ebe