### PR TITLE
Add logging for Knowledge Hub API endpoints

### DIFF
--- a/app/controllers/api/coding_tips_controller.rb
+++ b/app/controllers/api/coding_tips_controller.rb
@@ -43,6 +43,11 @@ class Api::CodingTipsController < Api::BaseController
   ].freeze
 
   def show
-    render json: { tip: TIPS.sample }
+    tip = TIPS.sample
+    Rails.logger.info("CodingTips success: #{tip}")
+    render json: { tip: tip }
+  rescue StandardError => e
+    Rails.logger.error("CodingTips error: #{e.message}")
+    render json: { error: 'Failed to fetch coding tip' }, status: :internal_server_error
   end
 end

--- a/app/controllers/api/english_phrases_controller.rb
+++ b/app/controllers/api/english_phrases_controller.rb
@@ -10,9 +10,11 @@ class Api::EnglishPhrasesController < Api::BaseController
     data = fetch_phrase(PRIMARY_URL) || fetch_phrase(FALLBACK_URL)
 
     if data
+      Rails.logger.info('EnglishPhrases success')
       render json: data
     else
-      render json: { error: 'Failed to fetch phrase' }, status: 500
+      Rails.logger.error('EnglishPhrases error: failed to fetch')
+      render json: { error: 'Failed to fetch phrase' }, status: :internal_server_error
     end
   end
 
@@ -21,6 +23,7 @@ class Api::EnglishPhrasesController < Api::BaseController
   def fetch_phrase(url)
     response = Faraday.get(url)
     return unless response.success?
+    Rails.logger.info("EnglishPhrases fetched from #{url}")
     body = JSON.parse(response.body)
     if url == FALLBACK_URL
       body = body.first if body.is_a?(Array)

--- a/app/controllers/api/english_tenses_controller.rb
+++ b/app/controllers/api/english_tenses_controller.rb
@@ -17,9 +17,11 @@ class Api::EnglishTensesController < Api::BaseController
     end
 
     if items
+      Rails.logger.info('EnglishTenses success')
       render json: items.sample
     else
-      render json: { error: 'Failed to fetch tense' }, status: 500
+      Rails.logger.error('EnglishTenses error: failed to fetch')
+      render json: { error: 'Failed to fetch tense' }, status: :internal_server_error
     end
   end
 
@@ -28,6 +30,7 @@ class Api::EnglishTensesController < Api::BaseController
   def fetch_items(url)
     response = Faraday.get(url)
     return unless response.success?
+    Rails.logger.info("EnglishTenses fetched from #{url}")
     JSON.parse(response.body)
   rescue StandardError => e
     Rails.logger.error "EnglishTenses error: #{e.message}"

--- a/app/controllers/api/english_words_controller.rb
+++ b/app/controllers/api/english_words_controller.rb
@@ -7,9 +7,10 @@ class Api::EnglishWordsController < Api::BaseController
     response = Faraday.get('https://random-word-api.herokuapp.com/word?number=1')
     data = JSON.parse(response.body)
     word = data.is_a?(Array) ? data.first : data
+    Rails.logger.info("EnglishWords success: #{word}")
     render json: { word: word }
   rescue StandardError => e
-    Rails.logger.error "EnglishWords error: #{e.message}"
-    render json: { error: 'Failed to fetch word' }, status: 500
+    Rails.logger.error("EnglishWords error: #{e.message}")
+    render json: { error: 'Failed to fetch word' }, status: :internal_server_error
   end
 end


### PR DESCRIPTION
## Summary
- log successful tip retrieval and errors in CodingTipsController
- log success and failure paths for English tenses, phrases, and word endpoints

## Testing
- `bundle exec rails test` *(fails: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c2f0b6848322b10de5e4250358dd