### PR TITLE
Add detailed project info to profile

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -88,12 +88,23 @@ class Api::AuthController < Api::BaseController
         status: tu.status
       }
     end
-    projects = current_user.project_users.includes(:project).map do |pu|
+    projects = current_user.project_users.includes(project: { project_users: :user }).map do |pu|
+      project = pu.project
       {
-        id: pu.project_id,
-        name: pu.project.name,
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        end_date: project.end_date,
         role: pu.role,
-        status: pu.status
+        status: pu.status,
+        members: project.project_users.map do |member|
+          {
+            id: member.user_id,
+            name: [member.user.first_name, member.user.last_name].compact.join(' '),
+            profile_picture: member.user.profile_picture.attached? ?
+              rails_blob_url(member.user.profile_picture, only_path: true) : nil
+          }
+        end
       }
     end
     render json: {

--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
 import { fetchUserInfo, updateUserInfo, fetchPosts, SchedulerAPI } from "../components/api";
 import { getStatusClasses } from '/utils/taskUtils';
 
 const Profile = () => {
+  const navigate = useNavigate();
   const [user, setUser] = useState(null);
   const [posts, setPosts] = useState([]);
   const [tasks, setTasks] = useState([]);
@@ -438,17 +440,42 @@ const Profile = () => {
                           <h3 className="font-bold text-gray-800">{project.name}</h3>
                           <span className="text-xs px-2 py-1 bg-purple-100 text-purple-800 rounded-full">{project.role}</span>
                         </div>
-                        <p className="text-sm text-gray-500 mb-6 line-clamp-2">Project description would go here if available in the data...</p>
+                        <p className="text-sm text-gray-500 mb-6 line-clamp-2">{project.description || 'No description provided.'}</p>
                         <div className="flex justify-between items-center">
                           <div className="flex -space-x-2">
-                            {[1, 2, 3].map((i) => (
-                              <div key={i} className="w-8 h-8 rounded-full bg-gray-200 border-2 border-white"></div>
+                            {project.members.slice(0,3).map((m) => (
+                              m.profile_picture ? (
+                                <img
+                                  key={m.id}
+                                  src={m.profile_picture}
+                                  alt={m.name}
+                                  className="w-8 h-8 rounded-full border-2 border-white object-cover"
+                                />
+                              ) : (
+                                <div
+                                  key={m.id}
+                                  className="w-8 h-8 rounded-full bg-gray-200 border-2 border-white flex items-center justify-center text-xs font-medium text-gray-500"
+                                >
+                                  {m.name.charAt(0).toUpperCase()}
+                                </div>
+                              )
                             ))}
-                            <div className="w-8 h-8 rounded-full bg-gray-100 border-2 border-white flex items-center justify-center text-xs text-gray-500">+3</div>
+                            {project.members.length > 3 && (
+                              <div className="w-8 h-8 rounded-full bg-gray-100 border-2 border-white flex items-center justify-center text-xs text-gray-500">
+                                +{project.members.length - 3}
+                              </div>
+                            )}
                           </div>
-                          <div className="text-xs text-gray-500">Due in 2 weeks</div>
+                          {project.end_date && (
+                            <div className="text-xs text-gray-500">
+                              Due {new Date(project.end_date).toLocaleDateString()}
+                            </div>
+                          )}
                         </div>
-                        <button className="mt-4 w-full py-2 text-sm font-medium text-purple-600 hover:text-purple-800 border border-purple-100 rounded-lg hover:bg-purple-50 transition">
+                        <button
+                          onClick={() => navigate(`/projects/${project.id}/dashboard`)}
+                          className="mt-4 w-full py-2 text-sm font-medium text-purple-600 hover:text-purple-800 border border-purple-100 rounded-lg hover:bg-purple-50 transition"
+                        >
                           View Project
                         </button>
                       </div>


### PR DESCRIPTION
## Summary
- expand `/view_profile` to include project descriptions, members, and end dates
- show project details in the "My Projects" tab and link to each dashboard

## Testing
- `bin/rails --version` *(fails: ruby missing)*

------
https://chatgpt.com/codex/tasks/task_e_68875465408c8322b6fba24d5ad1c14d