### PR TITLE
fix sprint selection feedback loop

### DIFF
--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -570,13 +570,13 @@ const SprintOverview = ({ sprintId, onSprintChange, projectId, sheetIntegrationE
                     if(onSprintChange) onSprintChange(null);
                 }
             });
-    }, [projectId]);
+    }, [projectId, sprintId]);
 
     useEffect(() => {
-        if (onSprintChange && selectedSprintId !== null) {
+        if (!sprintId && onSprintChange && selectedSprintId !== null) {
             onSprintChange(selectedSprintId);
         }
-    }, [selectedSprintId]);
+    }, [selectedSprintId, sprintId, onSprintChange]);
 
     useEffect(() => {
         if (selectedSprintId === null) {


### PR DESCRIPTION
## Summary
- prevent SprintOverview from re-triggering sprint selection when a sprint ID prop is present
- include sprintId in sprint list fetch effect dependencies

## Testing
- `npm run build` *(fails: esbuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b666b95a88322806b314103557dd9