### PR TITLE
Allow personal general tasks from Todo board

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -4,11 +4,13 @@ class Api::TasksController < Api::BaseController
   # GET /tasks.json
   def index
     @tasks = Task.includes(:assigned_user, :sprint)
+                 .where('type != ? OR created_by = ?', 'general', current_user.id)
                  .order(end_date: :asc)
 
     @tasks = @tasks.where(assigned_to_user: params[:assigned_to_user]) if params[:assigned_to_user].present?
     @tasks = @tasks.where(sprint_id: params[:sprint_id]) if params[:sprint_id].present?
     @tasks = @tasks.where(project_id: params[:project_id]) if params[:project_id].present?
+    @tasks = @tasks.where(type: params[:type]) if params[:type].present?
 
     render json: @tasks.as_json(include: {
       assigned_user: { only: [:id, :first_name, :email] },
@@ -69,7 +71,7 @@ class Api::TasksController < Api::BaseController
   private
 
   def set_task
-    @task = Task.find(params[:id])
+    @task = Task.where('type != ? OR created_by = ?', 'general', current_user.id).find(params[:id])
   end
 
   def task_params

--- a/app/javascript/components/TodoBoard/TaskCard.jsx
+++ b/app/javascript/components/TodoBoard/TaskCard.jsx
@@ -9,6 +9,7 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editDetails, setEditDetails] = useState({
       title: item.title || '',
+      description: item.description || '',
       type: item.type || '',
       status: item.status || 'todo',
       assigned_to_user: item.assigned_to_user || '',
@@ -37,11 +38,18 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
         placeholder="Title"
         className="border p-2 rounded"
       />
+      <textarea
+        value={editDetails.description}
+        onChange={(e) => setEditDetails(prev => ({ ...prev, description: e.target.value }))}
+        placeholder="Description"
+        className="border p-2 rounded"
+      />
       <input
         value={editDetails.type}
         onChange={(e) => setEditDetails(prev => ({ ...prev, type: e.target.value }))}
         placeholder="Type"
         className="border p-2 rounded"
+        disabled={item.type === 'general'}
       />
       <select
         value={editDetails.status}
@@ -81,10 +89,10 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
             <span className="font-semibold text-lg text-[var(--theme-color)] transition-colors">
               {item.task_url ? (
                 <a href={item.task_url} target="_blank" rel="noopener noreferrer" className="hover:underline">
-                  {item.task_id}
+                  {item.task_id || item.title}
                 </a>
               ) : (
-                item.task_id
+                item.task_id || item.title
               )}
             </span>
             <div className="flex items-center gap-2">
@@ -92,7 +100,7 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
                 <button onClick={() => onDelete(columnId, item.id)} className="text-gray-400 hover:text-red-600 transition-colors" title="Delete"><FiTrash2 size={18} /></button>
             </div>
         </div>
-        <p className="text-gray-600 text-sm">{item.title || 'No Title'}</p>
+        <p className="text-gray-600 text-sm">{item.description || item.title || 'No Description'}</p>
         
         {item.tags && item.tags.length > 0 && (
             <div className="flex items-center text-sm text-gray-500 mt-2">

--- a/app/javascript/components/TodoBoard/TaskForm.jsx
+++ b/app/javascript/components/TodoBoard/TaskForm.jsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { toast } from 'react-hot-toast';
 
-const TaskForm = ({ onAddTask, onCancel, projectId }) => {
+const TaskForm = ({ onAddTask, onCancel }) => {
   const [formData, setFormData] = useState({
     title: '',
-    type: '',
+    description: '',
+    type: 'general',
     status: 'todo',
-    assigned_to_user: '',
-    end_date: '',
-    project_id: projectId || ''
+    end_date: ''
   });
 
   const handleChange = (e) => {
@@ -20,7 +19,7 @@ const TaskForm = ({ onAddTask, onCancel, projectId }) => {
     e.preventDefault();
     if (!formData.title) return toast.error('Title is required.');
     onAddTask(formData);
-    setFormData({ title: '', type: '', status: 'todo', assigned_to_user: '', end_date: '', project_id: '' });
+    setFormData({ title: '', description: '', type: 'general', status: 'todo', end_date: '' });
   };
 
   return (
@@ -41,8 +40,8 @@ const TaskForm = ({ onAddTask, onCancel, projectId }) => {
           <input
             name="type"
             value={formData.type}
-            onChange={handleChange}
-            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-[var(--theme-color)]"
+            disabled
+            className="w-full px-3 py-2 border rounded-lg bg-gray-100 text-gray-500"
           />
         </div>
         <div>
@@ -58,20 +57,11 @@ const TaskForm = ({ onAddTask, onCancel, projectId }) => {
             <option value="completed">Completed</option>
           </select>
         </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Assigned User ID</label>
-          <input
-            name="assigned_to_user"
-            value={formData.assigned_to_user}
-            onChange={handleChange}
-            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-[var(--theme-color)]"
-          />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Project ID</label>
-          <input
-            name="project_id"
-            value={formData.project_id}
+        <div className="sm:col-span-2">
+          <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+          <textarea
+            name="description"
+            value={formData.description}
             onChange={handleChange}
             className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-[var(--theme-color)]"
           />

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,7 @@ class Task < ApplicationRecord
   include UserStampable
 
   belongs_to :sprint, optional: true
-  belongs_to :developer
+  belongs_to :developer, optional: true
   belongs_to :project, optional: true
   belongs_to :assigned_user, class_name: 'User', foreign_key: :assigned_to_user, optional: true
 
@@ -11,7 +11,14 @@ class Task < ApplicationRecord
   # This tells ActiveRecord NOT to use the 'type' column for Single Table Inheritance.
   self.inheritance_column = 'non_existent_type_column'
 
-  validates :task_id,  presence: true
-  validates :developer, presence: true
+  validates :task_id, presence: true, unless: :general?
+  validates :developer, presence: true, unless: :general?
   validates :type, presence: true
+  validates :title, presence: true, if: :general?
+
+  private
+
+  def general?
+    type == 'general'
+  end
 end

--- a/db/migrate/20260901009000_allow_null_task_id_and_developer_id_in_tasks.rb
+++ b/db/migrate/20260901009000_allow_null_task_id_and_developer_id_in_tasks.rb
@@ -1,0 +1,6 @@
+class AllowNullTaskIdAndDeveloperIdInTasks < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :tasks, :task_id, true
+    change_column_null :tasks, :developer_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -142,12 +142,12 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_01_008000) do
   end
 
   create_table "tasks", force: :cascade do |t|
-    t.string "task_id", null: false
+    t.string "task_id"
     t.string "task_url"
     t.string "type", null: false
     t.decimal "estimated_hours", precision: 5, scale: 2
     t.bigint "sprint_id"
-    t.bigint "developer_id", null: false
+    t.bigint "developer_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "status", default: "todo"


### PR DESCRIPTION
## Summary
- allow general tasks without developer or external task id
- limit visibility of general tasks to their creators
- enable Todo board UI to create and manage personal tasks

## Testing
- `bin/rails db:migrate` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*


------
https://chatgpt.com/codex/tasks/task_e_689096d733888322a8b15fc435a0c757