### PR TITLE
Fix task hyperlink formatting in scheduler sheet export

### DIFF
--- a/app/services/scheduler_sheet_service.rb
+++ b/app/services/scheduler_sheet_service.rb
@@ -100,7 +100,8 @@ class SchedulerSheetService
     formulas = cell_logs.map do |log|
       task = log.task
       url = task.task_url.presence || "https://resmedsaas.atlassian.net/browse/#{task.task_id}"
-      %(HYPERLINK("#{url}","#{task.task_id}")&" (#{log.hours_logged}h) - #{log.type}")
+      display_text = "#{task.task_id} (#{log.hours_logged}h) - #{log.type}"
+      %(HYPERLINK("#{url}","#{display_text}"))
     end
 
     "=" + formulas.join('&CHAR(10)&')


### PR DESCRIPTION
## Summary
- fix `SchedulerSheetService` task link formatting to keep entire log text inside the hyperlink

## Testing
- `bundle exec rake -T` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f6a285e08322a3276c88838c95ef