### PR TITLE
Refactor JWT expiry handling

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -185,8 +185,8 @@ class Api::AuthController < Api::BaseController
   end
 
   def set_jwt_cookie!(user)
-    access_token = JwtService.encode({ user_id: user.id }, 15.minutes.from_now)
-    refresh_token = JwtService.encode({ user_id: user.id }, 7.days.from_now)
+    access_token = JwtService.encode({ user_id: user.id }, exp: 15.minutes.from_now)
+    refresh_token = JwtService.encode({ user_id: user.id }, exp: 7.days.from_now)
 
     cookies.signed[:access_token] = {
       value: access_token,

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -1,8 +1,7 @@
 class JwtService
   SECRET_KEY = Rails.application.credentials.secret_key_base
-  EXPIRY = 15.minutes.from_now.to_i
 
-  def self.encode(payload, exp = EXPIRY)
+  def self.encode(payload, exp: 15.minutes.from_now.to_i)
     payload[:exp] = exp.to_i
     JWT.encode(payload, SECRET_KEY)
   end


### PR DESCRIPTION
## Summary
- simplify JWT encoding by removing EXPIRY constant and using keyword argument with default 15-minute expiration
- update AuthController to call JwtService.encode with explicit expiration values

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895ede8ae0c8322b280401e60c5f43e