### PR TITLE
Ensure sprint timeline auto-scrolls to active sprint

### DIFF
--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -199,6 +199,7 @@ export default function SprintDashboard() {
             projectId={projectId}
             projectName={project?.name}
             selectedDate={selectedDate}
+            isVisible={isHeaderExpanded}
           />
         </div>
       </header>


### PR DESCRIPTION
## Summary
- ensure the sprint manager scrolls the active sprint card into view when it becomes visible
- center the selected sprint card when clicked so the current selection stays in view
- pass the header visibility state down so expanding the selector triggers the auto-scroll

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e60792cd6083228b133ad6d664f9c1