### PR TITLE
feat: improve settings page ui

### DIFF
--- a/app/javascript/pages/Settings.jsx
+++ b/app/javascript/pages/Settings.jsx
@@ -2,6 +2,8 @@ import React, { useContext, useState, useEffect } from "react";
 import api from "../components/api";
 import { AuthContext } from "../context/AuthContext";
 import { COLOR_MAP } from "/utils/theme";
+import { Switch } from "@headlessui/react";
+import { FiPalette, FiHome, FiSun, FiMoon } from "react-icons/fi";
 
 const landingPageOptions = [
   { value: "posts", label: "Posts" },
@@ -15,10 +17,13 @@ const landingPageOptions = [
 
 const Settings = () => {
   const { user, setUser } = useContext(AuthContext);
-  const initialColor = COLOR_MAP[user?.color_theme] || user?.color_theme || "#3b82f6";
+  const initialColor =
+    COLOR_MAP[user?.color_theme] || user?.color_theme || "#3b82f6";
   const [color, setColor] = useState(initialColor);
   const [darkMode, setDarkMode] = useState(user?.dark_mode || false);
-  const [landingPage, setLandingPage] = useState(user?.landing_page || "posts");
+  const [landingPage, setLandingPage] = useState(
+    user?.landing_page || "posts"
+  );
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
@@ -30,8 +35,15 @@ const Settings = () => {
     e.preventDefault();
     setSaving(true);
     try {
-      await api.post("/update_profile", { auth: { color_theme: color, dark_mode: darkMode, landing_page: landingPage } });
-      setUser((prev) => ({ ...prev, color_theme: color, dark_mode: darkMode, landing_page: landingPage }));
+      await api.post("/update_profile", {
+        auth: { color_theme: color, dark_mode: darkMode, landing_page: landingPage },
+      });
+      setUser((prev) => ({
+        ...prev,
+        color_theme: color,
+        dark_mode: darkMode,
+        landing_page: landingPage,
+      }));
     } catch (err) {
       console.error("Failed to update color theme", err);
     } finally {
@@ -40,69 +52,93 @@ const Settings = () => {
   };
 
   return (
-    <div className="max-w-xl mx-auto py-8 px-4">
-      <h1 className="text-2xl font-semibold mb-6">Settings</h1>
-      <form onSubmit={handleSubmit} className="space-y-6">
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Theme Color
-          </label>
-          <div className="flex items-center gap-4">
-            <input
-              type="color"
-              value={color}
-              onChange={(e) => setColor(e.target.value)}
-              className="w-16 h-10 p-0 border-0 bg-transparent cursor-pointer rounded-lg overflow-hidden"
-            />
-            <div className="flex gap-2">
-              {Object.entries(COLOR_MAP).map(([name, value]) => (
-                <button
-                  key={name}
-                  type="button"
-                  onClick={() => setColor(value)}
-                  className="w-6 h-6 rounded-full"
-                  style={{ backgroundColor: value }}
-                  aria-label={name}
-                />
-              ))}
+    <div className="max-w-2xl mx-auto py-8 px-4">
+      <h1 className="text-2xl font-semibold mb-8">Settings</h1>
+      <form onSubmit={handleSubmit} className="space-y-8">
+        <section className="bg-white rounded-lg shadow p-6 space-y-6">
+          <h2 className="flex items-center text-lg font-medium gap-2">
+            <FiPalette className="text-[var(--theme-color)]" /> Appearance
+          </h2>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Theme Color
+            </label>
+            <div className="flex items-center gap-4 flex-wrap">
+              <input
+                type="color"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="w-16 h-10 p-0 border-0 bg-transparent cursor-pointer rounded-lg overflow-hidden"
+              />
+              <div className="flex gap-2 flex-wrap">
+                {Object.entries(COLOR_MAP).map(([name, value]) => (
+                  <button
+                    key={name}
+                    type="button"
+                    onClick={() => setColor(value)}
+                    className={`w-8 h-8 rounded-full border-2 ${
+                      color === value
+                        ? "border-[var(--theme-color)]"
+                        : "border-transparent"
+                    }`}
+                    style={{ backgroundColor: value }}
+                    aria-label={name}
+                  />
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">
-            Landing Page
-          </label>
-          <select
-            value={landingPage}
-            onChange={(e) => setLandingPage(e.target.value)}
-            className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-[var(--theme-color)] focus:ring-[var(--theme-color)]"
+          <div className="flex items-center justify-between">
+            <span className="flex items-center gap-2 text-sm font-medium text-gray-700">
+              {darkMode ? <FiMoon /> : <FiSun />}
+              Dark Mode
+            </span>
+            <Switch
+              checked={darkMode}
+              onChange={setDarkMode}
+              className={`${
+                darkMode ? "bg-[var(--theme-color)]" : "bg-gray-200"
+              } relative inline-flex h-6 w-11 items-center rounded-full transition-colors`}
+            >
+              <span className="sr-only">Enable dark mode</span>
+              <span
+                className={`${
+                  darkMode ? "translate-x-6" : "translate-x-1"
+                } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+              />
+            </Switch>
+          </div>
+        </section>
+        <section className="bg-white rounded-lg shadow p-6 space-y-4">
+          <h2 className="flex items-center text-lg font-medium gap-2">
+            <FiHome className="text-[var(--theme-color)]" /> Preferences
+          </h2>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Landing Page
+            </label>
+            <select
+              value={landingPage}
+              onChange={(e) => setLandingPage(e.target.value)}
+              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:border-[var(--theme-color)] focus:ring-[var(--theme-color)]"
+            >
+              {landingPageOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </section>
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-6 py-2 rounded-lg text-white bg-[var(--theme-color)] hover:opacity-90 disabled:opacity-50"
           >
-            {landingPageOptions.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+            {saving ? "Saving..." : "Save Changes"}
+          </button>
         </div>
-        <div className="flex items-center gap-2">
-          <input
-            id="dark-mode"
-            type="checkbox"
-            checked={darkMode}
-            onChange={(e) => setDarkMode(e.target.checked)}
-            className="h-4 w-4"
-          />
-          <label htmlFor="dark-mode" className="text-sm font-medium text-gray-700">
-            Dark Mode
-          </label>
-        </div>
-        <button
-          type="submit"
-          disabled={saving}
-          className="px-4 py-2 rounded-lg text-white bg-[var(--theme-color)] disabled:opacity-50"
-        >
-          {saving ? "Saving..." : "Save"}
-        </button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Summary
- restyle settings page with card-based layout
- add color palette and dark mode toggle using Headless UI
- group landing page option under preferences section

## Testing
- `bundle exec rails test` *(fails: command not found)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `yarn build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68959c536ef08322a7ba3a61f02d7d9a