### PR TITLE
Add customizable color theme

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -129,7 +129,17 @@ class Api::AuthController < Api::BaseController
   private
 
   def user_params
-    permitted = params.require(:auth).permit(:first_name, :last_name, :date_of_birth, :email, :password, :uid, :profile_picture, :cover_photo)
+    permitted = params.require(:auth).permit(
+      :first_name,
+      :last_name,
+      :date_of_birth,
+      :email,
+      :password,
+      :uid,
+      :profile_picture,
+      :cover_photo,
+      :color_theme
+    )
     permitted.delete(:profile_picture) if permitted[:profile_picture] == "null"
     permitted.delete(:cover_photo) if permitted[:cover_photo] == "null"
     permitted

--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -37,6 +37,7 @@ const Profile = () => {
     date_of_birth: "",
     profile_picture: null,
     cover_photo: null,
+    color_theme: "",
   });
 
   const refreshUserInfo = async () => {
@@ -64,6 +65,7 @@ const Profile = () => {
         date_of_birth: data.user.date_of_birth,
         profile_picture: data.user.profile_picture,
         cover_photo: data.user.cover_photo,
+        color_theme: data.user.color_theme || "",
       });
       const postsResponse = await fetchPosts(data.user.id);
       setPosts(postsResponse.data);
@@ -106,6 +108,7 @@ const Profile = () => {
     payload.append("auth[first_name]", formData.first_name);
     payload.append("auth[last_name]", formData.last_name);
     payload.append("auth[date_of_birth]", formData.date_of_birth);
+    payload.append("auth[color_theme]", formData.color_theme);
 
     if (formData.profile_picture instanceof File) {
       payload.append("auth[profile_picture]", formData.profile_picture);
@@ -158,7 +161,7 @@ const Profile = () => {
       <div className="max-w-7xl mx-auto">
         {/* Profile Header */}
         <div className="bg-white rounded-3xl shadow-xl overflow-hidden mb-8">
-          <div className="relative h-48 bg-gradient-to-r from-blue-500 to-indigo-600">
+          <div className="relative h-48 bg-gradient-to-r from-[var(--theme-color)] to-[var(--theme-color)]">
             {/* Cover Photo */}
             {user?.cover_photo && user.cover_photo !== 'null' && (
               <img src={user.cover_photo} alt="Cover" className="absolute inset-0 w-full h-full object-cover" />
@@ -240,7 +243,7 @@ const Profile = () => {
               {!editMode && (
                 <button
                   onClick={() => setEditMode(true)}
-                  className="flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-blue-500 to-indigo-600 text-white font-semibold rounded-full hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1"
+                  className="flex items-center gap-2 px-6 py-3 bg-theme text-white font-semibold rounded-full hover:shadow-lg transition-all duration-300 transform hover:-translate-y-1"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                     <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
@@ -257,25 +260,25 @@ const Profile = () => {
           <div className="flex overflow-x-auto pb-2 scrollbar-hide">
             <button
               onClick={() => setActiveTab('posts')}
-              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'posts' ? 'bg-white text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700'}`}
+              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'posts' ? 'bg-white text-[var(--theme-color)] border-b-2 border-[var(--theme-color)]' : 'text-gray-500 hover:text-gray-700'}`}
             >
               My Posts
             </button>
             <button
               onClick={() => setActiveTab('tasks')}
-              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'tasks' ? 'bg-white text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700'}`}
+              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'tasks' ? 'bg-white text-[var(--theme-color)] border-b-2 border-[var(--theme-color)]' : 'text-gray-500 hover:text-gray-700'}`}
             >
               My Tasks
             </button>
             <button
               onClick={() => setActiveTab('teams')}
-              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'teams' ? 'bg-white text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700'}`}
+              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'teams' ? 'bg-white text-[var(--theme-color)] border-b-2 border-[var(--theme-color)]' : 'text-gray-500 hover:text-gray-700'}`}
             >
               My Teams
             </button>
             <button
               onClick={() => setActiveTab('projects')}
-              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'projects' ? 'bg-white text-blue-600 border-b-2 border-blue-600' : 'text-gray-500 hover:text-gray-700'}`}
+              className={`px-6 py-3 font-medium rounded-t-lg whitespace-nowrap ${activeTab === 'projects' ? 'bg-white text-[var(--theme-color)] border-b-2 border-[var(--theme-color)]' : 'text-gray-500 hover:text-gray-700'}`}
             >
               My Projects
             </button>
@@ -555,7 +558,7 @@ const Profile = () => {
       {editMode && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
           <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md overflow-hidden">
-            <div className="bg-gradient-to-r from-blue-500 to-indigo-600 p-6 text-white">
+            <div className="bg-gradient-to-r from-[var(--theme-color)] to-[var(--theme-color)] p-6 text-white">
               <h3 className="text-2xl font-bold">Edit Profile</h3>
               <p className="opacity-90">Update your personal information</p>
             </div>
@@ -641,6 +644,21 @@ const Profile = () => {
                     </label>
                   </div>
                 </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">Theme Color</label>
+                  <select
+                    name="color_theme"
+                    value={formData.color_theme}
+                    onChange={handleInputChange}
+                    className="w-full border border-gray-300 rounded-lg p-2 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)]"
+                  >
+                    <option value="blue">Blue</option>
+                    <option value="purple">Purple</option>
+                    <option value="green">Green</option>
+                    <option value="red">Red</option>
+                  </select>
+                </div>
               </div>
               
               <div className="mt-8 flex justify-end space-x-3">
@@ -653,7 +671,7 @@ const Profile = () => {
                 </button>
                 <button
                   type="submit"
-                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                  className="px-4 py-2 bg-theme text-white rounded-lg hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)] focus:ring-offset-2"
                 >
                   Save Changes
                 </button>

--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -13,6 +13,11 @@ export function AuthProvider({ children }) {
   const navigate = useNavigate();
   const refreshTimer = useRef();
 
+  useEffect(() => {
+    const color = user?.color_theme || '#3b82f6';
+    document.documentElement.style.setProperty('--theme-color', color);
+  }, [user]);
+
   // Clear timer on unmount
   useEffect(() => () => clearTimeout(refreshTimer.current), []);
 

--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -209,7 +209,7 @@ const Projects = () => {
         <div className="p-4 border-b border-slate-200 flex justify-between items-center">
           <h2 className="text-lg font-bold text-slate-800">Projects</h2>
           {canEdit && (
-            <button onClick={handleNewClick} className="flex items-center gap-2 px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">
+            <button onClick={handleNewClick} className="flex items-center gap-2 px-3 py-1.5 text-sm bg-theme text-white rounded-md hover:brightness-110 transition-colors">
               <FiPlus /> New Project
             </button>
           )}
@@ -222,7 +222,7 @@ const Projects = () => {
               placeholder="Search projects..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full border border-slate-300 rounded-md pl-9 pr-4 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"
+              className="w-full border border-slate-300 rounded-md pl-9 pr-4 py-2 text-sm focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] outline-none"
             />
           </div>
         </div>
@@ -241,7 +241,7 @@ const Projects = () => {
                       <li key={project.id}>
                         <button
                           onClick={() => handleSelectProject(project.id)}
-                          className={`w-full text-left flex items-center justify-between p-4 border-b border-slate-100 transition-colors ${selectedProjectId === project.id ? 'bg-blue-50 text-blue-700' : 'hover:bg-slate-100'}`}
+                          className={`w-full text-left flex items-center justify-between p-4 border-b border-slate-100 transition-colors ${selectedProjectId === project.id ? 'bg-[color-mix(in_srgb,var(--theme-color),white_90%)] text-[var(--theme-color)]' : 'hover:bg-slate-100'}`}
                         >
                           <div>
                             <p className="font-semibold">
@@ -279,20 +279,20 @@ const Projects = () => {
                     <form onSubmit={handleProjectSubmit} className="space-y-4 bg-white p-6 border border-slate-200 rounded-lg shadow-sm">
                         <div>
                             <label htmlFor="name" className="block text-sm font-medium text-slate-700 mb-1">Project Name</label>
-                            <input id="name" name="name" value={projectForm.name} onChange={handleFormChange} placeholder="e.g. Engineering" required className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none"/>
+                            <input id="name" name="name" value={projectForm.name} onChange={handleFormChange} placeholder="e.g. Engineering" required className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] outline-none"/>
                         </div>
                         <div>
                             <label htmlFor="description" className="block text-sm font-medium text-slate-700 mb-1">Description</label>
-                            <textarea id="description" name="description" value={projectForm.description} onChange={handleFormChange} placeholder="A short description of the project's purpose" className="w-full border border-slate-300 rounded-md p-2 h-24 resize-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none" />
+                            <textarea id="description" name="description" value={projectForm.description} onChange={handleFormChange} placeholder="A short description of the project's purpose" className="w-full border border-slate-300 rounded-md p-2 h-24 resize-none focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] outline-none" />
                         </div>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                             <div>
                                 <label htmlFor="start_date" className="block text-sm font-medium text-slate-700 mb-1">Start Date</label>
-                                <input type="date" id="start_date" name="start_date" value={projectForm.start_date} onChange={handleFormChange} className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none" />
+                                <input type="date" id="start_date" name="start_date" value={projectForm.start_date} onChange={handleFormChange} className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] outline-none" />
                             </div>
                             <div>
                                 <label htmlFor="end_date" className="block text-sm font-medium text-slate-700 mb-1">End Date</label>
-                                <input type="date" id="end_date" name="end_date" value={projectForm.end_date} onChange={handleFormChange} className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none" />
+                                <input type="date" id="end_date" name="end_date" value={projectForm.end_date} onChange={handleFormChange} className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] outline-none" />
                             </div>
                         </div>
                         <div>
@@ -304,11 +304,11 @@ const Projects = () => {
                         {projectForm.sheet_integration_enabled && (
                         <div>
                             <label htmlFor="sheet_id" className="block text-sm font-medium text-slate-700 mb-1">Sheet ID</label>
-                            <input id="sheet_id" name="sheet_id" value={projectForm.sheet_id} onChange={handleFormChange} className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none" />
+                            <input id="sheet_id" name="sheet_id" value={projectForm.sheet_id} onChange={handleFormChange} className="w-full border border-slate-300 rounded-md p-2 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] outline-none" />
                         </div>
                         )}
                         <div className="flex items-center gap-3">
-                            <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">{editingId ? "Save Changes" : "Create Project"}</button>
+                            <button type="submit" className="px-4 py-2 bg-theme text-white rounded-md hover:brightness-110 transition-colors">{editingId ? "Save Changes" : "Create Project"}</button>
                             <button type="button" onClick={resetAndCloseForms} className="px-4 py-2 bg-slate-100 text-slate-700 rounded-md hover:bg-slate-200 transition-colors">Cancel</button>
                         </div>
                     </form>
@@ -357,7 +357,7 @@ const Projects = () => {
                                 </div>
                                 <div>
                                     <label htmlFor="role" className="block text-sm font-medium text-slate-700 mb-1">Role</label>
-                                    <select name="role" value={memberForm.role} onChange={handleRoleChange} className="border border-slate-300 rounded-md p-2 pr-8 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none">
+                                    <select name="role" value={memberForm.role} onChange={handleRoleChange} className="border border-slate-300 rounded-md p-2 pr-8 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] outline-none">
                                         <option value="owner">Owner</option>
                                         <option value="manager">Manager</option>
                                         <option value="collaborator">Collaborator</option>
@@ -395,7 +395,7 @@ const Projects = () => {
                                             <span className="text-xs text-slate-500 ml-2">+{project.users.length - 3} more</span>
                                         )}
                                     </div>
-                                    <button onClick={() => handleSelectProject(project.id)} className="self-start text-sm text-blue-600 hover:underline">
+                                    <button onClick={() => handleSelectProject(project.id)} className="self-start text-sm text-[var(--theme-color)] hover:underline">
                                         View Details
                                     </button>
                                 </div>

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root {
+  --theme-color: #3b82f6;
+}
+
+.bg-theme {
+  background-color: var(--theme-color);
+}
+
+.text-theme {
+  color: var(--theme-color);
+}
+
+.border-theme {
+  border-color: var(--theme-color);
+}

--- a/db/migrate/20260901007000_add_color_theme_to_users.rb
+++ b/db/migrate/20260901007000_add_color_theme_to_users.rb
@@ -1,0 +1,5 @@
+class AddColorThemeToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :color_theme, :string, default: 'blue'
+  end
+end


### PR DESCRIPTION
## Summary
- allow users to select a `color_theme`
- store theme choice on `User`
- expose `color_theme` through API
- apply theme color via CSS variable and update major pages

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_688787f8cedc8322903418b0b084ce43