### PR TITLE
Adjust Vault header layout

### DIFF
--- a/app/javascript/pages/Vault.jsx
+++ b/app/javascript/pages/Vault.jsx
@@ -440,34 +440,36 @@ const Vault = () => {
       
       {/* Header and Search */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-800 mb-2">Secure Vault</h1>
-        <p className="text-gray-600 mb-6">Store and manage your sensitive information securely</p>
-        
-        <div className="flex flex-col md:flex-row gap-4 mb-6">
-          <div className="relative flex-grow">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
-            </div>
-            <input
-              className="block w-full pl-10 pr-10 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="Search items..."
-              value={searchQuery}
-              onChange={handleSearchChange}
-            />
-            {searchQuery && (
-              <button
-                onClick={clearSearch}
-                className="absolute inset-y-0 right-0 pr-3 flex items-center"
-              >
-                <XMarkIcon className="h-5 w-5 text-gray-400 hover:text-gray-600" />
-              </button>
-            )}
+        <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-800 mb-2">Secure Vault</h1>
+            <p className="text-gray-600">Store and manage your sensitive information securely</p>
           </div>
-          
-          <div className="flex gap-2">
+
+          <div className="flex flex-col sm:flex-row sm:items-center gap-3 w-full md:w-auto">
+            <div className="relative w-full sm:w-72 md:w-64">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <MagnifyingGlassIcon className="h-5 w-5 text-gray-400" />
+              </div>
+              <input
+                className="block w-full pl-10 pr-10 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="Search items..."
+                value={searchQuery}
+                onChange={handleSearchChange}
+              />
+              {searchQuery && (
+                <button
+                  onClick={clearSearch}
+                  className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                >
+                  <XMarkIcon className="h-5 w-5 text-gray-400 hover:text-gray-600" />
+                </button>
+              )}
+            </div>
+
             <button
               onClick={handleExportAll}
-              className="flex items-center gap-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50"
+              className="flex items-center justify-center gap-1 px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 whitespace-nowrap"
             >
               <ArrowDownTrayIcon className="h-4 w-4" />
               Export


### PR DESCRIPTION
## Summary
- realign the Vault page header to keep the search bar beside the title and export button
- limit the search field width on larger screens to reduce its footprint while keeping it responsive

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d534aa61ac8322b3d06b1c25deff21