### PR TITLE
Add project reference to tasks and update forms

### DIFF
--- a/app/controllers/api/sprints_controller.rb
+++ b/app/controllers/api/sprints_controller.rb
@@ -51,7 +51,7 @@ class Api::SprintsController < Api::BaseController
   def import_tasks
     sprint = Sprint.find(params[:id])
     service = TaskSheetService.new(sprint.name, sprint.project.sheet_id)
-    service.import_tasks(sprint_id: sprint.id, created_by_id: current_user.id)
+    service.import_tasks(sprint_id: sprint.id, project_id: sprint.project_id, created_by_id: current_user.id)
     head :no_content
   rescue StandardError => e
     render json: { error: e.message }, status: :unprocessable_entity

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -8,10 +8,7 @@ class Api::TasksController < Api::BaseController
 
     @tasks = @tasks.where(assigned_to_user: params[:assigned_to_user]) if params[:assigned_to_user].present?
     @tasks = @tasks.where(sprint_id: params[:sprint_id]) if params[:sprint_id].present?
-
-    if params[:project_id].present?
-      @tasks = @tasks.joins(:sprint).where(sprints: { project_id: params[:project_id] })
-    end
+    @tasks = @tasks.where(project_id: params[:project_id]) if params[:project_id].present?
 
     render json: @tasks.as_json(include: {
       assigned_user: { only: [:id, :first_name, :email] },
@@ -63,7 +60,7 @@ class Api::TasksController < Api::BaseController
   def import_backlog
     project = Project.find(params[:project_id]) if params[:project_id].present?
     service = TaskSheetService.new('Backlog', project&.sheet_id)
-    service.import_tasks(sprint_id: nil, created_by_id: current_user.id)
+    service.import_tasks(sprint_id: nil, project_id: project&.id, created_by_id: current_user.id)
     head :no_content
   rescue StandardError => e
     render json: { error: e.message }, status: :unprocessable_entity
@@ -83,7 +80,7 @@ class Api::TasksController < Api::BaseController
       :status, :order, :assigned_to_user,
       :created_by, :created_at, :updated_by, :updated_at,
       :start_date, :end_date,
-      :estimated_hours, :sprint_id, :developer_id, :is_struck
+      :estimated_hours, :sprint_id, :developer_id, :project_id, :is_struck
     )
   end
 

--- a/app/javascript/components/TodoBoard/TaskForm.jsx
+++ b/app/javascript/components/TodoBoard/TaskForm.jsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react';
 import { toast } from 'react-hot-toast';
 
-const TaskForm = ({ onAddTask, onCancel }) => {
+const TaskForm = ({ onAddTask, onCancel, projectId }) => {
   const [formData, setFormData] = useState({
     title: '',
     type: '',
     status: 'todo',
     assigned_to_user: '',
-    end_date: ''
+    end_date: '',
+    project_id: projectId || ''
   });
 
   const handleChange = (e) => {
@@ -19,7 +20,7 @@ const TaskForm = ({ onAddTask, onCancel }) => {
     e.preventDefault();
     if (!formData.title) return toast.error('Title is required.');
     onAddTask(formData);
-    setFormData({ title: '', type: '', status: 'todo', assigned_to_user: '', end_date: '' });
+    setFormData({ title: '', type: '', status: 'todo', assigned_to_user: '', end_date: '', project_id: '' });
   };
 
   return (
@@ -62,6 +63,15 @@ const TaskForm = ({ onAddTask, onCancel }) => {
           <input
             name="assigned_to_user"
             value={formData.assigned_to_user}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-[var(--theme-color)]"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Project ID</label>
+          <input
+            name="project_id"
+            value={formData.project_id}
             onChange={handleChange}
             className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-[var(--theme-color)]"
           />

--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -92,7 +92,7 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
   // --- HANDLERS ---
   const handleAddTask = async (newTaskData) => {
     try {
-      const payload = { ...newTaskData, sprint_id: selectedSprintId };
+      const payload = { ...newTaskData, sprint_id: selectedSprintId, project_id: projectId || Number(newTaskData.project_id) || null };
       const { data } = await SchedulerAPI.createTask(payload);
       setColumns(prev => ({
         ...prev,
@@ -249,7 +249,7 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
       </header>
 
       <Modal isOpen={showForm} onClose={() => setShowForm(false)} title="Add a New Task">
-        <TaskForm onAddTask={handleAddTask} onCancel={() => setShowForm(false)} />
+        <TaskForm onAddTask={handleAddTask} onCancel={() => setShowForm(false)} projectId={projectId} />
       </Modal>
 
       <div className="grid md:grid-cols-2 gap-6 mb-8">

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,6 +3,7 @@ class Task < ApplicationRecord
 
   belongs_to :sprint, optional: true
   belongs_to :developer
+  belongs_to :project, optional: true
   belongs_to :assigned_user, class_name: 'User', foreign_key: :assigned_to_user, optional: true
 
   has_many :task_logs, dependent: :destroy

--- a/app/services/task_sheet_service.rb
+++ b/app/services/task_sheet_service.rb
@@ -11,9 +11,9 @@ class TaskSheetService
     @service.authorization = authorize
   end
 
-  def import_tasks(sprint_id:, created_by_id:)
+  def import_tasks(sprint_id:, created_by_id:, project_id: nil)
     data = read_sheet
-    import_tasks_from_sheet(data, sprint_id: sprint_id, created_by_id: created_by_id)
+    import_tasks_from_sheet(data, sprint_id: sprint_id, created_by_id: created_by_id, project_id: project_id)
   end
 
   def export_tasks(tasks)
@@ -48,7 +48,7 @@ class TaskSheetService
     val
   end
 
-  def import_tasks_from_sheet(sheet_data, sprint_id:, created_by_id:)
+  def import_tasks_from_sheet(sheet_data, sprint_id:, created_by_id:, project_id: nil)
     sheet_data[1..].each do |row|
       next if row.compact.empty?
 
@@ -81,7 +81,8 @@ class TaskSheetService
         start_date: start_date,
         end_date: end_date,
         status: status,
-        order: order
+        order: order,
+        project_id: project_id
       )
 
       task.save!

--- a/db/migrate/20260901008000_add_project_ref_to_tasks.rb
+++ b/db/migrate/20260901008000_add_project_ref_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddProjectRefToTasks < ActiveRecord::Migration[7.1]
+  def change
+    add_reference :tasks, :project, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -148,6 +148,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_01_007000) do
     t.decimal "estimated_hours", precision: 5, scale: 2
     t.bigint "sprint_id"
     t.bigint "developer_id", null: false
+    t.bigint "project_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status", default: "todo"
@@ -161,6 +162,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_01_007000) do
     t.date "end_date"
     t.index ["developer_id"], name: "index_tasks_on_developer_id"
     t.index ["sprint_id"], name: "index_tasks_on_sprint_id"
+    t.index ["project_id"], name: "index_tasks_on_project_id"
     t.index ["type"], name: "index_tasks_on_type"
   end
 
@@ -230,6 +232,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_01_007000) do
   add_foreign_key "task_logs", "tasks"
   add_foreign_key "tasks", "developers"
   add_foreign_key "tasks", "sprints"
+  add_foreign_key "tasks", "projects"
   add_foreign_key "team_users", "teams"
   add_foreign_key "team_users", "users"
   add_foreign_key "teams", "users", column: "owner_id"


### PR DESCRIPTION
## Summary
- Allow tasks to reference projects directly
- Include project selection in task creation forms and backlog imports
- Pass project context through task sheet import/export services

## Testing
- `npm run build` *(fails: esbuild: not found)*
- `bundle exec rails db:migrate` *(fails: command not found: bundle)*

------
https://chatgpt.com/codex/tasks/task_e_688b582e92bc8322b53fd5574f06309c