### PR TITLE
Enable team/project exit actions

### DIFF
--- a/app/controllers/api/project_users_controller.rb
+++ b/app/controllers/api/project_users_controller.rb
@@ -1,5 +1,6 @@
 class Api::ProjectUsersController < Api::BaseController
-  before_action :authorize_admin!
+  before_action :authorize_admin!, except: [:leave]
+  before_action :authorize_manager!, only: [:leave]
   before_action :set_project_user, only: [:update, :destroy]
 
   def create
@@ -24,10 +25,22 @@ class Api::ProjectUsersController < Api::BaseController
     head :no_content
   end
 
+  def leave
+    project_user = ProjectUser.find_by(project_id: params[:project_id], user_id: current_user.id)
+    return head :not_found unless project_user
+
+    project_user.destroy
+    head :no_content
+  end
+
   private
 
   def authorize_admin!
     head :forbidden unless current_user&.admin?
+  end
+
+  def authorize_manager!
+    head :forbidden unless current_user&.project_manager?
   end
 
   def set_project_user

--- a/app/controllers/api/team_users_controller.rb
+++ b/app/controllers/api/team_users_controller.rb
@@ -1,5 +1,6 @@
 class Api::TeamUsersController < Api::BaseController
-  before_action :authorize_admin!
+  before_action :authorize_admin!, except: [:leave]
+  before_action :authorize_leader!, only: [:leave]
   before_action :set_team_user, only: [:update, :destroy]
 
   def create
@@ -24,10 +25,22 @@ class Api::TeamUsersController < Api::BaseController
     head :no_content
   end
 
+  def leave
+    team_user = TeamUser.find_by(team_id: params[:team_id], user_id: current_user.id)
+    return head :not_found unless team_user
+
+    team_user.destroy
+    head :no_content
+  end
+
   private
 
   def authorize_admin!
     head :forbidden unless current_user&.admin?
+  end
+
+  def authorize_leader!
+    head :forbidden unless current_user&.team_leader?
   end
 
   def set_team_user

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -112,6 +112,7 @@ export const deleteTeam = (id) => api.delete(`/teams/${id}.json`);
 export const addTeamUser = (data) => api.post('/team_users.json', { team_user: data });
 export const updateTeamUser = (id, data) => api.patch(`/team_users/${id}.json`, { team_user: data });
 export const deleteTeamUser = (id) => api.delete(`/team_users/${id}.json`);
+export const leaveTeam = (teamId) => api.delete(`/team_users/leave/${teamId}.json`);
 export const fetchRoles = () => api.get('/roles.json');
 
 // PROJECT ENDPOINTS
@@ -122,6 +123,7 @@ export const deleteProject = (id) => api.delete(`/projects/${id}.json`);
 export const addProjectUser = (data) => api.post('/project_users.json', { project_user: data });
 export const updateProjectUser = (id, data) => api.patch(`/project_users/${id}.json`, { project_user: data });
 export const deleteProjectUser = (id) => api.delete(`/project_users/${id}.json`);
+export const leaveProject = (projectId) => api.delete(`/project_users/leave/${projectId}.json`);
 
 export const getTables = () => api.get('/admin/tables');
 export const getMeta = (table) => api.get(`/admin_meta/${table}`);

--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useContext, useCallback } from "react";
-import { fetchProjects, createProject, updateProject, deleteProject, addProjectUser, deleteProjectUser } from "../components/api";
+import { fetchProjects, createProject, updateProject, deleteProject, addProjectUser, deleteProjectUser, leaveProject } from "../components/api";
 import UserMultiSelect from "../components/UserMultiSelect";
 import { AuthContext } from "../context/AuthContext";
 // Import icons (e.g., from Feather Icons)
@@ -291,6 +291,24 @@ const Projects = () => {
         }
     };
 
+    const handleLeaveProject = async () => {
+        if (!window.confirm('Are you sure you want to leave this project?')) return;
+        setIsSaving(true);
+        setNotification(null);
+
+        try {
+            await leaveProject(selectedProjectId);
+            await loadProjects();
+            setNotification({ message: 'You have left the project.', type: 'success' });
+        } catch (err) {
+            console.error('Failed to leave project:', err);
+            setNotification({ message: `Failed to leave project: ${err.message || 'An error occurred.'}`, type: 'error' });
+        } finally {
+            setIsSaving(false);
+            setSelectedProjectId(null);
+        }
+    };
+
     // Derived State for rendering
     const filteredProjects = projects.filter((p) =>
         `${p.name} ${p.description || ''} ${p.users.map((u) => u.name).join(" ")}`
@@ -567,6 +585,14 @@ const Projects = () => {
                                                         className="text-sm text-red-500 hover:text-red-700 hover:bg-red-50 px-3 py-1 rounded-md transition-colors font-medium"
                                                     >
                                                         Remove
+                                                    </button>
+                                                )}
+                                                {member.id === user.id && user.roles?.some((r) => r.name === "project_manager") && (
+                                                    <button
+                                                        onClick={handleLeaveProject}
+                                                        className="text-sm text-red-500 hover:text-red-700 hover:bg-red-50 px-3 py-1 rounded-md transition-colors font-medium ml-2"
+                                                    >
+                                                        Leave
                                                     </button>
                                                 )}
                                             </li>

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext, useCallback } from "react";
 import { useLocation } from "react-router-dom";
-import { fetchTeams, createTeam, updateTeam, deleteTeam, addTeamUser, deleteTeamUser } from "../components/api";
+import { fetchTeams, createTeam, updateTeam, deleteTeam, addTeamUser, deleteTeamUser, leaveTeam } from "../components/api";
 import UserMultiSelect from "../components/UserMultiSelect";
 import { AuthContext } from "../context/AuthContext";
 // Import icons (e.g., from Feather Icons)
@@ -269,6 +269,24 @@ const Teams = () => {
         }
     };
 
+    const handleLeaveTeam = async () => {
+        if (!window.confirm('Are you sure you want to leave this team?')) return;
+        setIsSaving(true);
+        setNotification(null);
+
+        try {
+            await leaveTeam(selectedTeamId);
+            await loadTeams();
+            setNotification({ message: 'You have left the team.', type: 'success' });
+        } catch (err) {
+            console.error('Failed to leave team:', err);
+            setNotification({ message: `Failed to leave team: ${err.message || 'An error occurred.'}`, type: 'error' });
+        } finally {
+            setIsSaving(false);
+            setSelectedTeamId(null);
+        }
+    };
+
     // Derived State for rendering
     const filteredTeams = teams.filter((t) =>
         `${t.name} ${t.users.map((u) => u.name).join(" ")}`
@@ -451,6 +469,14 @@ const Teams = () => {
                                                         className="text-sm text-red-500 hover:text-red-700 hover:bg-red-50 px-3 py-1 rounded-md transition-colors font-medium"
                                                     >
                                                         Remove
+                                                    </button>
+                                                )}
+                                                {member.id === user.id && user.roles?.some((r) => r.name === "team_leader") && (
+                                                    <button
+                                                        onClick={handleLeaveTeam}
+                                                        className="text-sm text-red-500 hover:text-red-700 hover:bg-red-50 px-3 py-1 rounded-md transition-colors font-medium ml-2"
+                                                    >
+                                                        Leave
                                                     </button>
                                                 )}
                                             </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,9 +71,11 @@ Rails.application.routes.draw do
     end
     resources :teams, only: [:index, :create, :update, :destroy]
     resources :team_users, only: [:create, :update, :destroy]
+    delete 'team_users/leave/:team_id', to: 'team_users#leave'
 
     resources :projects, only: [:index, :create, :update, :destroy]
     resources :project_users, only: [:create, :update, :destroy]
+    delete 'project_users/leave/:project_id', to: 'project_users#leave'
     resources :task_logs, only: [:index, :create, :update, :destroy]
 
     resources :items, only: [:index, :create, :update, :destroy]


### PR DESCRIPTION
## Summary
- allow team leaders and project managers to remove themselves
- expose leave routes for team and project membership
- surface "Leave" buttons in team and project member lists
- add API helpers for leaving a team or project

## Testing
- `bin/rails routes | grep leave` *(fails: `ruby` not found)*
- `npm run build` *(fails: `esbuild: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688a2d3e5e6483229f4bf176fab91b60