### PR TITLE
Fix projects page initial view

### DIFF
--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -57,10 +57,10 @@ const Projects = () => {
       const { data } = await fetchProjects();
       const validProjects = Array.isArray(data) ? data : [];
       setProjects(validProjects);
-      // If a project was selected, keep it selected. Otherwise, select the user's project or the first one.
-      if (!validProjects.some(t => t.id === selectedProjectId)) {
-        const userProject = validProjects.find((t) => t.users.some((u) => u.id === user?.id));
-        setSelectedProjectId(userProject ? userProject.id : (validProjects[0]?.id || null));
+      // Keep the previously selected project if it still exists.
+      // Otherwise, leave no project selected to show the full listing.
+      if (!validProjects.some((t) => t.id === selectedProjectId)) {
+        setSelectedProjectId(null);
       }
     } catch (error) {
       console.error("Failed to fetch projects:", error);


### PR DESCRIPTION
## Summary
- do not auto-select a project when loading Projects page

## Testing
- `bin/rails test` *(fails: `ruby` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68839d6e497c832296e481a1c3ff7196