### PR TITLE
Use masonry layout for Knowledge Hub cards

### DIFF
--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -103,7 +103,7 @@ export default function KnowledgeDashboard() {
         ) : (
           <motion.div
             layout
-            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 items-start"
+            className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-6"
           >
             <AnimatePresence>
               {filteredCards.map((item, index) => (
@@ -115,7 +115,7 @@ export default function KnowledgeDashboard() {
                   exit={{ opacity: 0, scale: 0.9 }}
                   transition={{ duration: 0.3 }}
                   whileHover={{ y: -5 }}
-                  className="rounded-2xl overflow-hidden"
+                  className="mb-6 break-inside-avoid rounded-2xl overflow-hidden"
                 >
                   <div className="border bg-white border-gray-200 hover:border-gray-300 rounded-2xl shadow-sm hover:shadow-md transition-all duration-300">
                     {item.component}


### PR DESCRIPTION
## Summary
- Switch Knowledge Hub grid to CSS columns for masonry-like layout
- Prevent card breaks and add spacing to remove awkward gaps

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bf8452f4832288d44f1597e3f570