### PR TITLE
Dynamic role checkboxes for users

### DIFF
--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -1,0 +1,13 @@
+class Api::RolesController < Api::BaseController
+  before_action :authorize_owner!
+
+  def index
+    render json: Role.order(:name).pluck(:name)
+  end
+
+  private
+
+  def authorize_owner!
+    head :forbidden unless current_user&.owner?
+  end
+end

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -110,6 +110,7 @@ export const deleteTeam = (id) => api.delete(`/teams/${id}.json`);
 export const addTeamUser = (data) => api.post('/team_users.json', { team_user: data });
 export const updateTeamUser = (id, data) => api.patch(`/team_users/${id}.json`, { team_user: data });
 export const deleteTeamUser = (id) => api.delete(`/team_users/${id}.json`);
+export const fetchRoles = () => api.get('/roles.json');
 
 // PROJECT ENDPOINTS
 export const fetchProjects = () => api.get('/projects.json');

--- a/app/javascript/pages/Users.jsx
+++ b/app/javascript/pages/Users.jsx
@@ -5,9 +5,8 @@ import {
   updateUser,
   fetchTeams,
   fetchProjects,
+  fetchRoles,
 } from "../components/api";
-
-const ROLE_OPTIONS = ["owner", "admin", "member"];
 
 const Users = () => {
   const [users, setUsers] = useState([]);
@@ -24,6 +23,7 @@ const Users = () => {
   const [userToDelete, setUserToDelete] = useState(null);
   const [teams, setTeams] = useState([]);
   const [projects, setProjects] = useState([]);
+  const [roles, setRoles] = useState([]);
 
   const fetchUsers = async () => {
     try {
@@ -55,10 +55,21 @@ const Users = () => {
     }
   };
 
+  const fetchRolesData = async () => {
+    try {
+      const { data } = await fetchRoles();
+      setRoles(Array.isArray(data) ? data : []);
+    } catch (error) {
+      console.error("Error fetching roles:", error);
+      setRoles([]);
+    }
+  };
+
   useEffect(() => {
     fetchUsers();
     fetchTeamsData();
     fetchProjectsData();
+    fetchRolesData();
   }, []);
 
   const handleEdit = (user) => {
@@ -165,7 +176,7 @@ const Users = () => {
                   <input type="date" name="date_of_birth" value={formData.date_of_birth || ''} onChange={handleChange} className={`${inputBaseStyle} text-gray-500`} />
                   <input type="file" name="profile_picture" onChange={handleChange} className="text-xs text-gray-500 file:mr-2 file:py-1 file:px-2 file:rounded-full file:border-0 file:text-xs file:font-semibold file:bg-blue-200 file:text-blue-700 hover:file:bg-blue-300" accept="image/*" />
                   <div className="flex justify-center space-x-4">
-                    {ROLE_OPTIONS.map((role) => (
+                    {roles.map((role) => (
                       <label key={role} className="flex items-center space-x-1">
                         <input
                           type="checkbox"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,6 +79,8 @@ Rails.application.routes.draw do
 
     resources :items, only: [:index, :create, :update, :destroy]
 
+    resources :roles, only: [:index]
+
 
     resources :contacts, only: [:create]
 


### PR DESCRIPTION
## Summary
- expose new API endpoint to fetch available roles
- add role route
- allow frontend to fetch roles via API
- render role checkboxes dynamically in user edit form

## Testing
- `bin/rails test` *(fails: `ruby` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839612556083229ffa090dc71f5bef