### PR TITLE
Enable independent scroll for home page left sidebar

### DIFF
--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -181,7 +181,7 @@ const PostPage = () => {
         
         {/* Left Sidebar: At a Glance */}
         <aside className="lg:col-span-3">
-            <div className="space-y-8 sticky top-24">
+            <div className="space-y-8 sticky top-24 max-h-[calc(100vh-6rem)] overflow-y-auto">
                 <div className="p-5 bg-white rounded-2xl border border-slate-200 shadow-sm">
                     <h2 className="text-lg font-bold text-slate-800 mb-4 flex items-center gap-2">
                         <FiAlertTriangle className="text-red-500"/>


### PR DESCRIPTION
## Summary
- make left sidebar on home page independently scrollable for long content

## Testing
- `bundle exec rails test` *(fails: command not found: rails)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6895939977b88322a598685acf5354be