### PR TITLE
Align add-member form button with fields

### DIFF
--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -724,7 +724,7 @@ const Projects = () => {
 
                                 {/* Add Member Form */}
                                 {canManageMembers && (
-                                    <form onSubmit={handleAddMember} className="mt-8 pt-6 border-t border-gray-200 grid grid-cols-1 md:grid-cols-5 gap-4 items-end">
+                                    <form onSubmit={handleAddMember} className="mt-8 pt-6 border-t border-gray-200 grid grid-cols-1 md:grid-cols-6 gap-4 items-end">
                                         <div className="md:col-span-2">
                                             <label className="block text-sm font-medium text-gray-700 mb-1">Select Users to Add</label>
                                             <UserMultiSelect
@@ -779,7 +779,7 @@ const Projects = () => {
                                         </div>
                                         <button
                                             type="submit"
-                                            className="md:col-span-5 lg:col-span-1 px-5 py-2.5 bg-[var(--theme-color)] text-white rounded-lg hover:brightness-110 transition-colors font-semibold shadow-md flex items-center justify-center gap-2 active:scale-95 transform mt-4 md:mt-0"
+                                            className="md:col-span-1 px-5 py-2.5 bg-[var(--theme-color)] text-white rounded-lg hover:brightness-110 transition-colors font-semibold shadow-md flex items-center justify-center gap-2 whitespace-nowrap active:scale-95 transform mt-4 md:mt-0"
                                             disabled={isSaving || selectedUsersToAdd.length === 0}
                                         >
                                             {isSaving ? (

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -488,7 +488,7 @@ const Teams = () => {
 
                                 {/* Add Member Form */}
                                 {canManageMembers && (
-                                    <form onSubmit={handleAddMember} className="mt-8 pt-6 border-t border-gray-200 grid grid-cols-1 md:grid-cols-3 gap-4 items-end">
+                                    <form onSubmit={handleAddMember} className="mt-8 pt-6 border-t border-gray-200 grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
                                         <div className="md:col-span-2">
                                             <label className="block text-sm font-medium text-gray-700 mb-1">Select Users to Add</label>
                                             <UserMultiSelect
@@ -513,7 +513,7 @@ const Teams = () => {
                                         </div>
                                         <button
                                             type="submit"
-                                            className="md:col-span-3 lg:col-span-1 px-5 py-2.5 bg-theme text-white rounded-lg hover:brightness-110 transition-colors font-semibold shadow-md flex items-center justify-center gap-2 active:scale-95 transform mt-4 md:mt-0"
+                                            className="md:col-span-1 px-5 py-2.5 bg-theme text-white rounded-lg hover:brightness-110 transition-colors font-semibold shadow-md flex items-center justify-center gap-2 whitespace-nowrap active:scale-95 transform mt-4 md:mt-0"
                                             disabled={isSaving || selectedUsersToAdd.length === 0}
                                         >
                                             {isSaving ? (


### PR DESCRIPTION
## Summary
- ensure add-member button aligns with input fields on project and team pages
- prevent button text from wrapping to multiple lines

## Testing
- `bundle exec rails test` *(fails: command not found)*
- `bundle install` *(fails: Ruby version mismatch 3.3.0 required, 3.2.3 installed)*
- `yarn install --immutable` *(fails: RequestError 403)*

------
https://chatgpt.com/codex/tasks/task_e_6892f096ef88832292b5325e1b7b368f