### PR TITLE
Add dark mode user preference

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -138,7 +138,8 @@ class Api::AuthController < Api::BaseController
       :uid,
       :profile_picture,
       :cover_photo,
-      :color_theme
+      :color_theme,
+      :dark_mode
     )
     permitted.delete(:profile_picture) if permitted[:profile_picture] == "null"
     permitted.delete(:cover_photo) if permitted[:cover_photo] == "null"

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -44,7 +44,16 @@ class Api::UsersController < Api::BaseController
   end
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :date_of_birth, :profile_picture, :cover_photo)
+    params.require(:user).permit(
+      :first_name,
+      :last_name,
+      :email,
+      :date_of_birth,
+      :profile_picture,
+      :cover_photo,
+      :color_theme,
+      :dark_mode
+    )
   end
 
   def serialize_user(user)

--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -20,7 +20,13 @@ export function AuthProvider({ children }) {
     document.documentElement.style.setProperty('--theme-color', color);
     document.documentElement.style.setProperty('--theme-color-rgb', toRgb(color));
     document.documentElement.style.setProperty('--theme-color-light', lightenColor(color));
-  }, [user?.color_theme]);
+
+    if (user?.dark_mode) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  }, [user?.color_theme, user?.dark_mode]);
 
   // Clear timer on unmount
   useEffect(() => () => clearTimeout(refreshTimer.current), []);

--- a/app/javascript/pages/Settings.jsx
+++ b/app/javascript/pages/Settings.jsx
@@ -7,14 +7,15 @@ const Settings = () => {
   const { user, setUser } = useContext(AuthContext);
   const initialColor = COLOR_MAP[user?.color_theme] || user?.color_theme || "#3b82f6";
   const [color, setColor] = useState(initialColor);
+  const [darkMode, setDarkMode] = useState(user?.dark_mode || false);
   const [saving, setSaving] = useState(false);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSaving(true);
     try {
-      await api.post("/update_profile", { auth: { color_theme: color } });
-      setUser((prev) => ({ ...prev, color_theme: color }));
+      await api.post("/update_profile", { auth: { color_theme: color, dark_mode: darkMode } });
+      setUser((prev) => ({ ...prev, color_theme: color, dark_mode: darkMode }));
     } catch (err) {
       console.error("Failed to update color theme", err);
     } finally {
@@ -50,6 +51,18 @@ const Settings = () => {
               ))}
             </div>
           </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            id="dark-mode"
+            type="checkbox"
+            checked={darkMode}
+            onChange={(e) => setDarkMode(e.target.checked)}
+            className="h-4 w-4"
+          />
+          <label htmlFor="dark-mode" className="text-sm font-medium text-gray-700">
+            Dark Mode
+          </label>
         </div>
         <button
           type="submit"

--- a/db/migrate/20260902000000_add_dark_mode_to_users.rb
+++ b/db/migrate/20260902000000_add_dark_mode_to_users.rb
@@ -1,0 +1,5 @@
+class AddDarkModeToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :dark_mode, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_09_01_010500) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_02_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -217,6 +217,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_01_010500) do
     t.string "unconfirmed_email"
     t.string "status", default: "new", null: false
     t.string "color_theme", default: "blue"
+    t.boolean "dark_mode", default: false, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: [
     "./app/javascript/**/*.{js,jsx,ts,tsx}",
     "./app/views/**/*.html.erb",


### PR DESCRIPTION
## Summary
- allow users to store a `dark_mode` preference
- toggle dark mode in settings and apply it in the auth context
- enable Tailwind CSS class-based dark mode

## Testing
- `bin/rails db:migrate` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `yarn build` *(fails: app@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68947fa298588322926b534f5ad03498