### PR TITLE
Show task link and board button

### DIFF
--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -29,11 +29,25 @@ const StatCard = ({ icon, label, value, color }) => (
 
 const DueTaskItem = ({ task }) => (
     <div className="bg-white p-3 rounded-lg border border-slate-200 hover:border-slate-300 hover:shadow-sm transition-all">
-        <p className="font-semibold text-slate-800 truncate">{task.title || task.task_id}</p>
+        <p className="font-semibold text-slate-800 truncate">
+            <Link
+                to={`/projects/${task.project.id}/dashboard?tab=todo`}
+                className="text-blue-600 hover:underline"
+            >
+                {task.task_id}
+            </Link>
+            {task.title && ` - ${task.title}`}
+        </p>
         {task.project && (
             <p className="text-xs text-slate-500 truncate">Project: {task.project.name}</p>
         )}
         <p className="text-xs text-red-600 font-medium">Due: {new Date(task.end_date).toLocaleDateString()}</p>
+        <Link
+            to={`/projects/${task.project.id}/dashboard?tab=todo`}
+            className="mt-2 inline-block text-xs font-medium text-white bg-[var(--theme-color)] px-2 py-1 rounded hover:bg-[rgb(var(--theme-color-rgb)/0.9)]"
+        >
+            View Todo Board
+        </Link>
     </div>
 );
 

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { fetchProjects } from '../components/api';
 import { CalendarDaysIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/outline';
 import SprintOverview from './SprintOverview';
@@ -27,7 +27,9 @@ const formatDateRange = (start, end) => {
 
 export default function SprintDashboard() {
   const { projectId } = useParams();
-  const [activeTab, setActiveTab] = useState('overview');
+  const [searchParams] = useSearchParams();
+  const initialTab = searchParams.get('tab') || 'overview';
+  const [activeTab, setActiveTab] = useState(initialTab);
   const [sprintId, setSprintId] = useState(null);
   const [sprint, setSprint] = useState(null);
   const [sprints, setSprints] = useState([]);


### PR DESCRIPTION
## Summary
- Add task ID links and board buttons in home page "At a Glance" section
- Allow sprint dashboard to open tabs from `tab` query parameter

## Testing
- `npm test` *(fails: command not found)*
- `bundle exec rails test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b350bd3bc83228c8903de18de7ce9