### PR TITLE
Add dynamic page titles

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -21,11 +21,13 @@ import Legal from "../pages/Legal";
 import SprintDashboard from "../pages/SprintDashboard";
 import WorkLog from "../pages/WorkLog";
 import Settings from "../pages/Settings";
+import PageTitle from "./PageTitle";
 
 const App = () => {
   return (
     <Router>
       <AuthProvider> {/* ✅ Wrap the entire app with AuthProvider */}
+        <PageTitle />
         <div className="flex flex-col min-h-screen">
 
           {/* ✅ Navbar */}

--- a/app/javascript/components/PageTitle.jsx
+++ b/app/javascript/components/PageTitle.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const APP_NAME = "My Rails + Vite + React App";
+
+const PageTitle = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    const { pathname } = location;
+    const titles = {
+      "/contact": "Contact",
+      "/legal": "Legal",
+      "/pdf": "PDF",
+      "/posts": "Posts",
+      "/vault": "Vault",
+      "/profile": "Profile",
+      "/knowledge": "Knowledge Dashboard",
+      "/worklog": "Work Log",
+      "/projects": "Projects",
+      "/teams": "Teams",
+      "/users": "Users",
+      "/admin": "Admin",
+      "/settings": "Settings",
+    };
+
+    let title = APP_NAME;
+
+    if (pathname === "/") {
+      title = APP_NAME;
+    } else if (/^\/projects\/[^/]+\/dashboard$/.test(pathname)) {
+      title = `Sprint Dashboard | ${APP_NAME}`;
+    } else if (titles[pathname]) {
+      title = `${titles[pathname]} | ${APP_NAME}`;
+    } else {
+      title = APP_NAME;
+    }
+
+    document.title = title;
+  }, [location]);
+
+  return null;
+};
+
+export default PageTitle;


### PR DESCRIPTION
## Summary
- update React app to adjust browser tab title based on current route
- show app name on home and append page names for other routes

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `yarn build` *(fails: package not present in lockfile)*
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c31c417348322ba8c6f3b5f7fea98