### PR TITLE
Fix admin table metadata fetch logic

### DIFF
--- a/app/javascript/components/Admin/DynamicAdminTable.jsx
+++ b/app/javascript/components/Admin/DynamicAdminTable.jsx
@@ -45,7 +45,7 @@ function DynamicAdminTable({ table }) {
         console.error("Failed to fetch meta:", error);
       }
     }
-    fetchMeta();
+    fetchData();
   }, [table]);
 
   // Fetch records when table, page, per-page, or filters change
@@ -59,9 +59,9 @@ function DynamicAdminTable({ table }) {
         setTotalPages(recRes.data.pagination.total_pages);
       } catch (error) {
         toast.error('Failed to load table data');
+        console.error("Failed to fetch records:", error);
       } finally {
         setLoading(false);
-        console.error("Failed to fetch records:", error);
       }
     }
     fetchRecords();


### PR DESCRIPTION
## Summary
- Correct admin data loading by invoking the defined `fetchData` function instead of undefined `fetchMeta`
- Ensure record fetching logs errors only within the catch block, avoiding a reference error

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c8691e8c8832295e6ae931e6a9d1c