### PR TITLE
Fix layout issues in team insights panels

### DIFF
--- a/app/javascript/components/teams/TeamSkillMatrix.jsx
+++ b/app/javascript/components/teams/TeamSkillMatrix.jsx
@@ -85,7 +85,7 @@ const TeamSkillMatrix = ({ members = [], skills = [], roles = [] }) => {
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-md p-6 space-y-6">
+    <div className="bg-white rounded-xl shadow-md p-6 space-y-6 overflow-hidden">
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         <div>
           <h2 className="text-xl font-bold text-gray-800">Team Skill Matrix</h2>
@@ -113,11 +113,11 @@ const TeamSkillMatrix = ({ members = [], skills = [], roles = [] }) => {
         </div>
       </div>
 
-      <div className="relative overflow-hidden">
+      <div className="relative overflow-hidden w-full">
         <div className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-white via-white/80 to-transparent z-10" />
         <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-white via-white/80 to-transparent z-10" />
-        <div className="overflow-x-auto rounded-lg border border-gray-100 shadow-inner scrollbar-thin">
-          <table className="min-w-max w-full border-collapse">
+        <div className="overflow-x-auto rounded-lg border border-gray-100 shadow-inner scrollbar-thin w-full max-w-full">
+          <table className="w-full min-w-[640px] border-collapse table-auto">
             <thead className="bg-gray-50 sticky top-0 z-20">
               <tr>
                 <th className="border border-gray-200 px-4 py-3 text-left text-sm font-semibold text-gray-700 sticky left-0 top-0 bg-gray-50 z-30">

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -1017,7 +1017,7 @@ const Teams = () => {
                                                             onRemoveSkill={handleDeleteSkill}
                                                         />
                                                     </section>
-                                                    <section id="learning-goals-panel">
+                                                    <section id="learning-goals-panel" className="xl:col-span-2">
                                                         <LearningGoalsPanel
                                                             goals={teamInsights.current_user_learning_goals}
                                                             onCreateGoal={handleCreateGoal}


### PR DESCRIPTION
## Summary
- prevent the team skill matrix table from expanding the entire insights layout by constraining its container width and table sizing
- allow the Your Learning Goals panel to span the full insights width so it no longer appears squashed into a column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e6330ba144832291cd9d8339612042