### PR TITLE
Apply user theme color to admin pages

### DIFF
--- a/app/javascript/components/Admin/Admin.jsx
+++ b/app/javascript/components/Admin/Admin.jsx
@@ -21,13 +21,13 @@ function Admin() {
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-bold mb-4">Admin Dashboard</h1>
+      <h1 className="text-2xl font-bold mb-4 text-theme">Admin Dashboard</h1>
       <div className="mb-4">
         <label className="mr-2 font-medium">Select Table:</label>
         <select
           value={selectedTable}
           onChange={(e) => setSelectedTable(e.target.value)}
-          className="border rounded px-2 py-1"
+          className="border border-theme rounded px-2 py-1 focus:ring-2 focus:ring-[var(--theme-color)]"
         >
           <option value="">-- Choose a table --</option>
           {tables.map((tbl) => (

--- a/app/javascript/components/Admin/DynamicAdminTable.jsx
+++ b/app/javascript/components/Admin/DynamicAdminTable.jsx
@@ -150,7 +150,7 @@ function DynamicAdminTable({ table }) {
             <td className="border px-4 py-2">
               <button
                 onClick={handleCreate}
-                className="bg-blue-500 hover:bg-blue-700 text-white px-2 py-1 rounded"
+                className="bg-theme text-white px-2 py-1 rounded hover:brightness-110"
               >
                 Create
               </button>
@@ -193,7 +193,7 @@ function DynamicAdminTable({ table }) {
                   <>
                     <button
                       onClick={() => handleSave(rec.id)}
-                      className="bg-green-500 hover:bg-green-700 text-white px-2 py-1 rounded mr-2"
+                      className="bg-theme text-white px-2 py-1 rounded mr-2 hover:brightness-110"
                     >
                       Save
                     </button>
@@ -208,7 +208,7 @@ function DynamicAdminTable({ table }) {
                   <>
                     <button
                       onClick={() => handleEdit(rec)}
-                      className="bg-yellow-500 hover:bg-yellow-700 text-white px-2 py-1 rounded mr-2"
+                      className="bg-theme text-white px-2 py-1 rounded mr-2 hover:brightness-110"
                     >
                       Edit
                     </button>


### PR DESCRIPTION
## Summary
- use theme color variable for Admin header and select
- update Admin table action buttons to use theme color

## Testing
- `bundle exec rake -T` *(fails: bundle not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68878e90082483229b509e9c717777e2