### PR TITLE
Fix post comment handling and smooth comment UX

### DIFF
--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -78,7 +78,7 @@ class Api::PostsController < Api::BaseController
       created_at: post.created_at.iso8601,
       likes_count: post.post_likes.size,
       liked_by_current_user: current_user.present? && post.post_likes.any? { |like| like.user_id == current_user.id },
-      comments_count: post.comments_count,
+      comments_count: post.try(:comments_count) || post.comments.size,
       comments: serialize_comments(post),
       user: {
         id: post.user.id,

--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -100,6 +100,16 @@ const PostPage = () => {
   const [birthdays, setBirthdays] = useState([]);
   const [generalTasks, setGeneralTasks] = useState([]);
 
+  const handlePostUpdate = useCallback((postId, updater) => {
+    setPosts((prevPosts) =>
+      prevPosts.map((post) => {
+        if (post.id !== postId) return post;
+        const updatedPost = typeof updater === 'function' ? updater(post) : updater;
+        return updatedPost ?? post;
+      })
+    );
+  }, [setPosts]);
+
   const refreshPosts = useCallback(async () => {
     setIsLoading(true);
     try {
@@ -277,7 +287,11 @@ const PostPage = () => {
                             <p className="text-slate-600 font-medium">Loading Community Feed...</p>
                         </motion.div>
                     ) : posts.length > 0 ? (
-                        <PostList posts={posts} refreshPosts={refreshPosts} />
+                        <PostList
+                          posts={posts}
+                          refreshPosts={refreshPosts}
+                          onPostUpdate={handlePostUpdate}
+                        />
                     ) : (
                          <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="text-center py-20 bg-white rounded-2xl border border-slate-200 shadow-sm">
                             <div className="mx-auto w-20 h-20 bg-slate-100 rounded-full flex items-center justify-center mb-4">


### PR DESCRIPTION
## Summary
- fallback to association counts when posts do not expose a comments_count column
- optimistically update post comments and counts after create/delete instead of forcing a full refresh
- add a post update helper so the feed keeps its state in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4c3b89ffc8322a948b26ab590a98c