### PR TITLE
Fix work log tag association and seed default tags

### DIFF
--- a/app/controllers/api/work_logs_controller.rb
+++ b/app/controllers/api/work_logs_controller.rb
@@ -11,7 +11,7 @@ class Api::WorkLogsController < Api::BaseController
   end
 
   def create
-    log = current_user.work_logs.new(work_log_params)
+    log = current_user.work_logs.new(work_log_params.except(:tags))
     assign_tags(log)
     if log.save
       render json: serialize_log(log), status: :created
@@ -22,7 +22,7 @@ class Api::WorkLogsController < Api::BaseController
 
   def update
     assign_tags(@work_log)
-    if @work_log.update(work_log_params)
+    if @work_log.update(work_log_params.except(:tags))
       render json: serialize_log(@work_log)
     else
       render json: { errors: @work_log.errors.full_messages }, status: :unprocessable_entity
@@ -41,11 +41,21 @@ class Api::WorkLogsController < Api::BaseController
   end
 
   def work_log_params
-    params.require(:work_log).permit(:title, :description, :log_date, :start_time, :end_time, :category_id, :priority_id, :actual_minutes)
+    params.require(:work_log).permit(
+      :title,
+      :description,
+      :log_date,
+      :start_time,
+      :end_time,
+      :category_id,
+      :priority_id,
+      :actual_minutes,
+      tags: []
+    )
   end
 
   def assign_tags(log)
-    names = params[:work_log][:tags] || []
+    names = work_log_params[:tags] || []
     log.tags = names.map { |n| WorkTag.find_or_create_by(name: n) }
   end
 

--- a/app/models/work_log.rb
+++ b/app/models/work_log.rb
@@ -6,7 +6,7 @@ class WorkLog < ApplicationRecord
   belongs_to :priority, class_name: 'WorkPriority', optional: true
 
   has_many :work_log_tags, dependent: :destroy
-  has_many :tags, through: :work_log_tags, class_name: 'WorkTag'
+  has_many :tags, through: :work_log_tags, source: :work_tag, class_name: 'WorkTag'
 
   validates :title, :log_date, :start_time, :end_time, presence: true
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,3 +57,15 @@ end
     c.hex = category[:hex]
   end
 end
+
+# Default Work Tags
+[
+  'Team',
+  'Sync Frontend',
+  'React UI/UX',
+  'Figma Backend',
+  'Code Review Frontend',
+  'Research'
+].each do |tag_name|
+  WorkTag.find_or_create_by!(name: tag_name)
+end


### PR DESCRIPTION
## Summary
- fix work log tag association to use work_tag source
- permit tags in work log params and handle assignment safely
- seed default work tags for new installations

## Testing
- `bundle exec rails db:prepare` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6892f51b90d48322a3c7a7f79c53e254