### PR TITLE
Hide Teams/Projects links for unauthorized users

### DIFF
--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -46,8 +46,12 @@ const Navbar = () => {
 
                 {[
                   "posts",
-                  "projects",
-                  "teams",
+                  user.roles?.some((r) =>
+                    ["owner", "project_manager"].includes(r.name)
+                  ) && "projects",
+                  user.roles?.some((r) =>
+                    ["owner", "team_leader"].includes(r.name)
+                  ) && "teams",
                   "knowledge",
                   "profile",
                   "contact",


### PR DESCRIPTION
## Summary
- restrict navbar links to Projects and Teams

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883a34725e48322a0705d858ef74564