### PR TITLE
Make Knowledge Hub cards flexible to content

### DIFF
--- a/app/javascript/components/Knowledge/CommonEnglishWordCard.jsx
+++ b/app/javascript/components/Knowledge/CommonEnglishWordCard.jsx
@@ -22,7 +22,7 @@ export default function CommonEnglishWordCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
       <h2 className="text-lg font-semibold mb-2">Common English Word</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/DailyFactCard.jsx
+++ b/app/javascript/components/Knowledge/DailyFactCard.jsx
@@ -24,7 +24,7 @@ export default function DailyFactCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
       <h2 className="text-lg font-semibold mb-2">💡 Daily Fact</h2>
       {facts.length ? (
         <ul className="text-sm text-gray-700 italic space-y-1">

--- a/app/javascript/components/Knowledge/EnglishPhraseCard.jsx
+++ b/app/javascript/components/Knowledge/EnglishPhraseCard.jsx
@@ -22,7 +22,7 @@ export default function EnglishPhraseCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
       <h2 className="text-lg font-semibold mb-2">English Phrase</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/EnglishTenseCard.jsx
+++ b/app/javascript/components/Knowledge/EnglishTenseCard.jsx
@@ -22,7 +22,7 @@ export default function EnglishTenseCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
       <h2 className="text-lg font-semibold mb-2">English Tense</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/ImageOfTheDayCard.jsx
+++ b/app/javascript/components/Knowledge/ImageOfTheDayCard.jsx
@@ -72,7 +72,7 @@ export default function ImageOfTheDayCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">🖼️ Image of the Day</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/IndianStockNewsCard.jsx
+++ b/app/javascript/components/Knowledge/IndianStockNewsCard.jsx
@@ -44,7 +44,7 @@ export default function IndianStockNewsCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">🇮🇳 Market News</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/QuoteOfTheDayCard.jsx
+++ b/app/javascript/components/Knowledge/QuoteOfTheDayCard.jsx
@@ -73,7 +73,7 @@ export default function QuoteOfTheDayCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
       <h2 className="text-lg font-semibold mb-2">🧘 Quote of the Day</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/RandomCodingTipCard.jsx
+++ b/app/javascript/components/Knowledge/RandomCodingTipCard.jsx
@@ -24,7 +24,7 @@ export default function RandomCodingTipCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-center">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-center">
       <h2 className="text-lg font-semibold mb-2">💡 AI Coding Tip of the Day</h2>
       {loading ? (
         <p className="text-sm text-gray-500">Loading AI-generated tip...</p>

--- a/app/javascript/components/Knowledge/ScienceNewsCard.jsx
+++ b/app/javascript/components/Knowledge/ScienceNewsCard.jsx
@@ -84,7 +84,7 @@ export default function ScienceNewsCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">🔬 Science News</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/TechNewsCard.jsx
+++ b/app/javascript/components/Knowledge/TechNewsCard.jsx
@@ -76,7 +76,7 @@ export default function TechNewsCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">💻 Tech News</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/TodayInHistoryCard.jsx
+++ b/app/javascript/components/Knowledge/TodayInHistoryCard.jsx
@@ -18,7 +18,7 @@ export default function TodayInHistoryCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">📅 Today in History</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
+++ b/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
@@ -74,7 +74,7 @@ export default function TopBuyingStocksCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">🇮🇳 Top Buying</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/TopGainersCard.jsx
+++ b/app/javascript/components/Knowledge/TopGainersCard.jsx
@@ -77,7 +77,7 @@ export default function TopGainersCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">🇮🇳 Top Gainers</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/TopNewsCard.jsx
+++ b/app/javascript/components/Knowledge/TopNewsCard.jsx
@@ -71,7 +71,7 @@ export default function TopNewsCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">📰 Top News</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/TopVolumeStocksCard.jsx
+++ b/app/javascript/components/Knowledge/TopVolumeStocksCard.jsx
@@ -75,7 +75,7 @@ export default function TopVolumeStocksCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
       <h2 className="text-lg font-semibold mb-2">🇮🇳 Top Volume</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/components/Knowledge/WordOfTheDayCard.jsx
+++ b/app/javascript/components/Knowledge/WordOfTheDayCard.jsx
@@ -91,7 +91,7 @@ export default function WordOfTheDayCard() {
   }, []);
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 h-full flex flex-col justify-between">
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
       <h2 className="text-lg font-semibold mb-2">🧠 Word of the Day</h2>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -89,7 +89,7 @@ export default function KnowledgeDashboard() {
 
       <main className="max-w-7xl mx-auto px-6 py-8">
         {isLoading ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 items-start">
             {[...Array(8)].map((_, i) => (
               <motion.div
                 key={i}
@@ -103,7 +103,7 @@ export default function KnowledgeDashboard() {
         ) : (
           <motion.div
             layout
-            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6"
+            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 items-start"
           >
             <AnimatePresence>
               {filteredCards.map((item, index) => (
@@ -117,7 +117,7 @@ export default function KnowledgeDashboard() {
                   whileHover={{ y: -5 }}
                   className="rounded-2xl overflow-hidden"
                 >
-                  <div className="h-full border bg-white border-gray-200 hover:border-gray-300 rounded-2xl shadow-sm hover:shadow-md transition-all duration-300">
+                  <div className="border bg-white border-gray-200 hover:border-gray-300 rounded-2xl shadow-sm hover:shadow-md transition-all duration-300">
                     {item.component}
                   </div>
                 </motion.div>


### PR DESCRIPTION
## Summary
- Allow Knowledge Hub grid items to size to content instead of stretching to uniform height
- Drop fixed `h-full` on card components so short entries don't leave empty space

## Testing
- `yarn test` (fails: Couldn't find a script named "test")
- `bundle exec rake test` (fails: Ruby version 3.2.3, but Gemfile specifies 3.3.0)


------
https://chatgpt.com/codex/tasks/task_e_68b1be47d71083228c69fcd055a69d04