### PR TITLE
Add Image of the Day card with API fallbacks

### DIFF
--- a/app/javascript/components/Knowledge/ImageOfTheDayCard.jsx
+++ b/app/javascript/components/Knowledge/ImageOfTheDayCard.jsx
@@ -1,0 +1,96 @@
+import React, { useEffect, useState } from "react";
+
+const fetchers = [
+  // 1) NASA Astronomy Picture of the Day
+  () =>
+    fetch("https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY")
+      .then((res) => res.json())
+      .then((data) => {
+        if (data?.url && data.media_type === "image")
+          return { url: data.url, title: data.title };
+        throw new Error("Invalid NASA APOD response");
+      }),
+
+  // 2) Bing Image of the Day
+  () =>
+    fetch("https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1")
+      .then((res) => res.json())
+      .then((data) => {
+        const img = data?.images?.[0];
+        if (img?.url)
+          return {
+            url: `https://www.bing.com${img.url}`,
+            title: img.copyright || "Bing Image",
+          };
+        throw new Error("Invalid Bing response");
+      }),
+
+  // 3) Picsum random image
+  () =>
+    Promise.resolve({
+      url: "https://picsum.photos/800/600",
+      title: "Random Image",
+    }),
+];
+
+const fallbackImage = {
+  url: "https://via.placeholder.com/800x600?text=No+Image",
+  title: "No image available",
+};
+
+export default function ImageOfTheDayCard() {
+  const [image, setImage] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function fetchWithFallback() {
+      setLoading(true);
+      for (const fetcher of fetchers) {
+        try {
+          const result = await fetcher();
+          if (mounted) {
+            setImage(result);
+            setLoading(false);
+          }
+          return;
+        } catch (e) {
+          console.warn("Image fetch failed, trying next:", e.message);
+        }
+      }
+      if (mounted) {
+        setImage(fallbackImage);
+        setLoading(false);
+      }
+    }
+
+    fetchWithFallback();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+      <h2 className="text-lg font-semibold mb-2">🖼️ Image of the Day</h2>
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : (
+        <div className="flex-1 flex flex-col">
+          <img
+            src={image.url}
+            alt={image.title}
+            className="rounded-md object-cover mb-2 w-full h-48"
+            loading="lazy"
+          />
+          {image.title && (
+            <p className="text-sm text-gray-700">
+              {image.title}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -15,6 +15,7 @@ import IndianStockNewsCard from "../components/Knowledge/IndianStockNewsCard";
 import CommonEnglishWordCard from "../components/Knowledge/CommonEnglishWordCard";
 import EnglishTenseCard from "../components/Knowledge/EnglishTenseCard";
 import EnglishPhraseCard from "../components/Knowledge/EnglishPhraseCard";
+import ImageOfTheDayCard from "../components/Knowledge/ImageOfTheDayCard";
 
 export default function KnowledgeDashboard() {
   const [activeCategory, setActiveCategory] = useState("all");
@@ -37,6 +38,7 @@ export default function KnowledgeDashboard() {
   const cards = [
     { component: <TodayInHistoryCard />, category: "learning" },
     { component: <QuoteOfTheDayCard />, category: "learning" },
+    { component: <ImageOfTheDayCard />, category: "learning" },
     { component: <TopNewsCard />, category: "news" },
     { component: <DailyFactCard />, category: "learning" },
     { component: <WordOfTheDayCard />, category: "learning" },


### PR DESCRIPTION
## Summary
- add ImageOfTheDayCard component with NASA APOD, Bing and Picsum fallbacks
- integrate ImageOfTheDayCard into Knowledge dashboard

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7090f59848322ab3d5b8cd01094c7