### PR TITLE
Include general tasks irrespective of project or sprint

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -8,8 +8,8 @@ class Api::TasksController < Api::BaseController
                  .order(end_date: :asc)
 
     @tasks = @tasks.where(assigned_to_user: params[:assigned_to_user]) if params[:assigned_to_user].present?
-    @tasks = @tasks.where(sprint_id: params[:sprint_id]) if params[:sprint_id].present?
-    @tasks = @tasks.where(project_id: params[:project_id]) if params[:project_id].present?
+    @tasks = @tasks.where('sprint_id = ? OR type = ?', params[:sprint_id], 'general') if params[:sprint_id].present?
+    @tasks = @tasks.where('project_id = ? OR type = ?', params[:project_id], 'general') if params[:project_id].present?
     @tasks = @tasks.where(type: params[:type]) if params[:type].present?
 
     render json: @tasks.as_json(include: {


### PR DESCRIPTION
## Summary
- Ensure task listing includes `general` tasks even when filtering by project or sprint

## Testing
- `bundle exec rails test` *(fails: command not found)*
- `bundle install` *(fails: Ruby 3.3.0 required)*
- `yarn build` *(fails: package not present in lockfile)*
- `yarn install` *(fails: 403 Bad response)*

------
https://chatgpt.com/codex/tasks/task_e_68909da93914832284a228611f598469