### PR TITLE
Do not associate todo-board tasks with project or sprint

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -77,13 +77,22 @@ class Api::TasksController < Api::BaseController
   def task_params
     task_data = params.require(:task)
     task_data = task_data[:task] if task_data[:task].is_a?(ActionController::Parameters)
-    task_data.permit(
+
+    permitted = task_data.permit(
       :task_id, :task_url, :type, :title, :description,
       :status, :order, :assigned_to_user,
       :created_by, :created_at, :updated_by, :updated_at,
       :start_date, :end_date,
       :estimated_hours, :sprint_id, :developer_id, :project_id, :is_struck
     )
+
+    # Tasks of type "general" should never be tied to a sprint or project.
+    if permitted[:type] == 'general'
+      permitted.delete(:sprint_id)
+      permitted.delete(:project_id)
+    end
+
+    permitted
   end
 
   def reorder_group(sprint_id, developer_id)

--- a/app/javascript/components/TodoBoard/TodoBoard.jsx
+++ b/app/javascript/components/TodoBoard/TodoBoard.jsx
@@ -104,8 +104,8 @@ export default function TodoBoard({ sprintId, projectId, onSprintChange }) {
       const payload = { ...newTaskData };
       // ensure the task is assigned to the current user
       if (user) payload.assigned_to_user = user.id;
-      if (selectedSprintId) payload.sprint_id = selectedSprintId;
-      if (projectId) payload.project_id = projectId;
+      // Tasks created from the todo board should remain general and
+      // therefore must not be associated with any sprint or project.
       const { data } = await SchedulerAPI.createTask(payload);
       const statusKey = data.status || 'todo';
       setColumns(prev => ({


### PR DESCRIPTION
## Summary
- Avoid attaching sprint_id or project_id when creating tasks from the Todo board so they remain general.
- Strip sprint and project associations for general tasks on the backend.

## Testing
- `npm run build`
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895d234a67883229ddfab8a734a6069