### PR TITLE
Shrink TodoBoard card and layout spacing

### DIFF
--- a/app/javascript/components/TodoBoard/KanbanColumn.jsx
+++ b/app/javascript/components/TodoBoard/KanbanColumn.jsx
@@ -5,31 +5,31 @@ import TaskCard from './TaskCard';
 
 const KanbanColumn = ({ columnId, column, tasks, onDelete, onUpdate }) => {
   const columnStyles = {
-    'todo': 'border-t-4 border-[var(--theme-color)]',
-    'inprogress': 'border-t-4 border-yellow-500',
-    'completed': 'border-t-4 border-green-500'
+    'todo': 'border-t-2 border-[var(--theme-color)]',
+    'inprogress': 'border-t-2 border-yellow-500',
+    'completed': 'border-t-2 border-green-500'
   };
   
   return (
     <Droppable key={columnId} droppableId={columnId}>
       {(provided, snapshot) => (
         <div
-          className={`bg-gray-100 rounded-xl p-4 flex flex-col ${snapshot.isDraggingOver ? 'bg-gray-200' : ''} ${columnStyles[columnId] || ''}`}
+          className={`bg-gray-100 rounded-lg p-2 flex flex-col ${snapshot.isDraggingOver ? 'bg-gray-200' : ''} ${columnStyles[columnId] || ''}`}
           ref={provided.innerRef}
           {...provided.droppableProps}
         >
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg font-bold text-gray-800 flex items-center">
+          <div className="flex justify-between items-center mb-2">
+            <h2 className="text-base font-semibold text-gray-800 flex items-center">
               {column.name}
-              <span className="text-sm font-semibold text-gray-500 ml-3 bg-gray-200 px-2 py-1 rounded-full">
+              <span className="text-xs font-semibold text-gray-500 ml-2 bg-gray-200 px-1.5 py-0.5 rounded-full">
                 {tasks.length}
               </span>
             </h2>
           </div>
-          <div className="flex-grow min-h-[250px] overflow-y-auto">
+          <div className="flex-grow min-h-[200px] overflow-y-auto">
             {tasks.length === 0 && (
               <div className="flex items-center justify-center h-full">
-                <p className="text-sm italic text-gray-500">No tasks here.</p>
+                <p className="text-xs italic text-gray-500">No tasks here.</p>
               </div>
             )}
             

--- a/app/javascript/components/TodoBoard/TaskCard.jsx
+++ b/app/javascript/components/TodoBoard/TaskCard.jsx
@@ -84,9 +84,9 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
   );
 
   const renderTaskDetails = () => (
-    <div className="space-y-3">
+    <div className="space-y-2">
         <div className="flex justify-between items-start">
-            <span className="font-semibold text-lg text-[var(--theme-color)] transition-colors">
+            <span className="font-semibold text-base text-[var(--theme-color)] transition-colors">
               {item.task_url ? (
                 <a href={item.task_url} target="_blank" rel="noopener noreferrer" className="hover:underline">
                   {item.task_id || item.title}
@@ -95,19 +95,19 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
                 item.task_id || item.title
               )}
             </span>
-            <div className="flex items-center gap-2">
-                <button onClick={() => setIsEditing(true)} className="text-gray-400 hover:text-[var(--theme-color)] transition-colors" title="Edit"><FiEdit2 size={18} /></button>
-                <button onClick={() => onDelete(columnId, item.id)} className="text-gray-400 hover:text-red-600 transition-colors" title="Delete"><FiTrash2 size={18} /></button>
+            <div className="flex items-center gap-1">
+                <button onClick={() => setIsEditing(true)} className="text-gray-400 hover:text-[var(--theme-color)] transition-colors" title="Edit"><FiEdit2 size={16} /></button>
+                <button onClick={() => onDelete(columnId, item.id)} className="text-gray-400 hover:text-red-600 transition-colors" title="Delete"><FiTrash2 size={16} /></button>
             </div>
         </div>
-        <p className="text-gray-600 text-sm">{item.description || item.title || 'No Description'}</p>
+        <p className="text-gray-600 text-xs">{item.description || item.title || 'No Description'}</p>
         
         {item.tags && item.tags.length > 0 && (
-            <div className="flex items-center text-sm text-gray-500 mt-2">
-                <FiTag className="mr-2" />
+            <div className="flex items-center text-xs text-gray-500 mt-1">
+                <FiTag className="mr-1" />
                 <div className="flex flex-wrap gap-1">
                     {item.tags.map((tag, tagIndex) => (
-                        <span key={tagIndex} className="bg-[rgb(var(--theme-color-rgb)/0.1)] text-[var(--theme-color)] text-xs font-medium px-2.5 py-0.5 rounded-full">
+                        <span key={tagIndex} className="bg-[rgb(var(--theme-color-rgb)/0.1)] text-[var(--theme-color)] text-[10px] font-medium px-1.5 py-0.5 rounded-full">
                             {tag}
                         </span>
                     ))}
@@ -115,14 +115,14 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
             </div>
         )}
         
-        <div className="border-t border-gray-200 mt-3 pt-3">
-            <div className="flex justify-between items-center text-sm text-gray-500">
+        <div className="border-t border-gray-200 mt-2 pt-2">
+            <div className="flex justify-between items-center text-xs text-gray-500">
                 <div className="flex items-center">
-                    <FiCalendar className="mr-2" />
+                    <FiCalendar className="mr-1" />
                     <span>End Date: {item.end_date || "Not set"}</span>
                 </div>
                 <div className="flex items-center">
-                    <FiUser className="mr-2" />
+                    <FiUser className="mr-1" />
                     <span>{item.assigned_user ? item.assigned_user.first_name || item.assigned_user.email : 'Unassigned'}</span>
                 </div>
             </div>
@@ -134,13 +134,13 @@ const TaskCard = ({ item, index, columnId, onDelete, onUpdate }) => {
     <Draggable key={String(item.id)} draggableId={String(item.id)} index={index}>
       {(provided, snapshot) => (
         <div
-          className={`bg-white p-4 mb-4 rounded-lg shadow-md border-l-4 ${
+          className={`bg-white p-2 mb-2 rounded shadow border-l-2 ${
             {
               todo: 'border-[var(--theme-color)]',
               inprogress: 'border-yellow-500',
               completed: 'border-green-500'
             }[columnId]
-          } hover:shadow-xl transition-shadow transform hover:-translate-y-1 ${snapshot.isDragging ? 'ring-2 ring-[var(--theme-color)]' : ''}`}
+          } hover:shadow-lg transition-shadow transform hover:-translate-y-1 ${snapshot.isDragging ? 'ring-2 ring-[var(--theme-color)]' : ''}`}
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}

--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -231,45 +231,45 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
   }, {});
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-sky-100 p-8 font-sans text-gray-800">
-      <div className="max-w-8xl mx-auto bg-white rounded-xl shadow-lg p-4">
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-sky-100 p-4 font-sans text-gray-800">
+      <div className="max-w-6xl mx-auto bg-white rounded-lg shadow-md p-2">
         <Toaster position="top-right" />
-      <header className="mb-4">
+      <header className="mb-2">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
-          <div className="mb-4 sm:mb-0">
-            <h1 className="text-2xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-[var(--theme-color)] to-[var(--theme-color)] flex items-center">
-              <Squares2X2Icon className="h-7 w-7 mr-2" />Taskboard
+          <div className="mb-2 sm:mb-0">
+            <h1 className="text-xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-[var(--theme-color)] to-[var(--theme-color)] flex items-center">
+              <Squares2X2Icon className="h-5 w-5 mr-1" />Taskboard
             </h1>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
             <button
               onClick={() => setShowForm(true)}
-              className="flex items-center gap-2 bg-[var(--theme-color)] hover:brightness-110 text-white font-semibold py-2 px-4 rounded-lg shadow-md transition-all transform hover:scale-105"
+              className="flex items-center gap-1 bg-[var(--theme-color)] hover:brightness-110 text-white font-semibold py-1 px-2 rounded-md shadow transition-all transform hover:scale-105"
             >
-              <PlusIcon className="h-5 w-5" />
+              <PlusIcon className="h-4 w-4" />
               <span>Add Task</span>
             </button>
-            <div className="flex bg-white rounded-full p-1 shadow-md border border-gray-200">
+            <div className="flex bg-white rounded-full p-0.5 shadow border border-gray-200">
               <button
-                className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ease-in-out ${
+                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-300 ease-in-out ${
                   taskView === 'all'
                     ? 'bg-[var(--theme-color)] text-white shadow'
                     : 'text-gray-600 hover:bg-[rgb(var(--theme-color-rgb)/0.1)]'
                 }`}
                 onClick={() => setTaskView('all')}
               >
-                <Squares2X2Icon className="h-5 w-5"/>
+                <Squares2X2Icon className="h-4 w-4"/>
                 All Tasks
               </button>
               <button
-                className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 ease-in-out ml-1 ${
+                className={`flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-medium transition-all duration-300 ease-in-out ml-1 ${
                   taskView === 'my'
                     ? 'bg-[var(--theme-color)] text-white shadow'
                     : 'text-gray-600 hover:bg-[rgb(var(--theme-color-rgb)/0.1)]'
                 }`}
                 onClick={() => setTaskView('my')}
               >
-                <UserIcon className="h-5 w-5"/>
+                <UserIcon className="h-4 w-4"/>
                 My Tasks
               </button>
             </div>
@@ -281,7 +281,7 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
         <TaskForm onAddTask={handleAddTask} onCancel={() => setShowForm(false)} />
       </Modal>
 
-      <div className="grid md:grid-cols-2 gap-6 mb-8">
+      <div className="grid md:grid-cols-2 gap-4 mb-4">
         <Heatmap columns={columns} view={taskView} onViewChange={setTaskView} sprint={currentSprint} />
         <ProgressPieChart columns={applyView(columns)} />
       </div>
@@ -296,7 +296,7 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
       </div> */}
       
       <DragDropContext onDragEnd={onDragEnd}>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
             {Object.entries(filteredColumns).map(([columnId, column]) => (
                 <KanbanColumn
                     key={columnId}


### PR DESCRIPTION
## Summary
- tighten TaskCard padding, fonts and borders for more compact cards
- slim down KanbanColumn spacing and border widths
- reduce TodoBoard layout padding and button sizes

## Testing
- `npm run build`
- `bundle install` *(fails: Ruby version 3.2.3 does not satisfy Gemfile 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6890a5a557fc8322bb12288155e99162