### PR TITLE
Adjust add button style

### DIFF
--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -320,7 +320,7 @@ const Projects = () => {
                     {canEdit && (
                         <button
                             onClick={handleNewClick}
-                            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-[var(--theme-color)] hover:brightness-110 transition-colors rounded-full shadow-md active:scale-95 transform"
+                            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-white text-theme border border-theme hover:bg-theme hover:text-white transition-colors rounded-full shadow-md active:scale-95 transform"
                             title="Create New Project"
                         >
                             <FiPlus className="w-4 h-4" /> New Project

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -289,7 +289,7 @@ const Teams = () => {
                     {canEdit && (
                         <button
                             onClick={handleNewClick}
-                            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-theme hover:brightness-110 transition-colors rounded-full shadow-md active:scale-95 transform"
+                            className="flex items-center gap-2 px-3 py-1.5 text-sm bg-white text-theme border border-theme hover:bg-theme hover:text-white transition-colors rounded-full shadow-md active:scale-95 transform"
                             title="Create New Team"
                         >
                             <FiPlus className="w-4 h-4" /> New Team


### PR DESCRIPTION
## Summary
- tweak add button styles on Projects/Teams pages to use white background and theme-colored text

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889f6d5e3c08322a41a1d0946bd99c7