### PR TITLE
Add work log models and API endpoints

### DIFF
--- a/app/controllers/api/work_categories_controller.rb
+++ b/app/controllers/api/work_categories_controller.rb
@@ -1,0 +1,39 @@
+class Api::WorkCategoriesController < Api::BaseController
+  before_action :set_category, only: [:update, :destroy]
+
+  def index
+    render json: WorkCategory.all
+  end
+
+  def create
+    category = WorkCategory.new(category_params)
+    if category.save
+      render json: category, status: :created
+    else
+      render json: { errors: category.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @category.update(category_params)
+      render json: @category
+    else
+      render json: { errors: @category.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @category.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_category
+    @category = WorkCategory.find(params[:id])
+  end
+
+  def category_params
+    params.require(:work_category).permit(:name, :color, :hex)
+  end
+end

--- a/app/controllers/api/work_logs_controller.rb
+++ b/app/controllers/api/work_logs_controller.rb
@@ -1,0 +1,59 @@
+class Api::WorkLogsController < Api::BaseController
+  before_action :set_work_log, only: [:update, :destroy]
+
+  def index
+    logs = current_user.work_logs.includes(:category, :priority, :tags)
+    logs = logs.where(log_date: params[:date]) if params[:date].present?
+    if params[:from].present? && params[:to].present?
+      logs = logs.where(log_date: params[:from]..params[:to])
+    end
+    render json: logs.map { |log| serialize_log(log) }
+  end
+
+  def create
+    log = current_user.work_logs.new(work_log_params)
+    assign_tags(log)
+    if log.save
+      render json: serialize_log(log), status: :created
+    else
+      render json: { errors: log.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    assign_tags(@work_log)
+    if @work_log.update(work_log_params)
+      render json: serialize_log(@work_log)
+    else
+      render json: { errors: @work_log.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @work_log.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_work_log
+    @work_log = current_user.work_logs.find(params[:id])
+  end
+
+  def work_log_params
+    params.require(:work_log).permit(:title, :description, :log_date, :start_time, :end_time, :category_id, :priority_id, :actual_minutes)
+  end
+
+  def assign_tags(log)
+    names = params[:work_log][:tags] || []
+    log.tags = names.map { |n| WorkTag.find_or_create_by(name: n) }
+  end
+
+  def serialize_log(log)
+    log.as_json(include: {
+      category: { only: [:id, :name, :color, :hex] },
+      priority: { only: [:id, :name, :color, :hex] },
+      tags: { only: [:id, :name] }
+    })
+  end
+end

--- a/app/controllers/api/work_priorities_controller.rb
+++ b/app/controllers/api/work_priorities_controller.rb
@@ -1,0 +1,39 @@
+class Api::WorkPrioritiesController < Api::BaseController
+  before_action :set_priority, only: [:update, :destroy]
+
+  def index
+    render json: WorkPriority.all
+  end
+
+  def create
+    priority = WorkPriority.new(priority_params)
+    if priority.save
+      render json: priority, status: :created
+    else
+      render json: { errors: priority.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @priority.update(priority_params)
+      render json: @priority
+    else
+      render json: { errors: @priority.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @priority.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_priority
+    @priority = WorkPriority.find(params[:id])
+  end
+
+  def priority_params
+    params.require(:work_priority).permit(:name, :color, :hex)
+  end
+end

--- a/app/controllers/api/work_tags_controller.rb
+++ b/app/controllers/api/work_tags_controller.rb
@@ -1,0 +1,39 @@
+class Api::WorkTagsController < Api::BaseController
+  before_action :set_tag, only: [:update, :destroy]
+
+  def index
+    render json: WorkTag.all
+  end
+
+  def create
+    tag = WorkTag.new(tag_params)
+    if tag.save
+      render json: tag, status: :created
+    else
+      render json: { errors: tag.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @tag.update(tag_params)
+      render json: @tag
+    else
+      render json: { errors: @tag.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @tag.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_tag
+    @tag = WorkTag.find(params[:id])
+  end
+
+  def tag_params
+    params.require(:work_tag).permit(:name)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :posts, dependent: :destroy
   has_many :tasks, foreign_key: :assigned_to_user
   has_many :items
+  has_many :work_logs, dependent: :destroy
   has_many :team_users, dependent: :destroy
   has_many :teams, through: :team_users
   has_many :user_roles, dependent: :destroy

--- a/app/models/work_category.rb
+++ b/app/models/work_category.rb
@@ -1,0 +1,7 @@
+class WorkCategory < ApplicationRecord
+  include UserStampable
+
+  has_many :work_logs, dependent: :nullify
+
+  validates :name, presence: true
+end

--- a/app/models/work_log.rb
+++ b/app/models/work_log.rb
@@ -1,0 +1,12 @@
+class WorkLog < ApplicationRecord
+  include UserStampable
+
+  belongs_to :user
+  belongs_to :category, class_name: 'WorkCategory', optional: true
+  belongs_to :priority, class_name: 'WorkPriority', optional: true
+
+  has_many :work_log_tags, dependent: :destroy
+  has_many :tags, through: :work_log_tags, class_name: 'WorkTag'
+
+  validates :title, :log_date, :start_time, :end_time, presence: true
+end

--- a/app/models/work_log_tag.rb
+++ b/app/models/work_log_tag.rb
@@ -1,0 +1,4 @@
+class WorkLogTag < ApplicationRecord
+  belongs_to :work_log
+  belongs_to :work_tag
+end

--- a/app/models/work_priority.rb
+++ b/app/models/work_priority.rb
@@ -1,0 +1,7 @@
+class WorkPriority < ApplicationRecord
+  include UserStampable
+
+  has_many :work_logs, dependent: :nullify
+
+  validates :name, presence: true
+end

--- a/app/models/work_tag.rb
+++ b/app/models/work_tag.rb
@@ -1,0 +1,8 @@
+class WorkTag < ApplicationRecord
+  include UserStampable
+
+  has_many :work_log_tags, dependent: :destroy
+  has_many :work_logs, through: :work_log_tags
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,11 @@ Rails.application.routes.draw do
 
     resources :roles, only: [:index]
 
+    resources :work_categories, only: [:index, :create, :update, :destroy]
+    resources :work_priorities, only: [:index, :create, :update, :destroy]
+    resources :work_tags, only: [:index, :create, :update, :destroy]
+    resources :work_logs, only: [:index, :create, :update, :destroy]
+
 
     resources :contacts, only: [:create]
 

--- a/db/migrate/20260901010000_create_work_categories.rb
+++ b/db/migrate/20260901010000_create_work_categories.rb
@@ -1,0 +1,12 @@
+class CreateWorkCategories < ActiveRecord::Migration[7.1]
+  def change
+    create_table :work_categories do |t|
+      t.string :name, null: false
+      t.string :color
+      t.string :hex
+      t.integer :created_by
+      t.integer :updated_by
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260901010100_create_work_priorities.rb
+++ b/db/migrate/20260901010100_create_work_priorities.rb
@@ -1,0 +1,12 @@
+class CreateWorkPriorities < ActiveRecord::Migration[7.1]
+  def change
+    create_table :work_priorities do |t|
+      t.string :name, null: false
+      t.string :color
+      t.string :hex
+      t.integer :created_by
+      t.integer :updated_by
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260901010200_create_work_tags.rb
+++ b/db/migrate/20260901010200_create_work_tags.rb
@@ -1,0 +1,11 @@
+class CreateWorkTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :work_tags do |t|
+      t.string :name, null: false
+      t.integer :created_by
+      t.integer :updated_by
+      t.timestamps
+    end
+    add_index :work_tags, :name, unique: true
+  end
+end

--- a/db/migrate/20260901010300_create_work_logs.rb
+++ b/db/migrate/20260901010300_create_work_logs.rb
@@ -1,0 +1,18 @@
+class CreateWorkLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :work_logs do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :log_date, null: false
+      t.time :start_time, null: false
+      t.time :end_time, null: false
+      t.string :title, null: false
+      t.text :description
+      t.references :category, foreign_key: { to_table: :work_categories }
+      t.references :priority, foreign_key: { to_table: :work_priorities }
+      t.integer :actual_minutes, default: 0
+      t.integer :created_by
+      t.integer :updated_by
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260901010400_create_work_log_tags.rb
+++ b/db/migrate/20260901010400_create_work_log_tags.rb
@@ -1,0 +1,10 @@
+class CreateWorkLogTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :work_log_tags do |t|
+      t.references :work_log, null: false, foreign_key: true
+      t.references :work_tag, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :work_log_tags, [:work_log_id, :work_tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_09_01_009000) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_01_010400) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -220,6 +220,64 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_01_009000) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "work_categories", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "color"
+    t.string "hex"
+    t.integer "created_by"
+    t.integer "updated_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "work_log_tags", force: :cascade do |t|
+    t.bigint "work_log_id", null: false
+    t.bigint "work_tag_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["work_log_id", "work_tag_id"], name: "index_work_log_tags_on_work_log_id_and_work_tag_id", unique: true
+    t.index ["work_log_id"], name: "index_work_log_tags_on_work_log_id"
+    t.index ["work_tag_id"], name: "index_work_log_tags_on_work_tag_id"
+  end
+
+  create_table "work_logs", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.date "log_date", null: false
+    t.time "start_time", null: false
+    t.time "end_time", null: false
+    t.string "title", null: false
+    t.text "description"
+    t.bigint "category_id"
+    t.bigint "priority_id"
+    t.integer "actual_minutes", default: 0
+    t.integer "created_by"
+    t.integer "updated_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_work_logs_on_category_id"
+    t.index ["priority_id"], name: "index_work_logs_on_priority_id"
+    t.index ["user_id"], name: "index_work_logs_on_user_id"
+  end
+
+  create_table "work_priorities", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "color"
+    t.string "hex"
+    t.integer "created_by"
+    t.integer "updated_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "work_tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "created_by"
+    t.integer "updated_by"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_work_tags_on_name", unique: true
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "items", "users"
@@ -238,4 +296,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_01_009000) do
   add_foreign_key "teams", "users", column: "owner_id"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "users"
+  add_foreign_key "work_log_tags", "work_logs"
+  add_foreign_key "work_log_tags", "work_tags"
+  add_foreign_key "work_logs", "users"
+  add_foreign_key "work_logs", "work_categories", column: "category_id"
+  add_foreign_key "work_logs", "work_priorities", column: "priority_id"
 end


### PR DESCRIPTION
## Summary
- add WorkLog, WorkCategory, WorkPriority, and WorkTag models
- expose API endpoints for managing work logs, categories, priorities, and tags
- wire up routes and schema for work log tracking

## Testing
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `bundle exec rails db:migrate` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_68920a954c0c83228998aff87eb89c5e