### PR TITLE
Apply global profile theme color across app

### DIFF
--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -1,28 +1,10 @@
-import React, { useEffect, useState, useMemo } from "react";
+import React, { useEffect, useState, useMemo, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { fetchUserInfo, updateUserInfo, fetchPosts, SchedulerAPI, fetchTeams } from "../components/api";
+import { fetchUserInfo, fetchPosts, SchedulerAPI, fetchTeams } from "../components/api";
 import { getStatusClasses } from '/utils/taskUtils';
 import { Squares2X2Icon, FolderIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
-
-const COLOR_MAP = {
-  blue: '#3b82f6',
-  purple: '#8b5cf6',
-  green: '#10b981',
-  red: '#ef4444',
-  pink: '#ec4899',
-  indigo: '#6366f1'
-};
-
-const lightenColor = (color, amount = 0.9) => {
-  const hex = color.replace('#', '');
-  const r = parseInt(hex.substring(0, 2), 16);
-  const g = parseInt(hex.substring(2, 4), 16);
-  const b = parseInt(hex.substring(4, 6), 16);
-  const nr = Math.round(r + (255 - r) * amount);
-  const ng = Math.round(g + (255 - g) * amount);
-  const nb = Math.round(b + (255 - b) * amount);
-  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
-};
+import { AuthContext } from '../context/AuthContext';
+import { COLOR_MAP } from '/utils/theme';
 
 const Avatar = ({ name, src, size = 'md' }) => {
   const sizes = {
@@ -54,6 +36,7 @@ const Avatar = ({ name, src, size = 'md' }) => {
 
 const Profile = () => {
   const navigate = useNavigate();
+  const { setUser: setAuthUser } = useContext(AuthContext);
   const [user, setUser] = useState(null);
   const [posts, setPosts] = useState([]);
   const [tasks, setTasks] = useState([]);
@@ -76,7 +59,9 @@ const Profile = () => {
     try {
       const { data } = await fetchUserInfo();
       const theme = COLOR_MAP[data.user.color_theme] || data.user.color_theme || '#3b82f6';
-      setUser({ ...data.user, color_theme: theme });
+      const updatedUser = { ...data.user, color_theme: theme };
+      setUser(updatedUser);
+      setAuthUser(updatedUser);
 
       const basicTeams = Array.isArray(data.teams) ? data.teams : [];
       try {
@@ -112,12 +97,6 @@ const Profile = () => {
       setIsLoading(false);
     }
   };
-
-  useEffect(() => {
-    const baseColor = user ? (COLOR_MAP[user.color_theme] || user.color_theme) : '#3b82f6';
-    document.documentElement.style.setProperty('--theme-color', baseColor);
-    document.documentElement.style.setProperty('--theme-color-light', lightenColor(baseColor));
-  }, [user]);
 
   useEffect(() => {
     refreshUserInfo();

--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -4,13 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { auth, googleProvider } from "../firebaseConfig";
 import { signInWithPopup } from "firebase/auth";
 import { toast } from "react-hot-toast";
-
-const COLOR_MAP = {
-  blue: '#3b82f6',
-  purple: '#8b5cf6',
-  green: '#10b981',
-  red: '#ef4444',
-};
+import { COLOR_MAP, toRgb, lightenColor } from '/utils/theme';
 
 export const AuthContext = createContext();
 
@@ -20,20 +14,12 @@ export function AuthProvider({ children }) {
   const navigate = useNavigate();
   const refreshTimer = useRef();
 
-  const toRgb = (color) => {
-    const temp = document.createElement('div');
-    temp.style.color = color;
-    document.body.appendChild(temp);
-    const match = getComputedStyle(temp).color.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
-    document.body.removeChild(temp);
-    return match ? `${match[1]} ${match[2]} ${match[3]}` : '59 130 246';
-  };
-
   useEffect(() => {
     const raw = user?.color_theme;
     const color = COLOR_MAP[raw] || raw || '#3b82f6';
     document.documentElement.style.setProperty('--theme-color', color);
     document.documentElement.style.setProperty('--theme-color-rgb', toRgb(color));
+    document.documentElement.style.setProperty('--theme-color-light', lightenColor(color));
   }, [user]);
 
   // Clear timer on unmount
@@ -112,6 +98,7 @@ export function AuthProvider({ children }) {
 
   const value = {
     user,
+    setUser,
     initializing,
     isAuthenticated: !!user,
     handleLogin,

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -5,6 +5,11 @@
 :root {
   --theme-color: #3b82f6;
   --theme-color-rgb: 59 130 246;
+  --theme-color-light: #ebf3fe;
+}
+
+body {
+  background: linear-gradient(to bottom right, var(--theme-color-light), white);
 }
 
 .bg-theme {

--- a/app/javascript/utils/theme.js
+++ b/app/javascript/utils/theme.js
@@ -1,0 +1,28 @@
+export const COLOR_MAP = {
+  blue: '#3b82f6',
+  purple: '#8b5cf6',
+  green: '#10b981',
+  red: '#ef4444',
+  pink: '#ec4899',
+  indigo: '#6366f1'
+};
+
+export const lightenColor = (color, amount = 0.9) => {
+  const hex = color.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  const nr = Math.round(r + (255 - r) * amount);
+  const ng = Math.round(g + (255 - g) * amount);
+  const nb = Math.round(b + (255 - b) * amount);
+  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
+};
+
+export const toRgb = (color) => {
+  const temp = document.createElement('div');
+  temp.style.color = color;
+  document.body.appendChild(temp);
+  const match = getComputedStyle(temp).color.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  document.body.removeChild(temp);
+  return match ? `${match[1]} ${match[2]} ${match[3]}` : '59 130 246';
+};


### PR DESCRIPTION
## Summary
- centralize color mapping and helpers in `theme.js`
- update AuthContext to set theme color variables globally and expose setter
- use context in Profile to update global theme when user saves color
- apply light theme variable and gradient background globally

## Testing
- `yarn build`
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68905df1af388322933a4ba598f4d7ca