### PR TITLE
Hide existing members from dropdown

### DIFF
--- a/app/javascript/components/UserMultiSelect.jsx
+++ b/app/javascript/components/UserMultiSelect.jsx
@@ -1,7 +1,12 @@
 import React, { useState, useEffect, useRef } from "react";
 import { getUsers } from "./api";
 
-const UserMultiSelect = ({ selectedUsers, setSelectedUsers, placeholder = "Search users..." }) => {
+const UserMultiSelect = ({
+  selectedUsers,
+  setSelectedUsers,
+  excludedIds = [],
+  placeholder = "Search users...",
+}) => {
   const [allUsers, setAllUsers] = useState([]);
   const [query, setQuery] = useState("");
   const [showDropdown, setShowDropdown] = useState(false);
@@ -43,7 +48,9 @@ const UserMultiSelect = ({ selectedUsers, setSelectedUsers, placeholder = "Searc
 
   const filtered = allUsers.filter((u) => {
     const text = `${u.first_name || ""} ${u.last_name || ""} ${u.email || ""}`.toLowerCase();
-    return text.includes(query.toLowerCase()) && !selectedUsers.some((s) => s.id === u.id);
+    const isSelected = selectedUsers.some((s) => s.id === u.id);
+    const isExcluded = excludedIds.includes(u.id);
+    return text.includes(query.toLowerCase()) && !isSelected && !isExcluded;
   });
 
   return (

--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -581,7 +581,11 @@ const Projects = () => {
                                     <form onSubmit={handleAddMember} className="mt-8 pt-6 border-t border-gray-200 grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
                                         <div className="md:col-span-2">
                                             <label className="block text-sm font-medium text-gray-700 mb-1">Select Users to Add</label>
-                                            <UserMultiSelect selectedUsers={selectedUsersToAdd} setSelectedUsers={setSelectedUsersToAdd} />
+                                            <UserMultiSelect
+                                                selectedUsers={selectedUsersToAdd}
+                                                setSelectedUsers={setSelectedUsersToAdd}
+                                                excludedIds={selectedProject.users.map((u) => u.id)}
+                                            />
                                         </div>
                                         <div>
                                             <label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">Role</label>

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -465,7 +465,11 @@ const Teams = () => {
                                     <form onSubmit={handleAddMember} className="mt-8 pt-6 border-t border-gray-200 grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
                                         <div className="md:col-span-2">
                                             <label className="block text-sm font-medium text-gray-700 mb-1">Select Users to Add</label>
-                                            <UserMultiSelect selectedUsers={selectedUsersToAdd} setSelectedUsers={setSelectedUsersToAdd} />
+                                            <UserMultiSelect
+                                                selectedUsers={selectedUsersToAdd}
+                                                setSelectedUsers={setSelectedUsersToAdd}
+                                                excludedIds={selectedTeam.users.map((u) => u.id)}
+                                            />
                                         </div>
                                         <div>
                                             <label htmlFor="role" className="block text-sm font-medium text-gray-700 mb-1">Role</label>


### PR DESCRIPTION
## Summary
- update `UserMultiSelect` to accept an `excludedIds` prop
- filter out already-added users from dropdown lists in Teams and Projects pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a0adbd05c8322beee04d2f119b0ee