### PR TITLE
Update vault page default state

### DIFF
--- a/app/javascript/pages/Vault.jsx
+++ b/app/javascript/pages/Vault.jsx
@@ -27,10 +27,10 @@ const Vault = () => {
   const [editContent, setEditContent] = useState("");
   const [openMenuId, setOpenMenuId] = useState(null);
   const [copiedKey, setCopiedKey] = useState(null);
-  const [showCredentials, setShowCredentials] = useState(false);
-  const [showCommands, setShowCommands] = useState(false);
-  const [showTokens, setShowTokens] = useState(false);
-  const [showOthers, setShowOthers] = useState(false);
+  const [showCredentials, setShowCredentials] = useState(true);
+  const [showCommands, setShowCommands] = useState(true);
+  const [showTokens, setShowTokens] = useState(true);
+  const [showOthers, setShowOthers] = useState(true);
 
   useEffect(() => {
     loadItems();


### PR DESCRIPTION
## Summary
- expand all sections on the Vault page by default

## Testing
- `grep -n "useState(true)" app/javascript/pages/Vault.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68874bb5d90c8322b3e73313961e7228