### PR TITLE
Show avatars in team insights views

### DIFF
--- a/app/javascript/components/teams/SkillDirectory.jsx
+++ b/app/javascript/components/teams/SkillDirectory.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import Avatar from "../ui/Avatar";
 
 const SkillDirectory = ({
   members = [],
@@ -149,7 +150,11 @@ const SkillDirectory = ({
             <div className="flex flex-col md:flex-row md:items-center justify-between">
               <div className="flex items-center mb-4 md:mb-0">
                 <div className="bg-indigo-100 rounded-full p-1 mr-4">
-                  <div className="bg-gray-200 border-2 border-dashed rounded-xl w-12 h-12" />
+                  <Avatar
+                    name={member.name}
+                    src={member.profile_picture}
+                    className="w-12 h-12 text-lg"
+                  />
                 </div>
                 <div>
                   <h3 className="font-semibold text-lg">{member.name}</h3>

--- a/app/javascript/components/teams/TeamSkillMatrix.jsx
+++ b/app/javascript/components/teams/TeamSkillMatrix.jsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState } from "react";
+import Avatar from "../ui/Avatar";
 
 const LEVEL_COLORS = {
   expert: "bg-green-100 text-green-800",
@@ -147,7 +148,11 @@ const TeamSkillMatrix = ({ members = [], skills = [], roles = [] }) => {
               <tr key={member.id} className="hover:bg-gray-50">
                 <td className="border border-gray-200 px-4 py-3 text-sm sticky left-0 bg-white z-10">
                   <div className="flex items-center">
-                    <div className="bg-gray-200 border-2 border-dashed rounded-xl w-8 h-8 mr-3" />
+                    <Avatar
+                      name={member.name}
+                      src={member.profile_picture}
+                      className="w-8 h-8 mr-3 text-sm"
+                    />
                     <div>
                       <div className="font-medium">{member.name}</div>
                       <div className="text-gray-500 text-xs">{member.job_title}</div>

--- a/app/javascript/components/ui/Avatar.jsx
+++ b/app/javascript/components/ui/Avatar.jsx
@@ -1,20 +1,25 @@
 import React from "react";
 
 const Avatar = ({ name, src, className = "" }) => {
-  if (src) {
+  const hasValidSrc = src && src !== "null" && src !== "";
+  const displayName = (name || "").trim();
+  const altText = displayName ? `${displayName}'s avatar` : "User avatar";
+
+  if (hasValidSrc) {
     return (
       <img
         src={src}
-        alt={name}
+        alt={altText}
         className={`rounded-full object-cover ${className}`.trim()}
       />
     );
   }
 
-  const initial = name ? name.charAt(0).toUpperCase() : "?";
+  const initial = displayName ? displayName.charAt(0).toUpperCase() : "?";
   return (
     <div
       className={`bg-blue-500 text-white flex items-center justify-center rounded-full font-bold ${className}`.trim()}
+      aria-label={altText}
     >
       {initial}
     </div>


### PR DESCRIPTION
## Summary
- render member avatars in the Team Skill Matrix using the shared Avatar component
- display teammate avatars in the Find Team Experts directory
- harden the Avatar component to ignore null sources and improve accessibility text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5285e46808322a48ad263ee7197eb