### PR TITLE
Update Ruby requirement to 3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "3.2.3"
+ruby "3.3.0"
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,7 +453,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 3.2.3p0
+   ruby 3.3.0p0
 
 BUNDLED WITH
    2.5.3


### PR DESCRIPTION
## Summary
- bump the declared Ruby version in the Gemfile to 3.3.0
- update the Gemfile.lock Ruby version metadata to match

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e51561595083228cb2c48fab448645