### PR TITLE
Add pagination and filtering to admin API and UI

### DIFF
--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -141,7 +141,7 @@ export const updateWorkNote = (id, data) => api.put(`/work_notes/${id}`, { work_
 
 export const getTables = () => api.get('/admin/tables');
 export const getMeta = (table) => api.get(`/admin_meta/${table}`);
-export const getRecords = (table) => api.get(`/admin/${table}`);
+export const getRecords = (table, params = {}) => api.get(`/admin/${table}`, { params });
 export const createRecord = (table, data) => api.post(`/admin/${table}`, { record: data });
 export const updateRecord = (table, id, data) => api.patch(`/admin/${table}/${id}`, { record: data });
 export const deleteRecord = (table, id) => api.delete(`/admin/${table}/${id}`);


### PR DESCRIPTION
## Summary
- Add page/per_page and optional filter support to admin API with pagination metadata
- Update DynamicAdminTable to request paginated data and render pagination controls
- Allow getRecords helper to forward pagination and filter params

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_689ae1ca7da88322bec5a0471f27eb78