### PR TITLE
Allow authenticated users to fetch user list

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,7 +1,7 @@
 class Api::UsersController < Api::BaseController
   include Rails.application.routes.url_helpers
-  before_action :authorize_owner!
-  before_action :set_user, only: [:update, :destroy, :update_profile]
+  before_action :authorize_owner!, only: [:update, :destroy]
+  before_action :set_user, only: [:update, :destroy]
 
   # GET /api/users.json
   def index
@@ -29,6 +29,7 @@ class Api::UsersController < Api::BaseController
 
   # POST /api/update_profile
   def update_profile
+    @user = current_user
     if @user.update(user_params)
       render json: @user
     else


### PR DESCRIPTION
## Summary
- relax user endpoint to allow non-owners access
- ensure profile updates apply only to the current user

## Testing
- `bundle exec rubocop -A --fail-level E` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_6890a1c278208322a29f77d6dee98d6b