### PR TITLE
fix: remove duplicate general tasks

### DIFF
--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -169,7 +169,13 @@ const PostPage = () => {
   useEffect(() => {
     if (!user) return;
     SchedulerAPI.getTasks({ type: 'general', assigned_to_user: user.id })
-      .then(({ data }) => setGeneralTasks(Array.isArray(data) ? data : []))
+      .then(({ data }) => {
+        const tasks = Array.isArray(data) ? data : [];
+        const uniqueTasks = tasks.filter(
+          (t, idx, arr) => idx === arr.findIndex((u) => u.id === t.id)
+        );
+        setGeneralTasks(uniqueTasks);
+      })
       .catch(() => setGeneralTasks([]));
   }, [user]);
 


### PR DESCRIPTION
## Summary
- avoid rendering duplicate general tasks on home page

## Testing
- `bundle exec rake test` (fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68959df1feec832282da2a59034a472b