### PR TITLE
Add manager and leader roles

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -1,7 +1,7 @@
 class Api::ProjectsController < Api::BaseController
   include Rails.application.routes.url_helpers
   before_action :set_project, only: [:update, :destroy]
-  before_action :authorize_owner!, only: [:create, :update, :destroy]
+  before_action :authorize_manager!, only: [:create, :update, :destroy]
 
   def index
     projects = Project.includes(project_users: :user).order(:name)
@@ -48,8 +48,9 @@ class Api::ProjectsController < Api::BaseController
     )
   end
 
-  def authorize_owner!
-    head :forbidden unless current_user&.owner?
+  def authorize_manager!
+    allowed = current_user&.owner? || current_user&.project_manager?
+    head :forbidden unless allowed
   end
 
   def serialize_project(project)

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,7 +1,7 @@
 class Api::TeamsController < Api::BaseController
   include Rails.application.routes.url_helpers
   before_action :set_team, only: [:update, :destroy]
-  before_action :authorize_owner!, only: [:create, :update, :destroy]
+  before_action :authorize_leader!, only: [:create, :update, :destroy]
 
   def index
     teams = Team.includes(team_users: :user).order(:name)
@@ -41,8 +41,9 @@ class Api::TeamsController < Api::BaseController
     params.require(:team).permit(:name, :description)
   end
 
-  def authorize_owner!
-    head :forbidden unless current_user&.owner?
+  def authorize_leader!
+    allowed = current_user&.owner? || current_user&.team_leader?
+    head :forbidden unless allowed
   end
 
   def serialize_team(team)

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -50,8 +50,8 @@ const App = () => {
               <Route path="/vault" element={<PrivateRoute><MainLayout><Vault /></MainLayout></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><MainLayout><Profile /></MainLayout></PrivateRoute>} />
               <Route path="/knowledge" element={<PrivateRoute><MainLayout><KnowledgeDashboard /></MainLayout></PrivateRoute>} />
-              <Route path="/projects" element={<PrivateRoute><MainLayout><Projects /></MainLayout></PrivateRoute>} />
-              <Route path="/teams" element={<PrivateRoute><MainLayout><Teams /></MainLayout></PrivateRoute>} />
+              <Route path="/projects" element={<PrivateRoute allowedRoles={["owner","project_manager"]}><MainLayout><Projects /></MainLayout></PrivateRoute>} />
+              <Route path="/teams" element={<PrivateRoute allowedRoles={["owner","team_leader"]}><MainLayout><Teams /></MainLayout></PrivateRoute>} />
               <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><MainLayout><SprintDashboard /></MainLayout></ProjectMemberRoute>} />
               <Route path="/users" element={<PrivateRoute ownerOnly><MainLayout><Users /></MainLayout></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><MainLayout><Admin /></MainLayout></PrivateRoute>} />

--- a/app/javascript/components/PrivateRoute.jsx
+++ b/app/javascript/components/PrivateRoute.jsx
@@ -3,7 +3,7 @@ import { useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
 import AuthPage from "../pages/AuthPage";
 
-const PrivateRoute = ({ children, ownerOnly = false }) => {
+const PrivateRoute = ({ children, ownerOnly = false, allowedRoles = [] }) => {
   const { isAuthenticated, initializing, user } = useContext(AuthContext);
   const location = useLocation();
   const mode = location.state?.mode || "login";
@@ -11,6 +11,9 @@ const PrivateRoute = ({ children, ownerOnly = false }) => {
   if (initializing) return <div>Loading…</div>;
   if (!isAuthenticated) return <AuthPage mode={mode} />;
   if (ownerOnly && !user?.roles?.some((r) => r.name === "owner")) {
+    return <div className="p-4">Unauthorized</div>;
+  }
+  if (allowedRoles.length > 0 && !user?.roles?.some((r) => allowedRoles.includes(r.name))) {
     return <div className="p-4">Unauthorized</div>;
   }
   return children;

--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -26,7 +26,7 @@ const Avatar = ({ name, src }) => {
 
 const Projects = () => {
   const { user } = useContext(AuthContext);
-  const canEdit = user?.roles?.some((r) => r.name === "owner");
+  const canEdit = user?.roles?.some((r) => ["owner", "project_manager"].includes(r.name));
   const canManageMembers = user?.roles?.some((r) => r.name === "admin");
 
   // State Management

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -26,7 +26,7 @@ const Avatar = ({ name, src }) => {
 
 const Teams = () => {
   const { user } = useContext(AuthContext);
-  const canEdit = user?.roles?.some((r) => r.name === "owner");
+  const canEdit = user?.roles?.some((r) => ["owner", "team_leader"].includes(r.name));
   const canManageMembers = user?.roles?.some((r) => r.name === "admin");
 
   // State Management

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,5 +1,5 @@
 class Role < ApplicationRecord
-  NAMES = %w[owner admin member].freeze
+  NAMES = %w[owner admin member project_manager team_leader].freeze
 
   has_many :user_roles, dependent: :destroy
   has_many :users, through: :user_roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,14 @@ class User < ApplicationRecord
     has_role?(:member)
   end
 
+  def project_manager?
+    has_role?(:project_manager)
+  end
+
+  def team_leader?
+    has_role?(:team_leader)
+  end
+
   private
 
   def after_confirmation

--- a/db/migrate/20260901006000_add_manager_roles.rb
+++ b/db/migrate/20260901006000_add_manager_roles.rb
@@ -1,0 +1,11 @@
+class AddManagerRoles < ActiveRecord::Migration[7.1]
+  def up
+    %w[project_manager team_leader].each do |name|
+      Role.find_or_create_by!(name: name)
+    end
+  end
+
+  def down
+    Role.where(name: %w[project_manager team_leader]).delete_all
+  end
+end


### PR DESCRIPTION
## Summary
- add project_manager and team_leader roles to Role model
- create migration to seed new roles
- expose helper methods in User
- permit project managers to manage projects and team leaders to manage teams
- add role-based guards in PrivateRoute
- restrict /projects and /teams routes to new roles
- update project and team pages to allow editing for new roles

## Testing
- `bundle exec rails about` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68838fbbdecc8322bf488d69e9f3b3b0