### PR TITLE
Add fallback news API and fix top-buying fallback key

### DIFF
--- a/app/javascript/components/Knowledge/IndianStockNewsCard.jsx
+++ b/app/javascript/components/Knowledge/IndianStockNewsCard.jsx
@@ -1,6 +1,13 @@
 import React, { useEffect, useState } from "react";
 
+// API keys for optional fallbacks
+const API_KEYS = {
+  NEWSDATA: "YOUR_NEWSDATA_API_KEY", // https://newsdata.io/
+};
+
+// Try multiple sources in order
 const fetchers = [
+  // 1) Inshorts unofficial API
   () =>
     fetch("https://inshorts.vercel.app/api/news?category=business")
       .then((res) => res.json())
@@ -8,6 +15,19 @@ const fetchers = [
         if (data?.data?.length)
           return data.data.slice(0, 5).map((a) => ({ title: a.title, url: a.url }));
         throw new Error("Invalid Inshorts response");
+      }),
+
+  // 2) NewsData.io fallback
+  () =>
+    fetch(
+      `https://newsdata.io/api/1/news?apikey=${API_KEYS.NEWSDATA}&country=in&category=business`
+    )
+      .then((res) => res.json())
+      .then((data) => {
+        const arr = data?.results;
+        if (Array.isArray(arr) && arr.length)
+          return arr.slice(0, 5).map((a) => ({ title: a.title, url: a.link }));
+        throw new Error("Invalid NewsData response");
       }),
 ];
 

--- a/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
+++ b/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 // API keys for buy volume data
 const API_KEYS = {
   FMP: "e5ye9VH06cq5TTNyyA6z2gd2S8pf9sBV", // Financial Modeling Prep
-  ALPHA: "e5ye9VH06cq5TTNyyA6z2gd2S8pf9sBV", // AlphaVantage fallback
+  ALPHA: "YOUR_ALPHA_VANTAGE_KEY", // AlphaVantage fallback
 };
 
 const fetchers = [


### PR DESCRIPTION
## Summary
- fetch Indian market news from NewsData if Inshorts API fails
- correct Alpha Vantage API key placeholder for top-buying stocks card

## Testing
- `npm test`
- `bundle exec rails test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c117085c8322b8e8634dfcced72a