### PR TITLE
Hide sheet actions when sheet integration disabled

### DIFF
--- a/app/javascript/components/Scheduler/Scheduler.jsx
+++ b/app/javascript/components/Scheduler/Scheduler.jsx
@@ -235,7 +235,7 @@ function TaskCell({ date, devId, tasksInCell, setEditingTask, handleTaskUpdate, 
   );
 }
 
-function Scheduler({ sprintId, projectId }) {
+function Scheduler({ sprintId, projectId, sheetIntegrationEnabled }) {
   const [sprint, setSprint] = useState(null);
   const [developers, setDevelopers] = useState([]);
   const [tasks, setTasks] = useState([]); // will hold task logs
@@ -540,13 +540,15 @@ function Scheduler({ sprintId, projectId }) {
                       <PlusCircleIcon className="h-5 w-5 mr-2" />
                       Add Log
                     </button>
-                    <button
-                      onClick={handleExportScheduler}
-                      className="flex items-center bg-green-500 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105"
-                    >
-                      <TableCellsIcon className="h-5 w-5 mr-2" />
-                      Export to Scheduler Sheet
-                    </button>
+                    {sheetIntegrationEnabled && (
+                      <button
+                        onClick={handleExportScheduler}
+                        className="flex items-center bg-green-500 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md hover:shadow-lg transition-all duration-150 ease-in-out transform hover:scale-105"
+                      >
+                        <TableCellsIcon className="h-5 w-5 mr-2" />
+                        Export to Scheduler Sheet
+                      </button>
+                    )}
                   </div>
                 </div>
               </div>

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -192,10 +192,23 @@ export default function SprintDashboard() {
         </div>
       </header>
       {activeTab === 'overview' && (
-        <SprintOverview projectId={projectId} sprintId={sprintId} onSprintChange={handleSprintChange} />
+        <SprintOverview
+          projectId={projectId}
+          sprintId={sprintId}
+          onSprintChange={handleSprintChange}
+          sheetIntegrationEnabled={project?.sheet_integration_enabled}
+        />
       )}
       {activeTab === 'scheduler' && (
-        sprintId ? <Scheduler sprintId={sprintId} projectId={projectId} /> : <p className="p-4">No sprint selected</p>
+        sprintId ? (
+          <Scheduler
+            sprintId={sprintId}
+            projectId={projectId}
+            sheetIntegrationEnabled={project?.sheet_integration_enabled}
+          />
+        ) : (
+          <p className="p-4">No sprint selected</p>
+        )
       )}
       {activeTab === 'todo' && (
         sprintId ? <TodoBoard sprintId={sprintId} projectId={projectId} onSprintChange={handleSprintChange} /> : <p className="p-4">No sprint selected</p>

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -491,7 +491,7 @@ const AddTaskModal = ({ developers, users, onClose, onCreate }) => {
 };
 
 // Main Component
-const SprintOverview = ({ sprintId, onSprintChange, projectId }) => {
+const SprintOverview = ({ sprintId, onSprintChange, projectId, sheetIntegrationEnabled }) => {
     const [sprints, setSprints] = useState([]);
     const [developers, setDevelopers] = useState([]);
     const [users, setUsers] = useState([]);
@@ -852,18 +852,22 @@ const SprintOverview = ({ sprintId, onSprintChange, projectId }) => {
                             <PlusCircleIcon className="h-5 w-5 mr-2" />
                             Add Task
                         </button>
-                        <button
-                            onClick={handleImport}
-                            className="flex items-center bg-green-500 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
-                        >
-                            Import from Sheet
-                        </button>
-                        <button
-                            onClick={handleExport}
-                            className="flex items-center bg-[var(--theme-color)] hover:brightness-110 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
-                        >
-                            Export to Sheet
-                        </button>
+                        {sheetIntegrationEnabled && (
+                            <>
+                                <button
+                                    onClick={handleImport}
+                                    className="flex items-center bg-green-500 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
+                                >
+                                    Import from Sheet
+                                </button>
+                                <button
+                                    onClick={handleExport}
+                                    className="flex items-center bg-[var(--theme-color)] hover:brightness-110 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
+                                >
+                                    Export to Sheet
+                                </button>
+                            </>
+                        )}
                     </div>
                 </div>
 
@@ -988,12 +992,14 @@ const SprintOverview = ({ sprintId, onSprintChange, projectId }) => {
                             <PlusCircleIcon className="h-5 w-5 mr-2" />
                             Add Task
                         </button>
-                        <button
-                            onClick={handleBacklogImport}
-                            className="flex items-center bg-green-500 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
-                        >
-                            Import Backlog
-                        </button>
+                        {sheetIntegrationEnabled && (
+                            <button
+                                onClick={handleBacklogImport}
+                                className="flex items-center bg-green-500 hover:bg-green-700 text-white font-semibold py-2 px-4 rounded-lg shadow-md"
+                            >
+                                Import Backlog
+                            </button>
+                        )}
                     </div>
                 </div>
                 <div className="overflow-x-auto bg-white rounded-xl shadow-md">


### PR DESCRIPTION
## Summary
- Only show sheet import/export actions when sheet integration is enabled
- Pass sheet integration flag from dashboard to overview and scheduler

## Testing
- `bundle exec rails test` *(fails: command not found: bundle)*
- `npm run build` *(fails: esbuild: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b4ffd9418832297fbae1e909154d7