### PR TITLE
Fix PDF viewer cache not refreshing after multiple edits

### DIFF
--- a/app/javascript/components/FormComponent.jsx
+++ b/app/javascript/components/FormComponent.jsx
@@ -25,7 +25,8 @@ const FormComponent = ({ setActiveForm, setPdfUpdated, formFields = [], endpoint
 
       if (!response.ok) throw new Error("Request failed");
 
-      setPdfUpdated((prev) => !prev);
+      // Increment the counter so the viewer reloads the updated PDF
+      setPdfUpdated((prev) => prev + 1);
       setActiveForm(null);
     } catch (error) {
       console.error(error);

--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -26,7 +26,8 @@ import {
 
 const PdfPage = () => {
   const [pdfUrl, setPdfUrl] = useState(null);
-  const [pdfUpdated, setPdfUpdated] = useState(false);
+  // Use a numeric counter to bust the cache after each modification.
+  const [pdfUpdated, setPdfUpdated] = useState(0);
   const [uploading, setUploading] = useState(false);
   const [showUploadMessage, setShowUploadMessage] = useState(false);
   const [uploadMessage, setUploadMessage] = useState("");
@@ -100,7 +101,8 @@ const PdfPage = () => {
   const handleRemovePdf = () => {
     setPdfUrl(null);
     localStorage.removeItem("pdfUrl");
-    setPdfUpdated(false);
+    // Reset the version counter when removing the PDF
+    setPdfUpdated(0);
     setShowUploadMessage(false);
   };
 
@@ -113,7 +115,8 @@ const PdfPage = () => {
         },
       });
       if (response.ok) {
-        setPdfUpdated((prev) => !prev);
+        // Increment the counter to force the viewer to reload the PDF
+        setPdfUpdated((prev) => prev + 1);
         setUploadMessage("PDF reset to original state!");
         setIsError(false);
         setShowUploadMessage(true);


### PR DESCRIPTION
## Summary
- switch PDF refresh tracker to an incrementing counter
- reset counter when removing PDF to avoid stale views
- increment counter on form submissions to bust cache

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68905ed4f6048322b2d1acd9d5ffe7ff