### PR TITLE
Remove project/sprint IDs from todo tasks and add optional start date

### DIFF
--- a/app/javascript/components/TodoBoard/TaskForm.jsx
+++ b/app/javascript/components/TodoBoard/TaskForm.jsx
@@ -7,6 +7,7 @@ const TaskForm = ({ onAddTask, onCancel }) => {
     description: '',
     type: 'general',
     status: 'todo',
+    start_date: '',
     end_date: ''
   });
 
@@ -19,7 +20,7 @@ const TaskForm = ({ onAddTask, onCancel }) => {
     e.preventDefault();
     if (!formData.title) return toast.error('Title is required.');
     onAddTask(formData);
-    setFormData({ title: '', description: '', type: 'general', status: 'todo', end_date: '' });
+    setFormData({ title: '', description: '', type: 'general', status: 'todo', start_date: '', end_date: '' });
   };
 
   return (
@@ -62,6 +63,16 @@ const TaskForm = ({ onAddTask, onCancel }) => {
           <textarea
             name="description"
             value={formData.description}
+            onChange={handleChange}
+            className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-[var(--theme-color)]"
+          />
+        </div>
+        <div className="sm:col-span-2">
+          <label className="block text-sm font-medium text-gray-700 mb-1">Start Date</label>
+          <input
+            type="date"
+            name="start_date"
+            value={formData.start_date}
             onChange={handleChange}
             className="w-full px-3 py-2 border rounded-lg shadow-sm focus:ring-2 focus:ring-[var(--theme-color)]"
           />

--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -95,10 +95,7 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
   // --- HANDLERS ---
   const handleAddTask = async (newTaskData) => {
     try {
-      const payload = { ...newTaskData };
-      if (selectedSprintId) payload.sprint_id = selectedSprintId;
-      if (projectId) payload.project_id = projectId;
-      const { data } = await SchedulerAPI.createTask(payload);
+      const { data } = await SchedulerAPI.createTask({ ...newTaskData });
       setColumns(prev => ({
         ...prev,
         todo: { ...prev.todo, items: [...prev.todo.items, data] }


### PR DESCRIPTION
## Summary
- stop sending project and sprint IDs when creating tasks from the Todo board
- allow optional start date when creating a task on the Todo board

## Testing
- `npm run build`
- `bundle exec rails test` *(fails: bundler could not find rails and bundle install requires Ruby 3.3.0)*
- `bundle install` *(fails: Ruby version mismatch; Gemfile requires 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68909c09076083229e1de0c86d6c6e6f