### PR TITLE
Replace missing FiPalette icon

### DIFF
--- a/app/javascript/pages/Settings.jsx
+++ b/app/javascript/pages/Settings.jsx
@@ -3,7 +3,8 @@ import api from "../components/api";
 import { AuthContext } from "../context/AuthContext";
 import { COLOR_MAP } from "/utils/theme";
 import { Switch } from "@headlessui/react";
-import { FiPalette, FiHome, FiSun, FiMoon } from "react-icons/fi";
+import { FiHome, FiSun, FiMoon } from "react-icons/fi";
+import { FaPalette } from "react-icons/fa";
 
 const landingPageOptions = [
   { value: "posts", label: "Posts" },
@@ -57,7 +58,7 @@ const Settings = () => {
       <form onSubmit={handleSubmit} className="space-y-8">
         <section className="bg-white rounded-lg shadow p-6 space-y-6">
           <h2 className="flex items-center text-lg font-medium gap-2">
-            <FiPalette className="text-[var(--theme-color)]" /> Appearance
+            <FaPalette className="text-[var(--theme-color)]" /> Appearance
           </h2>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">


### PR DESCRIPTION
## Summary
- Replace nonexistent `FiPalette` import with `FaPalette` in settings page

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `mise install ruby@3.3.0` *(fails: failed to get latest ruby-build version)*
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6895a13de1d08322ac557959c50d83d5