### PR TITLE
Set community as home page

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -37,7 +37,8 @@ const App = () => {
               <Route path="/legal" element={<Legal />} />
 
               {/* 🔐 Protected */}
-              <Route path="/" element={<PrivateRoute><PdfPage /></PrivateRoute>} />
+              <Route path="/" element={<PrivateRoute><PostPage /></PrivateRoute>} />
+              <Route path="/pdf" element={<PrivateRoute><PdfPage /></PrivateRoute>} />
               <Route path="/posts" element={<PrivateRoute><PostPage /></PrivateRoute>} />
               <Route path="/vault" element={<PrivateRoute><Vault /></PrivateRoute>} />
               <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -5,10 +5,10 @@ import { fetchProjects } from "./api";
 import logo from "../images/logo.webp";
 
 // Icons
-import { 
-  FiChevronDown, FiMenu, FiX, FiLogOut, FiUser, 
+import {
+  FiChevronDown, FiMenu, FiX, FiLogOut, FiUser,
   FiUsers, FiBriefcase, FiHome, FiLayers, FiBook,
-  FiMessageSquare, FiSettings, FiZap, FiAward
+  FiMessageSquare, FiSettings, FiZap, FiAward, FiFileText
 } from "react-icons/fi";
 import { motion, AnimatePresence, useScroll, useMotionValueEvent } from "framer-motion";
 
@@ -207,7 +207,7 @@ const Navbar = () => {
   // Navigation configuration
   const navLinks = [
     { to: "/", label: "Home", icon: FiHome, visible: !!user },
-    { to: "/posts", label: "Community", icon: FiMessageSquare, visible: !!user },
+    { to: "/pdf", label: "PDF Modifier", icon: FiFileText, visible: !!user },
     { to: "/knowledge", label: "Knowledge", icon: FiBook, visible: !!user },
     { to: "/vault", label: "Vault", visible: !!user },
     { 

--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -140,6 +140,7 @@ const PdfPage = () => {
   return (
     <div className="font-inter flex flex-col min-h-screen items-center bg-gray-50 p-4 sm:p-6 lg:p-8">
       <header className="w-full max-w-6xl text-center mb-8">
+        <h1 className="text-4xl font-bold text-gray-800 mb-2">PDF Modifier</h1>
         <p className="text-lg text-gray-600">Your all-in-one online PDF editor. Upload, edit, and manage your documents with ease.</p>
       </header>
 

--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -73,7 +73,7 @@ export function AuthProvider({ children }) {
       );
       setUser(data.user);
       scheduleRefresh(data.exp);
-      navigate("/posts");
+      navigate("/");
       toast.success("Logged in successfully");
     } catch (error) {
       console.error("Google login failed:", error);

--- a/app/javascript/pages/Login.jsx
+++ b/app/javascript/pages/Login.jsx
@@ -25,7 +25,7 @@ const Login = ({ switchToSignup }) => {
 
     try {
       await handleLogin({ auth: formData });
-      navigate("/posts");
+      navigate("/");
       toast.success("Logged in successfully");
     } catch (err) {
       const msg = "Invalid email or password. Please try again.";

--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -56,7 +56,7 @@ const PostPage = () => {
             </div>
           </div>
           <h1 className="text-4xl font-bold text-slate-800 tracking-tight mb-3">
-            Community Feed
+            Home
           </h1>
           <p className="text-slate-600 max-w-lg mx-auto">
             Connect with others, share your thoughts, and discover what's happening in our community.


### PR DESCRIPTION
## Summary
- route `/` to the community feed and add `/pdf` for PDF editing
- update navbar to link to new PDF Modifier page
- show "PDF Modifier" title in PDF page header
- rename community feed heading to Home
- redirect login and Google auth to new home page

## Testing
- `bin/rails test` *(fails: `ruby` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875f0794488322b10c9d145f22ec6d