### PR TITLE
Format work log times as local strings

### DIFF
--- a/app/controllers/api/work_logs_controller.rb
+++ b/app/controllers/api/work_logs_controller.rb
@@ -64,6 +64,9 @@ class Api::WorkLogsController < Api::BaseController
       category: { only: [:id, :name, :color, :hex] },
       priority: { only: [:id, :name, :color, :hex] },
       tags: { only: [:id, :name] }
-    })
+    }).merge(
+      start_time: log.start_time&.strftime("%H:%M"),
+      end_time: log.end_time&.strftime("%H:%M")
+    )
   end
 end


### PR DESCRIPTION
## Summary
- return start and end times as plain `HH:MM` strings in WorkLog responses

## Testing
- `bundle exec rake test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6892f89929e0832286d03db82925c09f