### PR TITLE
Allow all roles to view project and team pages

### DIFF
--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -210,17 +210,17 @@ const Navbar = () => {
     { to: "/pdf", label: "PDF Modifier", icon: FiFileText, visible: !!user },
     { to: "/knowledge", label: "Knowledge", icon: FiBook, visible: !!user },
     { to: "/vault", label: "Vault", icon: FiMenu, visible: !!user },
-    { 
-      to: "/teams", 
-      label: "Teams", 
-      icon: FiUsers, 
-      visible: user?.roles?.some(r => ["owner", "team_leader"].includes(r.name)) 
+    {
+      to: "/teams",
+      label: "Teams",
+      icon: FiUsers,
+      visible: !!user
     },
-    { 
-      to: "/projects", 
-      label: "Projects", 
-      icon: FiLayers, 
-      visible: user?.roles?.some(r => ["owner", "project_manager"].includes(r.name)) 
+    {
+      to: "/projects",
+      label: "Projects",
+      icon: FiLayers,
+      visible: !!user
     },
   ];
 


### PR DESCRIPTION
## Summary
- expose Teams and Projects links for all signed in users

## Testing
- `yarn test` *(fails: lockfile missing)*
- `yarn install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a0f5da3208322ba21aeea63b9cf74