### PR TITLE
Default Todo board to current sprint

### DIFF
--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -52,18 +52,18 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
     if (!projectId) return;
     SchedulerAPI.getSprints(projectId)
       .then(res => {
-        setSprints(res.data);
-        if (!sprintId && res.data.length) {
-          SchedulerAPI.getLastSprint(projectId)
-            .then(last => {
-              const defaultSprintId = last.data?.id || res.data[0].id;
-              setSelectedSprintId(defaultSprintId);
-              onSprintChange && onSprintChange(defaultSprintId);
-            })
-            .catch(() => {
-              setSelectedSprintId(res.data[0].id);
-              onSprintChange && onSprintChange(res.data[0].id);
-            });
+        const list = Array.isArray(res.data) ? res.data : [];
+        setSprints(list);
+        if (!sprintId && list.length) {
+          const today = new Date();
+          const current =
+            list.find(s => {
+              const start = new Date(s.start_date);
+              const end = new Date(s.end_date);
+              return today >= start && today <= end;
+            }) || list[0];
+          setSelectedSprintId(current.id);
+          onSprintChange && onSprintChange(current.id);
         }
       })
       .catch(() => toast.error("Could not load sprints"));


### PR DESCRIPTION
## Summary
- Default Todo board sprint selection to the current sprint based on start/end dates

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68959438ab988322ab28116c68c518b5