### PR TITLE
Apply profile theme color across navigation and pages

### DIFF
--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -88,9 +88,9 @@ const AnimatedNavLink = ({ to, label, icon: Icon }) => {
       </div>
       
       {isActive && (
-        <motion.div 
+        <motion.div
           layoutId="nav-active-bg"
-          className="absolute inset-0 bg-gradient-to-r from-blue-500 to-sky-600 rounded-lg shadow-lg"
+          className="absolute inset-0 bg-[var(--theme-color)] rounded-lg shadow-lg"
           transition={{ type: 'spring', bounce: 0.2, duration: 0.6 }}
         />
       )}

--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -140,7 +140,7 @@ const PdfPage = () => {
   return (
     <div className="font-inter flex flex-col min-h-screen items-center bg-gray-50 p-4 sm:p-6 lg:p-8">
       <header className="w-full max-w-6xl text-center mb-8">
-        <h1 className="text-4xl font-bold text-gray-800 mb-2">PDF Modifier</h1>
+        <h1 className="text-4xl font-bold text-[var(--theme-color)] mb-2">PDF Modifier</h1>
         <p className="text-lg text-gray-600">Your all-in-one online PDF editor. Upload, edit, and manage your documents with ease.</p>
       </header>
 

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -64,7 +64,7 @@ export default function KnowledgeDashboard() {
       <header className="sticky top-0 z-10 backdrop-blur-md bg-white/80 dark:bg-gray-900/80 border-b border-gray-200 dark:border-gray-700">
         <div className="max-w-7xl mx-auto px-6 py-4 flex flex-col sm:flex-row justify-between items-center">
           <div className="flex items-center mb-4 sm:mb-0">
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+            <h1 className="text-3xl font-bold bg-gradient-to-r from-[var(--theme-color)] to-[var(--theme-color-light)] bg-clip-text text-transparent">
               Knowledge Hub
             </h1>
             <button 
@@ -82,7 +82,7 @@ export default function KnowledgeDashboard() {
                 onClick={() => setActiveCategory(cat.id)}
                 className={`px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
                   activeCategory === cat.id
-                    ? 'bg-blue-600 text-white'
+                    ? 'bg-[var(--theme-color)] text-white'
                     : 'bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600'
                 }`}
               >

--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -32,7 +32,7 @@ const DueTaskItem = ({ task }) => (
         <p className="font-semibold text-slate-800 truncate">
             <Link
                 to={`/projects/${task.project.id}/dashboard?tab=todo`}
-                className="text-blue-600 hover:underline"
+                className="text-[var(--theme-color)] hover:underline"
             >
                 {task.task_id}
             </Link>
@@ -215,7 +215,7 @@ const PostPage = () => {
                 <AnimatePresence>
                     {isLoading ? (
                         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} className="flex flex-col items-center justify-center py-20 text-center">
-                            <FiLoader className="animate-spin text-blue-500 text-4xl mb-4" />
+                            <FiLoader className="animate-spin text-[var(--theme-color)] text-4xl mb-4" />
                             <p className="text-slate-600 font-medium">Loading Community Feed...</p>
                         </motion.div>
                     ) : posts.length > 0 ? (
@@ -241,7 +241,7 @@ const PostPage = () => {
                 <div className="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
                     <h2 className="text-lg font-bold text-slate-800 mb-4">Community Stats</h2>
                     <div className="space-y-4">
-                        <StatCard icon={<FiMessageSquare className="text-blue-500"/>} label="Total Posts" value={stats.totalPosts} color="bg-blue-100" />
+                        <StatCard icon={<FiMessageSquare className="text-[var(--theme-color)]"/>} label="Total Posts" value={stats.totalPosts} color="bg-[rgb(var(--theme-color-rgb)/0.1)]" />
                         <StatCard icon={<FiUsers className="text-purple-500"/>} label="Active Users" value={stats.activeUsers} color="bg-purple-100" />
                         <StatCard icon={<FiClock className="text-green-500"/>} label="Last Activity" value={stats.recentActivity} color="bg-green-100" />
                     </div>


### PR DESCRIPTION
## Summary
- use profile theme color for active navbar links
- show user-selected color on PDF Modifier and Knowledge pages
- highlight home page elements with the user's theme color

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6890601ade5083228dde9b62ef73b366