### PR TITLE
Fix sprint selection to use current project sprint

### DIFF
--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -53,15 +53,21 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
     SchedulerAPI.getSprints(projectId)
       .then(res => {
         setSprints(res.data);
-        if (res.data.length) {
-          if(!sprintId) {
-            setSelectedSprintId(res.data[0].id);
-            onSprintChange && onSprintChange(res.data[0].id);
-          }
+        if (!sprintId && res.data.length) {
+          SchedulerAPI.getLastSprint(projectId)
+            .then(last => {
+              const defaultSprintId = last.data?.id || res.data[0].id;
+              setSelectedSprintId(defaultSprintId);
+              onSprintChange && onSprintChange(defaultSprintId);
+            })
+            .catch(() => {
+              setSelectedSprintId(res.data[0].id);
+              onSprintChange && onSprintChange(res.data[0].id);
+            });
         }
       })
       .catch(() => toast.error("Could not load sprints"));
-  }, [projectId]);
+  }, [projectId, sprintId]);
 
   useEffect(() => {
     const params = selectedSprintId ? { sprint_id: selectedSprintId, project_id: projectId } : { type: 'general' };


### PR DESCRIPTION
## Summary
- ensure TodoBoard selects the current sprint for a project instead of defaulting to the first sprint

## Testing
- `bin/rails test` *(fails: Ruby version 3.2.3 is not compatible with required 3.3.0)*
- `yarn test` *(fails: script "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_689592a5ec68832297b043533a91b543