### PR TITLE
Add team details to profile

### DIFF
--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useContext } from "react";
+import { useLocation } from "react-router-dom";
 import { fetchTeams, createTeam, updateTeam, deleteTeam, addTeamUser, deleteTeamUser } from "../components/api";
 import UserMultiSelect from "../components/UserMultiSelect";
 import { AuthContext } from "../context/AuthContext";
@@ -26,6 +27,7 @@ const Avatar = ({ name, src }) => {
 
 const Teams = () => {
   const { user } = useContext(AuthContext);
+  const location = useLocation();
   const canEdit = user?.roles?.some((r) => ["owner", "team_leader"].includes(r.name));
   const canManageMembers = user?.roles?.some((r) => r.name === "admin");
 
@@ -65,6 +67,12 @@ const Teams = () => {
     loadTeams();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (teams.length > 0 && location.state?.teamId) {
+      setSelectedTeamId(location.state.teamId);
+    }
+  }, [teams, location.state]);
 
   // When teams are reloaded, ensure a non-existent selection is cleared
   useEffect(() => {


### PR DESCRIPTION
## Summary
- show member avatars and member counts in Profile's My Teams
- navigate to Teams page with selected team
- auto-select passed team in Teams page
- load full team data for profile via fetchTeams

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68875630e0108322bb4470fc36b7aa4e