### PR TITLE
Handle null task IDs when filtering tasks

### DIFF
--- a/app/javascript/components/Scheduler/EditTaskForm.jsx
+++ b/app/javascript/components/Scheduler/EditTaskForm.jsx
@@ -40,7 +40,10 @@ export default function EditTaskForm({ task, developers, dates, types, tasks, on
   };
 
   const filteredTasks = tasks.filter(t =>
-    t.task_id.toLowerCase().includes(taskSearch.toLowerCase())
+    (t.task_id ?? '')
+      .toString()
+      .toLowerCase()
+      .includes(taskSearch.toLowerCase())
   );
 
   return (


### PR DESCRIPTION
## Summary
- avoid `toLowerCase` on null task IDs in `EditTaskForm`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `bundle exec rake test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6890bc67cb4c83228f46ae38c2ae55f5