### PR TITLE
Adjust theme color lightening for readability

### DIFF
--- a/app/javascript/utils/theme.js
+++ b/app/javascript/utils/theme.js
@@ -7,7 +7,7 @@ export const COLOR_MAP = {
   indigo: '#6366f1'
 };
 
-export const lightenColor = (color, amount = 0.9) => {
+export const lightenColor = (color, amount = 0.5) => {
   const hex = color.replace('#', '');
   const r = parseInt(hex.substring(0, 2), 16);
   const g = parseInt(hex.substring(2, 4), 16);


### PR DESCRIPTION
## Summary
- decrease lightening amount to keep themed gradients readable

## Testing
- `bundle exec rake test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895e96ae98c8322b92b2df46667f41e