### PR TITLE
Add theme color settings page

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -20,6 +20,7 @@ import Vault from "../pages/Vault";
 import Legal from "../pages/Legal";
 import SprintDashboard from "../pages/SprintDashboard";
 import WorkLog from "../pages/WorkLog";
+import Settings from "../pages/Settings";
 
 const App = () => {
   return (
@@ -48,6 +49,7 @@ const App = () => {
               <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><SprintDashboard /></ProjectMemberRoute>} />
               <Route path="/users" element={<PrivateRoute ownerOnly><Users /></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
+              <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
               </Routes>
 
           {/* ✅ Footer */}

--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -20,7 +20,7 @@ export function AuthProvider({ children }) {
     document.documentElement.style.setProperty('--theme-color', color);
     document.documentElement.style.setProperty('--theme-color-rgb', toRgb(color));
     document.documentElement.style.setProperty('--theme-color-light', lightenColor(color));
-  }, [user]);
+  }, [user?.color_theme]);
 
   // Clear timer on unmount
   useEffect(() => () => clearTimeout(refreshTimer.current), []);

--- a/app/javascript/pages/Settings.jsx
+++ b/app/javascript/pages/Settings.jsx
@@ -1,0 +1,66 @@
+import React, { useContext, useState } from "react";
+import api from "../components/api";
+import { AuthContext } from "../context/AuthContext";
+import { COLOR_MAP } from "/utils/theme";
+
+const Settings = () => {
+  const { user, setUser } = useContext(AuthContext);
+  const initialColor = COLOR_MAP[user?.color_theme] || user?.color_theme || "#3b82f6";
+  const [color, setColor] = useState(initialColor);
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    try {
+      await api.post("/update_profile", { auth: { color_theme: color } });
+      setUser((prev) => ({ ...prev, color_theme: color }));
+    } catch (err) {
+      console.error("Failed to update color theme", err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto py-8 px-4">
+      <h1 className="text-2xl font-semibold mb-6">Settings</h1>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Theme Color
+          </label>
+          <div className="flex items-center gap-4">
+            <input
+              type="color"
+              value={color}
+              onChange={(e) => setColor(e.target.value)}
+              className="w-16 h-10 p-0 border-0 bg-transparent cursor-pointer rounded-lg overflow-hidden"
+            />
+            <div className="flex gap-2">
+              {Object.entries(COLOR_MAP).map(([name, value]) => (
+                <button
+                  key={name}
+                  type="button"
+                  onClick={() => setColor(value)}
+                  className="w-6 h-6 rounded-full"
+                  style={{ backgroundColor: value }}
+                  aria-label={name}
+                />
+              ))}
+            </div>
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={saving}
+          className="px-4 py-2 rounded-lg text-white bg-[var(--theme-color)] disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Save"}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add user settings page with theme color picker and palette
- persist selected theme color via `/api/update_profile`
- reapply CSS variables when `color_theme` changes

## Testing
- `npm test` (fails: Missing script "test")
- `bundle exec rails test` (fails: bundler: command not found: rails)
- `bundle install` (fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)

------
https://chatgpt.com/codex/tasks/task_e_68947bef7ed0832291b3179adbccdf03