### PR TITLE
Prevent scheduler task search crash on null IDs

### DIFF
--- a/app/javascript/components/Scheduler/AddTaskForm.jsx
+++ b/app/javascript/components/Scheduler/AddTaskForm.jsx
@@ -46,8 +46,12 @@ export default function AddTaskForm({developers, dates, types, tasks, onAddTask}
     setTaskQuery('');
   };
 
+  // Safely match tasks that may not have a task_id
   const filteredTasks = tasks.filter(t =>
-    t.task_id.toLowerCase().includes(taskQuery.toLowerCase())
+    (t.task_id ?? '')
+      .toString()
+      .toLowerCase()
+      .includes(taskQuery.toLowerCase())
   );
 
   return (


### PR DESCRIPTION
## Summary
- avoid calling `toLowerCase` on null task IDs when filtering in add log form

## Testing
- `npm run build`
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6893003856548322aaadeb19d24adc25