### PR TITLE
Improve Knowledge Hub heading contrast

### DIFF
--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { auth, googleProvider } from "../firebaseConfig";
 import { signInWithPopup } from "firebase/auth";
 import { toast } from "react-hot-toast";
-import { COLOR_MAP, toRgb, lightenColor } from '/utils/theme';
+import { COLOR_MAP, toRgb, lightenColor, darkenColor } from '/utils/theme';
 
 export const AuthContext = createContext();
 
@@ -20,6 +20,7 @@ export function AuthProvider({ children }) {
     document.documentElement.style.setProperty('--theme-color', color);
     document.documentElement.style.setProperty('--theme-color-rgb', toRgb(color));
     document.documentElement.style.setProperty('--theme-color-light', lightenColor(color));
+    document.documentElement.style.setProperty('--theme-color-dark', darkenColor(color));
 
     if (user?.dark_mode) {
       document.documentElement.classList.add('dark');

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -64,7 +64,7 @@ export default function KnowledgeDashboard() {
       <header className="sticky top-0 z-10 backdrop-blur-md bg-white/80 border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-6 py-4 flex flex-col sm:flex-row justify-between items-center">
           <div className="flex items-center mb-4 sm:mb-0">
-            <h1 className="text-3xl font-bold bg-gradient-to-r from-[var(--theme-color)] to-[var(--theme-color-light)] bg-clip-text text-transparent">
+            <h1 className="text-3xl font-bold bg-gradient-to-r from-[var(--theme-color)] to-[var(--theme-color-dark)] bg-clip-text text-transparent">
               Knowledge Hub
             </h1>
           </div>

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -6,6 +6,7 @@
   --theme-color: #3b82f6;
   --theme-color-rgb: 59 130 246;
   --theme-color-light: #ebf3fe;
+  --theme-color-dark: #1d4ed8;
 }
 
 body {

--- a/app/javascript/utils/theme.js
+++ b/app/javascript/utils/theme.js
@@ -18,6 +18,17 @@ export const lightenColor = (color, amount = 0.5) => {
   return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
 };
 
+export const darkenColor = (color, amount = 0.25) => {
+  const hex = color.replace('#', '');
+  const r = parseInt(hex.substring(0, 2), 16);
+  const g = parseInt(hex.substring(2, 4), 16);
+  const b = parseInt(hex.substring(4, 6), 16);
+  const nr = Math.round(r * (1 - amount));
+  const ng = Math.round(g * (1 - amount));
+  const nb = Math.round(b * (1 - amount));
+  return `#${nr.toString(16).padStart(2, '0')}${ng.toString(16).padStart(2, '0')}${nb.toString(16).padStart(2, '0')}`;
+};
+
 export const toRgb = (color) => {
   const temp = document.createElement('div');
   temp.style.color = color;


### PR DESCRIPTION
## Summary
- add a darkened theme color variant for gradients
- update theming context to expose the darker shade as a CSS variable
- switch the Knowledge Hub title gradient to use the darker tone for better readability

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68d53454f608832293116cfc56513de0