### PR TITLE
fix dark mode persistence

### DIFF
--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -60,8 +60,8 @@ const Profile = () => {
       const { data } = await fetchUserInfo();
       const theme = COLOR_MAP[data.user.color_theme] || data.user.color_theme || '#3b82f6';
       const updatedUser = { ...data.user, color_theme: theme };
-      setUser(updatedUser);
-      setAuthUser(updatedUser);
+      setUser((prev) => ({ ...prev, ...updatedUser }));
+      setAuthUser((prev) => ({ ...(prev || {}), ...updatedUser }));
 
       const basicTeams = Array.isArray(data.teams) ? data.teams : [];
       try {

--- a/app/javascript/pages/Settings.jsx
+++ b/app/javascript/pages/Settings.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect } from "react";
 import api from "../components/api";
 import { AuthContext } from "../context/AuthContext";
 import { COLOR_MAP } from "/utils/theme";
@@ -9,6 +9,10 @@ const Settings = () => {
   const [color, setColor] = useState(initialColor);
   const [darkMode, setDarkMode] = useState(user?.dark_mode || false);
   const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setDarkMode(user?.dark_mode || false);
+  }, [user?.dark_mode]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- preserve dark mode when refreshing profile info
- sync settings toggle with user preferences

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894823bd9e88322a480b634ce553fab