### PR TITLE
Format role names in user edit form

### DIFF
--- a/app/javascript/pages/Users.jsx
+++ b/app/javascript/pages/Users.jsx
@@ -9,6 +9,11 @@ import {
 } from "../components/api";
 
 const Users = () => {
+  const formatRole = (role) =>
+    role
+      .split("_")
+      .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ");
   const [users, setUsers] = useState([]);
   const [search, setSearch] = useState("");
   const [editingId, setEditingId] = useState(null);
@@ -183,7 +188,7 @@ const Users = () => {
                           checked={formData.roles.includes(role)}
                           onChange={() => handleRoleChange(role)}
                         />
-                        <span className="text-sm capitalize">{role}</span>
+                        <span className="text-sm">{formatRole(role)}</span>
                       </label>
                     ))}
                   </div>
@@ -214,7 +219,7 @@ const Users = () => {
                     </p>
                   )}
                   {user.roles && (
-                    <p className="text-gray-500 text-xs">Roles: {user.roles.join(', ')}</p>
+                    <p className="text-gray-500 text-xs">Roles: {user.roles.map(formatRole).join(', ')}</p>
                   )}
                   {userTeams.length > 0 && (
                     <p className="text-gray-500 text-xs">Teams: {userTeams.join(', ')}</p>


### PR DESCRIPTION
## Summary
- format roles like `project_manager` as `Project Manager`
- show formatted roles in user cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688399e9d580832294a1c0706ea1f25c