### PR TITLE
Apply theme color in sprint forms

### DIFF
--- a/app/javascript/components/Scheduler/EditTaskForm.jsx
+++ b/app/javascript/components/Scheduler/EditTaskForm.jsx
@@ -141,7 +141,7 @@ export default function EditTaskForm({ task, developers, dates, types, tasks, on
         {/* Save Button */}
         <button
           type="submit"
-          className="bg-green-600 text-white px-6 py-2 rounded-lg shadow hover:bg-green-700 transition"
+          className="bg-[var(--theme-color)] text-white px-6 py-2 rounded-lg shadow hover:brightness-110 transition"
         >
           💾 Save Changes
         </button>

--- a/app/javascript/components/Scheduler/SprintManager.jsx
+++ b/app/javascript/components/Scheduler/SprintManager.jsx
@@ -145,7 +145,7 @@ export default function SprintManager({ onSprintChange, projectId, projectName }
   if (loading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-blue-500"></div>
+        <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-[var(--theme-color)]"></div>
       </div>
     );
   }
@@ -163,7 +163,7 @@ export default function SprintManager({ onSprintChange, projectId, projectName }
         <motion.button
           whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}
           onClick={() => openForm()}
-          className="mt-3 sm:mt-0 flex items-center gap-2 px-4 py-2 bg-blue-500 text-white rounded-lg shadow-sm hover:bg-blue-600 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-50 focus:ring-blue-500"
+          className="mt-3 sm:mt-0 flex items-center gap-2 px-4 py-2 bg-[var(--theme-color)] text-white rounded-lg shadow-sm hover:brightness-110 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-50 focus:ring-[var(--theme-color)]"
         >
           <FiPlus /><span>New Sprint</span>
         </motion.button>
@@ -184,7 +184,7 @@ export default function SprintManager({ onSprintChange, projectId, projectName }
                 onClick={() => handleSelectSprint(s)}
                 className={`relative flex-shrink-0 w-56 h-32 p-4 rounded-xl cursor-pointer transition-all duration-300 border flex flex-col justify-between
                   ${isActive 
-                    ? 'bg-blue-500 border-blue-500 shadow-lg shadow-blue-500/20 text-white' 
+                    ? 'bg-[var(--theme-color)] border-[var(--theme-color)] shadow-lg shadow-[var(--theme-color)]/20 text-white' 
                     : 'bg-white border-slate-200 text-slate-700 hover:border-blue-400 hover:shadow-md'
                   }`}
               >
@@ -244,23 +244,23 @@ export default function SprintManager({ onSprintChange, projectId, projectName }
                   <div className="space-y-4">
                     <div>
                       <label className="block text-sm font-medium text-slate-600 mb-1">Sprint Name</label>
-                      <input type="text" name="name" value={formData.name} onChange={handleChange} placeholder="e.g., Summer Release" required className="w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md text-slate-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"/>
+                      <input type="text" name="name" value={formData.name} onChange={handleChange} placeholder="e.g., Summer Release" required className="w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md text-slate-800 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] transition"/>
                     </div>
                     <div className="grid grid-cols-2 gap-4">
                       <div>
                         <label className="block text-sm font-medium text-slate-600 mb-1">Start Date</label>
-                        <input type="date" name="start_date" value={formData.start_date} onChange={handleChange} required className="w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md text-slate-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"/>
+                        <input type="date" name="start_date" value={formData.start_date} onChange={handleChange} required className="w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md text-slate-800 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] transition"/>
                       </div>
                       <div>
                         <label className="block text-sm font-medium text-slate-600 mb-1">End Date</label>
-                        <input type="date" name="end_date" value={formData.end_date} onChange={handleChange} required className="w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md text-slate-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"/>
+                        <input type="date" name="end_date" value={formData.end_date} onChange={handleChange} required className="w-full px-3 py-2 bg-slate-50 border border-slate-300 rounded-md text-slate-800 focus:ring-2 focus:ring-[var(--theme-color)] focus:border-[var(--theme-color)] transition"/>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div className="bg-slate-50 px-6 py-4 flex justify-end gap-3 rounded-b-xl border-t border-slate-200">
                   <motion.button type="button" onClick={() => setFormVisible(false)} className="px-4 py-2 bg-white text-slate-700 rounded-md border border-slate-300 hover:bg-slate-100 transition" whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>Cancel</motion.button>
-                  <motion.button type="submit" disabled={isSubmitting} className="px-4 py-2 bg-blue-500 text-white rounded-md shadow-sm hover:bg-blue-600 transition disabled:bg-blue-300" whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+                  <motion.button type="submit" disabled={isSubmitting} className="px-4 py-2 bg-[var(--theme-color)] text-white rounded-md shadow-sm hover:brightness-110 transition disabled:bg-blue-300" whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
                     {isSubmitting ? 'Saving...' : (formData.id ? 'Update Sprint' : 'Create Sprint')}
                   </motion.button>
                 </div>

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -58,7 +58,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                 >
                     <FiX className="w-5 h-5" />
                 </button>
-                <h2 className="text-3xl font-bold text-indigo-700 mb-6 text-center">Task Details</h2>
+                <h2 className="text-3xl font-bold text-[var(--theme-color)] mb-6 text-center">Task Details</h2>
                 <form onSubmit={handleSubmit}>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
                         <div>
@@ -71,7 +71,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="id"
                                 value={editedTask.id}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -84,7 +84,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="link"
                                 value={editedTask.link}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -96,7 +96,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="status"
                                 value={editedTask.status}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             >
                                 <option value="To Do">To Do</option>
                                 <option value="In Progress">In Progress</option>
@@ -113,7 +113,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 value={editedTask.title}
                                 onChange={handleChange}
                                 rows="3"
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             ></textarea>
                         </div>
                         {/* <div className="md:col-span-2 lg:col-span-3">
@@ -126,7 +126,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 value={editedTask.description}
                                 onChange={handleChange}
                                 rows="2"
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             ></textarea>
                         </div> */}
                         <div>
@@ -139,7 +139,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="estimatedHours"
                                 value={editedTask.estimatedHours}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -151,7 +151,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="assignedTo"
                                 value={editedTask.assignedTo}
                                 onChange={handleDeveloperChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             >
                                 {developers.map(dev => (
                                     <option key={dev.id} value={dev.id}>
@@ -169,7 +169,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="assignedUser"
                                 value={editedTask.assignedUser || ''}
                                 onChange={handleUserChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             >
                                 <option value="">Select user</option>
                                 {users.map(u => (
@@ -188,7 +188,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="sprintId"
                                 value={editedTask.sprintId || ''}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             >
                                 <option value="">Unassigned</option>
                                 {sprints.map(s => (
@@ -208,7 +208,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="startDate"
                                 value={editedTask.startDate}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -221,7 +221,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="endDate"
                                 value={editedTask.endDate}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -234,7 +234,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                                 name="order"
                                 value={editedTask.order}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                     </div>
@@ -256,7 +256,7 @@ const TaskDetailsModal = ({ task, developers, users, sprints, onClose, onUpdate,
                         </button>
                         <button
                             type="submit"
-                            className="px-6 py-3 bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 transition duration-200 ease-in-out shadow-md"
+                            className="px-6 py-3 bg-[var(--theme-color)] text-white rounded-lg font-semibold hover:brightness-110 transition duration-200 ease-in-out shadow-md"
                         >
                             Save Changes
                         </button>
@@ -308,7 +308,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                 >
                     <FiX className="w-5 h-5" />
                 </button>
-                <h2 className="text-3xl font-bold text-indigo-700 mb-6 text-center">Add Task</h2>
+                <h2 className="text-3xl font-bold text-[var(--theme-color)] mb-6 text-center">Add Task</h2>
                 <form onSubmit={handleSubmit}>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-6">
                         <div>
@@ -321,7 +321,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="task_id"
                                 value={newTask.task_id}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -334,7 +334,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="task_url"
                                 value={newTask.task_url}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -346,7 +346,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="status"
                                 value={newTask.status}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             >
                                 <option value="todo">To Do</option>
                                 <option value="inprogress">In Progress</option>
@@ -363,7 +363,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 value={newTask.title}
                                 onChange={handleChange}
                                 rows="3"
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             ></textarea>
                         </div>
                         {/* <div className="md:col-span-2 lg:col-span-3">
@@ -376,7 +376,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 value={newTask.description}
                                 onChange={handleChange}
                                 rows="2"
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             ></textarea>
                         </div> */}
                         <div>
@@ -389,7 +389,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="estimated_hours"
                                 value={newTask.estimated_hours}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -401,7 +401,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="developer_id"
                                 value={newTask.developer_id}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             >
                                 {developers.map(dev => (
                                     <option key={dev.id} value={dev.id}>
@@ -419,7 +419,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="assigned_to_user"
                                 value={newTask.assigned_to_user}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             >
                                 <option value="">Select user</option>
                                 {users.map(u => (
@@ -439,7 +439,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="start_date"
                                 value={newTask.start_date}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -452,7 +452,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="end_date"
                                 value={newTask.end_date}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                         <div>
@@ -465,7 +465,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                                 name="order"
                                 value={newTask.order}
                                 onChange={handleChange}
-                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                             />
                         </div>
                     </div>
@@ -479,7 +479,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
                         </button>
                         <button
                             type="submit"
-                            className="px-6 py-3 bg-indigo-600 text-white rounded-lg font-semibold hover:bg-indigo-700 transition duration-200 ease-in-out shadow-md"
+                            className="px-6 py-3 bg-[var(--theme-color)] text-white rounded-lg font-semibold hover:brightness-110 transition duration-200 ease-in-out shadow-md"
                         >
                             Create Task
                         </button>


### PR DESCRIPTION
## Summary
- apply user-selected `--theme-color` variable in SprintOverview add/edit task forms
- update SprintManager form styles to use `--theme-color`
- style scheduler edit task form save button with theme color

## Testing
- `bin/rails test` *(fails: `/usr/bin/env: ‘ruby’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_688791fc54608322b81124feb9430e8a