### PR TITLE
Select active sprint by date

### DIFF
--- a/app/controllers/api/sprints_controller.rb
+++ b/app/controllers/api/sprints_controller.rb
@@ -5,7 +5,7 @@ class Api::SprintsController < Api::BaseController
       sprint = Sprint.order(created_at: :desc).first
       render json: sprint
     else
-      sprints = Sprint.order(created_at: :desc)
+      sprints = Sprint.order(start_date: :asc)
       sprints = sprints.where(project_id: params[:project_id]) if params[:project_id].present?
       render json: sprints
     end


### PR DESCRIPTION
## Summary
- sort sprints by start date in SprintController#index so the default selection uses the current sprint by date

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889b1961e308322bfe95666bc4cfb37