### PR TITLE
Fix profile header layout

### DIFF
--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -253,10 +253,10 @@ const Profile = () => {
             )}
           </div>
           
-          <div className="px-6 md:px-8 pb-8 -mt-16 relative z-10">
+          <div className="px-6 md:px-8 pb-8 relative z-10">
             <div className="flex flex-col md:flex-row items-center md:items-end gap-6">
               {/* Profile Picture */}
-              <div className="relative group">
+              <div className="relative group -mt-16">
                 <div className="absolute inset-0 rounded-full bg-[var(--theme-color)]/20 blur-md -z-10"></div>
                 {user?.profile_picture && user.profile_picture !== 'null' ? (
                   <img


### PR DESCRIPTION
## Summary
- prevent name and email from overlapping the cover image on the profile page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688a042c8e7c8322baf42a4f38a120e8