### PR TITLE
Fix sprint selection based on date

### DIFF
--- a/app/javascript/components/Scheduler/SprintManager.jsx
+++ b/app/javascript/components/Scheduler/SprintManager.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { FiEdit2, FiTrash2, FiPlus, FiX, FiCalendar, FiChevronLeft, FiChevronRight, FiAlertTriangle } from 'react-icons/fi';
 import { motion, AnimatePresence } from 'framer-motion';
 
-export default function SprintManager({ onSprintChange, projectId, projectName }) {
+export default function SprintManager({ onSprintChange, projectId, projectName, selectedDate }) {
   const [sprints, setSprints] = useState([]);
   const [currentSprint, setCurrentSprint] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -19,12 +19,12 @@ export default function SprintManager({ onSprintChange, projectId, projectName }
       .then(res => res.json())
       .then(data => {
         const sortedData = data?.sort((a, b) => new Date(a.start_date) - new Date(b.start_date)) || [];
-        const today = new Date();
+        const reference = selectedDate ? new Date(selectedDate) : new Date();
         const activeSprint = sortedData.find(sprint => {
           const startDate = new Date(sprint.start_date);
           const endDate = new Date(sprint.end_date);
           endDate.setHours(23, 59, 59, 999);
-          return today >= startDate && today <= endDate;
+          return reference >= startDate && reference <= endDate;
         });
 
         setSprints(sortedData);
@@ -34,7 +34,7 @@ export default function SprintManager({ onSprintChange, projectId, projectName }
       })
       .catch(err => console.error("Error fetching sprints:", err))
       .finally(() => setLoading(false));
-  }, [projectId]);
+  }, [projectId, selectedDate]);
 
   // Scroll to active sprint on load or change
   useEffect(() => {

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -29,6 +29,10 @@ export default function SprintDashboard() {
   const { projectId } = useParams();
   const [searchParams] = useSearchParams();
   const initialTab = searchParams.get('tab') || 'overview';
+  const dateParam = searchParams.get('date');
+  const selectedDate = React.useMemo(() =>
+    dateParam ? new Date(dateParam) : new Date(),
+  [dateParam]);
   const [activeTab, setActiveTab] = useState(initialTab);
   const [sprintId, setSprintId] = useState(null);
   const [sprint, setSprint] = useState(null);
@@ -57,11 +61,11 @@ export default function SprintDashboard() {
       .then(data => {
         setSprints(data || []);
         if (data && data.length) {
-          const today = new Date();
+          const reference = selectedDate;
           const current = data.find(s => {
             const start = new Date(s.start_date);
             const end = new Date(s.end_date);
-            return today >= start && today <= end;
+            return reference >= start && reference <= end;
           });
           const selected = current || data[0];
           if (selected) {
@@ -70,7 +74,7 @@ export default function SprintDashboard() {
           }
         }
       });
-  }, [projectId]);
+  }, [projectId, selectedDate]);
 
   const isCurrentSprint = (s) => {
     if (!s) return false;
@@ -188,6 +192,7 @@ export default function SprintDashboard() {
             onSprintChange={handleSprintChange}
             projectId={projectId}
             projectName={project?.name}
+            selectedDate={selectedDate}
           />
         </div>
       </header>


### PR DESCRIPTION
## Summary
- use `date` query parameter to pick matching sprint on project dashboard
- initialize sprint manager with the same date for consistent selection

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_68959d8f5d98832283bdd3f7e766179b