### PR TITLE
fix: sync header with selected sprint

### DIFF
--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -75,6 +75,13 @@ export default function SprintDashboard() {
       });
   }, [projectId, selectedDate]);
 
+  useEffect(() => {
+    if (sprintId !== null && sprints.length) {
+      const found = sprints.find(sp => sp.id === sprintId);
+      if (found) setSprint(found);
+    }
+  }, [sprintId, sprints]);
+
   const isCurrentSprint = (s) => {
     if (!s) return false;
     const today = new Date();


### PR DESCRIPTION
## Summary
- keep SprintDashboard header in sync with selected sprint

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895be2937408322833a616a39ce7d5e