### PR TITLE
Use project sheet for imports and exports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,6 @@ DATABASE_URL=
 REDIS_URL=redis://localhost:6379/1
 
 # Google Sheets integration
-GOOGLE_SPREADSHEET_ID=
 
 # Misc settings
 RAILS_LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ a service account. To configure it:
 
 1. Add the service account JSON key to `config/google_service_account.json` (the
    file is ignored by Git).
-2. Edit `SPREADSHEET_ID` in `app/services/google_sheets_reader.rb` to match your
-   sheet ID.
+2. Set the `sheet_id` column on each project record to the Google Sheet ID you
+   want to use for imports and exports.
 3. Visit `/sheet` in your browser to see the raw rows rendered in a table. Pass
    `?sheet=TabName` to view a specific tab.
 

--- a/app/controllers/api/sheets_controller.rb
+++ b/app/controllers/api/sheets_controller.rb
@@ -3,7 +3,8 @@ class Api::SheetsController < Api::BaseController
 
   def show
     sheet_name = params[:sheet] || 'X2'
-    reader = GoogleSheetsReader.new(sheet_name)
+    project = Project.find(params[:project_id]) if params[:project_id].present?
+    reader = GoogleSheetsReader.new(sheet_name, project&.sheet_id)
     rows = reader.read_data
     render json: { rows: rows }
   rescue StandardError => e

--- a/app/controllers/api/sprints_controller.rb
+++ b/app/controllers/api/sprints_controller.rb
@@ -50,7 +50,7 @@ class Api::SprintsController < Api::BaseController
 
   def import_tasks
     sprint = Sprint.find(params[:id])
-    service = TaskSheetService.new(sprint.name)
+    service = TaskSheetService.new(sprint.name, sprint.project.sheet_id)
     service.import_tasks(sprint_id: sprint.id, created_by_id: current_user.id)
     head :no_content
   rescue StandardError => e
@@ -60,7 +60,7 @@ class Api::SprintsController < Api::BaseController
   def export_tasks
     sprint = Sprint.find(params[:id])
     tasks = Task.where(sprint_id: sprint.id).order(:developer_id, :start_date)
-    service = TaskSheetService.new(sprint.name)
+    service = TaskSheetService.new(sprint.name, sprint.project.sheet_id)
     service.export_tasks(tasks)
     head :no_content
   rescue StandardError => e
@@ -71,7 +71,7 @@ class Api::SprintsController < Api::BaseController
     sprint = Sprint.find(params[:id])
     logs = TaskLog.joins(:task).where(tasks: { sprint_id: sprint.id }).includes(:task, :developer)
     sheet_name = "#{sprint.name} Scheduler"
-    service = SchedulerSheetService.new(sheet_name)
+    service = SchedulerSheetService.new(sheet_name, sprint.project.sheet_id)
     service.export_logs(logs)
     head :no_content
   rescue StandardError => e

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -61,7 +61,8 @@ class Api::TasksController < Api::BaseController
   end
 
   def import_backlog
-    service = TaskSheetService.new('Backlog')
+    project = Project.find(params[:project_id]) if params[:project_id].present?
+    service = TaskSheetService.new('Backlog', project&.sheet_id)
     service.import_tasks(sprint_id: nil, created_by_id: current_user.id)
     head :no_content
   rescue StandardError => e

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -71,7 +71,7 @@ export const SchedulerAPI = {
   updateTaskLog: (id, data) => api.patch(`/task_logs/${id}.json`, { task_log: data }),
   deleteTaskLog: (id) => api.delete(`/task_logs/${id}.json`),
   importSprintTasks: (id) => api.post(`/sprints/${id}/import_tasks`),
-  importBacklogTasks: () => api.post('/tasks/import_backlog'),
+  importBacklogTasks: (projectId) => api.post('/tasks/import_backlog', { project_id: projectId }),
   exportSprintTasks: (id) => api.post(`/sprints/${id}/export_tasks`),
   exportSprintLogs: (id) => api.post(`/sprints/${id}/export_logs`)
 };

--- a/app/javascript/pages/Sheet.jsx
+++ b/app/javascript/pages/Sheet.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { fetchSheetData } from '../components/api';
 
-const Sheet = ({ sheetName }) => {
+const Sheet = ({ sheetName, projectId }) => {
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -9,7 +9,7 @@ const Sheet = ({ sheetName }) => {
   useEffect(() => {
     const load = async () => {
       try {
-        const params = sheetName ? { sheet: sheetName } : undefined;
+        const params = sheetName ? { sheet: sheetName, project_id: projectId } : { project_id: projectId };
         const { data } = await fetchSheetData(params);
         setRows(data.rows || []);
       } catch (err) {
@@ -19,7 +19,7 @@ const Sheet = ({ sheetName }) => {
       }
     };
     load();
-  }, [sheetName]);
+  }, [sheetName, projectId]);
 
   if (loading) return <p className="text-center">Loading...</p>;
   if (error) return <p className="text-center text-red-600">{error}</p>;

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -199,7 +199,7 @@ export default function SprintDashboard() {
         sprintId ? <TodoBoard sprintId={sprintId} projectId={projectId} onSprintChange={handleSprintChange} /> : <p className="p-4">No sprint selected</p>
       )}
       {activeTab === 'sheet' && (
-        <Sheet sheetName={sprint?.name} />
+        <Sheet sheetName={sprint?.name} projectId={projectId} />
       )}
     </div>
   );

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -792,7 +792,7 @@ const SprintOverview = ({ sprintId, onSprintChange, projectId }) => {
     const handleBacklogImport = async () => {
         try {
             setProcessing(true);
-            await SchedulerAPI.importBacklogTasks();
+            await SchedulerAPI.importBacklogTasks(projectId);
             toast.success('Imported backlog from sheet');
             const res = await SchedulerAPI.getTasks();
             const mapped = res.data.filter(t => !t.sprint_id).map(mapTask);

--- a/app/services/google_sheets_reader.rb
+++ b/app/services/google_sheets_reader.rb
@@ -2,10 +2,9 @@ require 'google/apis/sheets_v4'
 require 'googleauth'
 
 class GoogleSheetsReader
-  SPREADSHEET_ID = ENV['GOOGLE_SPREADSHEET_ID']
-
-  def initialize(sheet_name)
+  def initialize(sheet_name, spreadsheet_id)
     @sheet_name = sheet_name
+    @spreadsheet_id = spreadsheet_id
     @service = Google::Apis::SheetsV4::SheetsService.new
     @service.client_options.application_name = 'Rails Sheet Reader'
     @service.authorization = authorize
@@ -13,7 +12,7 @@ class GoogleSheetsReader
 
   def read_data
     range = "#{@sheet_name}!A1:Z"
-    response = @service.get_spreadsheet_values(SPREADSHEET_ID, range)
+    response = @service.get_spreadsheet_values(@spreadsheet_id, range)
     response.values
   end
 

--- a/app/services/scheduler_sheet_service.rb
+++ b/app/services/scheduler_sheet_service.rb
@@ -2,10 +2,9 @@ require 'google/apis/sheets_v4'
 require 'googleauth'
 
 class SchedulerSheetService
-  SPREADSHEET_ID = GoogleSheetsReader::SPREADSHEET_ID
-
-  def initialize(sheet_name)
+  def initialize(sheet_name, spreadsheet_id)
     @sheet_name = sheet_name
+    @spreadsheet_id = spreadsheet_id
     @service = Google::Apis::SheetsV4::SheetsService.new
     @service.client_options.application_name = 'Rails Scheduler Sheet'
     @service.authorization = authorize
@@ -50,7 +49,7 @@ class SchedulerSheetService
     clear_sheet
     value_range = Google::Apis::SheetsV4::ValueRange.new(values: values)
     @service.update_spreadsheet_value(
-      SPREADSHEET_ID,
+      @spreadsheet_id,
       "#{@sheet_name}!A1",
       value_range,
       value_input_option: 'RAW'
@@ -58,7 +57,7 @@ class SchedulerSheetService
   end
 
   def clear_sheet
-    @service.clear_values(SPREADSHEET_ID, "#{@sheet_name}!A1:Z")
+    @service.clear_values(@spreadsheet_id, "#{@sheet_name}!A1:Z")
   end
 
   def strike_completed_cells(matrix, developers, dates)
@@ -92,12 +91,12 @@ class SchedulerSheetService
     return if requests.empty?
 
     batch = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests: requests)
-    @service.batch_update_spreadsheet(SPREADSHEET_ID, batch)
+    @service.batch_update_spreadsheet(@spreadsheet_id, batch)
   end
 
   def sheet_id
     @sheet_id ||= begin
-      spreadsheet = @service.get_spreadsheet(SPREADSHEET_ID)
+      spreadsheet = @service.get_spreadsheet(@spreadsheet_id)
       sheet = spreadsheet.sheets.find { |s| s.properties.title == @sheet_name }
       sheet.properties.sheet_id
     end

--- a/app/services/task_sheet_service.rb
+++ b/app/services/task_sheet_service.rb
@@ -3,10 +3,9 @@ require 'googleauth'
 require 'date'
 
 class TaskSheetService
-  SPREADSHEET_ID = GoogleSheetsReader::SPREADSHEET_ID
-
-  def initialize(sheet_name)
+  def initialize(sheet_name, spreadsheet_id)
     @sheet_name = sheet_name
+    @spreadsheet_id = spreadsheet_id
     @service = Google::Apis::SheetsV4::SheetsService.new
     @service.client_options.application_name = 'Rails Task Sheet'
     @service.authorization = authorize
@@ -33,7 +32,7 @@ class TaskSheetService
 
   def read_sheet
     range = "#{@sheet_name}!A1:Z"
-    response = @service.get_spreadsheet_values(SPREADSHEET_ID, range)
+    response = @service.get_spreadsheet_values(@spreadsheet_id, range)
     response.values || []
   end
 
@@ -114,7 +113,7 @@ class TaskSheetService
     value_range = Google::Apis::SheetsV4::ValueRange.new(values: values)
 
     @service.update_spreadsheet_value(
-      SPREADSHEET_ID,
+      @spreadsheet_id,
       "#{@sheet_name}!A1",
       value_range,
       value_input_option: 'RAW'
@@ -125,7 +124,7 @@ class TaskSheetService
   end
 
   def clear_sheet
-    @service.clear_values(SPREADSHEET_ID, "#{@sheet_name}!A1:Z")
+    @service.clear_values(@spreadsheet_id, "#{@sheet_name}!A1:Z")
   end
 
   def highlight_completed_rows(tasks)
@@ -159,7 +158,7 @@ class TaskSheetService
     return if requests.empty?
 
     batch_request = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests: requests)
-    @service.batch_update_spreadsheet(SPREADSHEET_ID, batch_request)
+    @service.batch_update_spreadsheet(@spreadsheet_id, batch_request)
   end
 
   def highlight_in_progress_rows(tasks)
@@ -194,12 +193,12 @@ class TaskSheetService
     return if requests.empty?
 
     batch_request = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests: requests)
-    @service.batch_update_spreadsheet(SPREADSHEET_ID, batch_request)
+    @service.batch_update_spreadsheet(@spreadsheet_id, batch_request)
   end
 
   def sheet_id
     @sheet_id ||= begin
-      spreadsheet = @service.get_spreadsheet(SPREADSHEET_ID)
+      spreadsheet = @service.get_spreadsheet(@spreadsheet_id)
       sheet = spreadsheet.sheets.find { |s| s.properties.title == @sheet_name }
       sheet.properties.sheet_id
     end


### PR DESCRIPTION
## Summary
- read sheet IDs from projects instead of env variables
- update services and controllers to use project sheet_id
- pass projectId to sheet endpoints and backlog import
- document new sheet integration setup

## Testing
- `bin/rails test` *(fails: `ruby` not found)*
- `yarn test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_688865aaa7f88322a5353d842a276226