### PR TITLE
Add profile pictures in posts

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -52,7 +52,12 @@ class Api::PostsController < Api::BaseController
       message: post.message,
       image_url: post.image.attached? ? rails_blob_url(post.image, disposition: "attachment", only_path: true) : nil, 
       created_at: post.created_at.strftime("%Y-%m-%d %H:%M"),
-      user: { id: post.user.id, email: post.user.email }
+      user: {
+        id: post.user.id,
+        email: post.user.email,
+        profile_picture: post.user.profile_picture.attached? ?
+          rails_blob_url(post.user.profile_picture, only_path: true) : nil
+      }
     }
   end
 end

--- a/app/javascript/components/PostList.jsx
+++ b/app/javascript/components/PostList.jsx
@@ -3,6 +3,7 @@ import toast from "react-hot-toast";
 import { formatDistanceToNow } from 'date-fns';
 import { FiTrash2 } from 'react-icons/fi';
 import { deletePost } from "../components/api";
+import Avatar from "./ui/Avatar";
 
 const PostList = ({ posts, refreshPosts }) => {
   const handleDelete = async (id) => {
@@ -27,9 +28,11 @@ const PostList = ({ posts, refreshPosts }) => {
             {/* Post Header */}
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center space-x-3">
-                <div className="w-11 h-11 bg-blue-500 rounded-full flex items-center justify-center text-white font-bold text-lg">
-                  {post.user.email[0].toUpperCase()}
-                </div>
+                <Avatar
+                  name={post.user.email}
+                  src={post.user.profile_picture}
+                  className="w-11 h-11 text-lg"
+                />
                 <div>
                   <p className="text-slate-800 font-semibold">{post.user.email}</p>
                   <p className="text-slate-500 text-sm">

--- a/app/javascript/components/ui/Avatar.jsx
+++ b/app/javascript/components/ui/Avatar.jsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+const Avatar = ({ name, src, className = "" }) => {
+  if (src) {
+    return (
+      <img
+        src={src}
+        alt={name}
+        className={`rounded-full object-cover ${className}`.trim()}
+      />
+    );
+  }
+
+  const initial = name ? name.charAt(0).toUpperCase() : "?";
+  return (
+    <div
+      className={`bg-blue-500 text-white flex items-center justify-center rounded-full font-bold ${className}`.trim()}
+    >
+      {initial}
+    </div>
+  );
+};
+
+export default Avatar;


### PR DESCRIPTION
## Summary
- add `Avatar` component to render profile images with a fallback initial
- expose the user's profile picture URL when serializing posts
- use the new `Avatar` component in `PostList`

## Testing
- `bin/rails test` *(fails: `/usr/bin/env: ‘ruby’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6883a4046a808322bbec3d5e1a9bdef1