### PR TITLE
Fix PostList share menu initialization order

### DIFF
--- a/app/javascript/components/PostList.jsx
+++ b/app/javascript/components/PostList.jsx
@@ -27,6 +27,10 @@ const PostList = ({ posts, refreshPosts, onPostUpdate = () => {} }) => {
   const shareButtonRefs = React.useRef({});
   const shareMenuRefs = React.useRef({});
 
+  const closeShareMenu = React.useCallback(() => {
+    setOpenSharePostId(null);
+  }, []);
+
   React.useEffect(() => {
     const initialLikedPosts = new Set();
     const initialLikeCounts = {};
@@ -42,10 +46,6 @@ const PostList = ({ posts, refreshPosts, onPostUpdate = () => {} }) => {
     setLikeCounts(initialLikeCounts);
     closeShareMenu();
   }, [posts, closeShareMenu]);
-
-  const closeShareMenu = React.useCallback(() => {
-    setOpenSharePostId(null);
-  }, []);
 
   const toggleShareMenu = (postId) => {
     setOpenSharePostId((current) => (current === postId ? null : postId));


### PR DESCRIPTION
## Summary
- move the closeShareMenu callback above the effect that depends on it to prevent runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f2570c4c8322abc6dfbd7db948b2