### PR TITLE
Add fallback APIs for English Phrase and English Tense

### DIFF
--- a/app/controllers/api/english_phrases_controller.rb
+++ b/app/controllers/api/english_phrases_controller.rb
@@ -3,12 +3,33 @@ class Api::EnglishPhrasesController < Api::BaseController
   require 'faraday'
   require 'json'
 
+  PRIMARY_URL = 'https://api.quotable.io/random'
+  FALLBACK_URL = 'https://zenquotes.io/api/random'
+
   def show
-    response = Faraday.get('https://api.quotable.io/random')
-    data = JSON.parse(response.body)
-    render json: { phrase: data['content'], author: data['author'] }
+    data = fetch_phrase(PRIMARY_URL) || fetch_phrase(FALLBACK_URL)
+
+    if data
+      render json: data
+    else
+      render json: { error: 'Failed to fetch phrase' }, status: 500
+    end
+  end
+
+  private
+
+  def fetch_phrase(url)
+    response = Faraday.get(url)
+    return unless response.success?
+    body = JSON.parse(response.body)
+    if url == FALLBACK_URL
+      body = body.first if body.is_a?(Array)
+      { phrase: body['q'], author: body['a'] }
+    else
+      { phrase: body['content'], author: body['author'] }
+    end
   rescue StandardError => e
     Rails.logger.error "EnglishPhrases error: #{e.message}"
-    render json: { error: 'Failed to fetch phrase' }, status: 500
+    nil
   end
 end


### PR DESCRIPTION
## Summary
- add secondary API for English Phrase quotes when primary endpoint fails
- support multiple English Tense sources and fall back when one is unreachable

## Testing
- `bin/rails test` *(fails: Ruby version is 3.2.3 but Gemfile requires 3.3.0)*
- `yarn test` *(fails: package not present in lockfile; suggests running `yarn install`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b882459c83228f010458c2483677