### PR TITLE
Redirect profile post actions to posts page

### DIFF
--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -511,7 +511,10 @@ const Profile = () => {
               <div>
                 <div className="flex justify-between items-center mb-6">
                   <h2 className="text-2xl font-bold text-gray-800">Recent Posts</h2>
-                  <button className="px-4 py-2 bg-[var(--theme-color)] text-white rounded-lg hover:bg-[var(--theme-color)]/90 transition flex items-center gap-2">
+                  <button
+                    onClick={() => navigate('/posts')}
+                    className="px-4 py-2 bg-[var(--theme-color)] text-white rounded-lg hover:bg-[var(--theme-color)]/90 transition flex items-center gap-2"
+                  >
                     <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                       <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
                     </svg>
@@ -554,7 +557,10 @@ const Profile = () => {
                     </svg>
                     <h3 className="mt-4 text-lg font-medium text-gray-700">No posts yet</h3>
                     <p className="mt-1 text-gray-500">Share your thoughts with your team!</p>
-                    <button className="mt-4 px-4 py-2 bg-[var(--theme-color)] text-white rounded-lg hover:bg-[var(--theme-color)]/90 transition flex items-center gap-2 mx-auto">
+                    <button
+                      onClick={() => navigate('/posts')}
+                      className="mt-4 px-4 py-2 bg-[var(--theme-color)] text-white rounded-lg hover:bg-[var(--theme-color)]/90 transition flex items-center gap-2 mx-auto"
+                    >
                       <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
                         <path fillRule="evenodd" d="M10 5a1 1 0 011 1v3h3a1 1 0 110 2h-3v3a1 1 0 11-2 0v-3H6a1 1 0 110-2h3V6a1 1 0 011-1z" clipRule="evenodd" />
                       </svg>


### PR DESCRIPTION
## Summary
- ensure the "New Post" and "Create your first post" buttons in the profile Posts tab navigate to the posts page

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_688a2b45a8748322a5a1c080962a1130