### PR TITLE
Persist work log items and notes in database

### DIFF
--- a/app/controllers/api/work_notes_controller.rb
+++ b/app/controllers/api/work_notes_controller.rb
@@ -1,0 +1,44 @@
+class Api::WorkNotesController < Api::BaseController
+  before_action :set_note, only: [:update, :destroy]
+
+  def index
+    if params[:date].present?
+      note = current_user.work_notes.find_by(note_date: params[:date])
+      render json: note || {}
+    else
+      render json: current_user.work_notes
+    end
+  end
+
+  def create
+    note = current_user.work_notes.new(work_note_params)
+    if note.save
+      render json: note, status: :created
+    else
+      render json: { errors: note.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @note.update(work_note_params)
+      render json: @note
+    else
+      render json: { errors: @note.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @note.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_note
+    @note = current_user.work_notes.find(params[:id])
+  end
+
+  def work_note_params
+    params.require(:work_note).permit(:note_date, :content)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@ class User < ApplicationRecord
   has_many :tasks, foreign_key: :assigned_to_user
   has_many :items
   has_many :work_logs, dependent: :destroy
+  has_many :work_notes, dependent: :destroy
   has_many :team_users, dependent: :destroy
   has_many :teams, through: :team_users
   has_many :user_roles, dependent: :destroy

--- a/app/models/work_note.rb
+++ b/app/models/work_note.rb
@@ -1,0 +1,7 @@
+class WorkNote < ApplicationRecord
+  include UserStampable
+
+  belongs_to :user
+
+  validates :note_date, presence: true
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,6 +86,7 @@ Rails.application.routes.draw do
     resources :work_priorities, only: [:index, :create, :update, :destroy]
     resources :work_tags, only: [:index, :create, :update, :destroy]
     resources :work_logs, only: [:index, :create, :update, :destroy]
+    resources :work_notes, only: [:index, :create, :update, :destroy]
 
 
     resources :contacts, only: [:create]

--- a/db/migrate/20260901010500_create_work_notes.rb
+++ b/db/migrate/20260901010500_create_work_notes.rb
@@ -1,0 +1,13 @@
+class CreateWorkNotes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :work_notes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.date :note_date, null: false
+      t.text :content
+      t.integer :created_by
+      t.integer :updated_by
+      t.timestamps
+    end
+    add_index :work_notes, [:user_id, :note_date], unique: true
+  end
+end


### PR DESCRIPTION
## Summary
- Replace WorkLog localStorage persistence with API calls for tasks, tags and daily notes
- Add WorkNote model, controller and routes to store notes per day
- Track work notes per user and load priorities, categories and tags from backend

## Testing
- `bin/rails db:migrate` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `yarn test` *(fails: Couldn't find a script named "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892ee813b7c8322af06008d155870c0