### PR TITLE
Add stamp action to PDF modifiers controller

### DIFF
--- a/app/controllers/pdf_modifiers_controller.rb
+++ b/app/controllers/pdf_modifiers_controller.rb
@@ -64,6 +64,15 @@ class PdfModifiersController < ApplicationController
     end
   end
 
+  def add_stamp
+    begin
+      PdfMaster.add_stamp(@pdf_path, @stamp, @x.to_i, @y.to_i, @page_number.to_i)
+      render json: { message: "Stamp added successfully." }, status: :ok
+    rescue => e
+      render json: { error: e.message }, status: :unprocessable_entity
+    end
+  end
+
   def rotate_left
     begin
       PdfMaster.rotate_page(@pdf_path, 270, @page_number.to_i)


### PR DESCRIPTION
## Summary
- implement `add_stamp` action in `PdfModifiersController`

## Testing
- `bundle exec rails test` *(fails: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6895edfd336c83229972fb792b372ec9