### PR TITLE
feat: apply theme color to knowledge and pdf pages

### DIFF
--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -141,7 +141,7 @@ const PdfPage = () => {
   };
 
   return (
-    <div className="font-inter flex flex-col min-h-screen items-center bg-gray-50 p-4 sm:p-6 lg:p-8">
+    <div className="font-inter flex flex-col min-h-screen items-center bg-[rgb(var(--theme-color-rgb)/0.1)] p-4 sm:p-6 lg:p-8">
       <header className="w-full max-w-6xl text-center mb-8">
         <h1 className="text-4xl font-bold text-[var(--theme-color)] mb-2">PDF Modifier</h1>
         <p className="text-lg text-gray-600">Your all-in-one online PDF editor. Upload, edit, and manage your documents with ease.</p>

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -57,7 +57,7 @@ export default function KnowledgeDashboard() {
     : cards.filter(card => card.category === activeCategory);
 
   return (
-    <div className="min-h-screen transition-colors duration-300 bg-gray-50 text-gray-900">
+    <div className="min-h-screen transition-colors duration-300 bg-[rgb(var(--theme-color-rgb)/0.1)] text-gray-900">
       {/* Header */}
       <header className="sticky top-0 z-10 backdrop-blur-md bg-white/80 border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-6 py-4 flex flex-col sm:flex-row justify-between items-center">


### PR DESCRIPTION
## Summary
- tint PDF editor page background with user-selected theme
- apply theme-colored background to knowledge dashboard

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894844503dc83228668c63a776c7fb6