### PR TITLE
Fix image param for post creation

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -43,7 +43,7 @@ class Api::PostsController < Api::BaseController
   private
 
   def post_params
-    params.require(:post).permit(:message, image: [])
+    params.require(:post).permit(:message, :image)
   end
 
   def serialize_post(post)


### PR DESCRIPTION
## Summary
- permit `:image` in post params so uploaded images are saved

## Testing
- `bundle exec rake -T | head -n 20` *(fails: `bundle` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889feab25ec8322bc5db6553e0dad5c