### PR TITLE
Add knowledge bookmarking with reminders and UI

### DIFF
--- a/app/controllers/api/knowledge_bookmarks_controller.rb
+++ b/app/controllers/api/knowledge_bookmarks_controller.rb
@@ -1,0 +1,69 @@
+require "digest"
+
+class Api::KnowledgeBookmarksController < Api::BaseController
+  before_action :set_bookmark, only: [:update, :destroy, :mark_reviewed]
+
+  def index
+    bookmarks = current_user.knowledge_bookmarks.order(created_at: :desc)
+    render json: bookmarks.map { |bookmark| serialize_bookmark(bookmark) }
+  end
+
+  def create
+    bookmark = current_user.knowledge_bookmarks.find_or_initialize_by(identity_params)
+    bookmark.assign_attributes(bookmark_params)
+
+    if bookmark.save
+      render json: serialize_bookmark(bookmark), status: :created
+    else
+      render json: { errors: bookmark.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @bookmark.update(bookmark_params)
+      render json: serialize_bookmark(@bookmark)
+    else
+      render json: { errors: @bookmark.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @bookmark.destroy
+    head :no_content
+  end
+
+  def mark_reviewed
+    @bookmark.mark_reviewed!
+    render json: serialize_bookmark(@bookmark)
+  end
+
+  private
+
+  def set_bookmark
+    @bookmark = current_user.knowledge_bookmarks.find(params[:id])
+  end
+
+  def identity_params
+    computed_source_id = params[:source_id].presence
+    if computed_source_id.blank? && params[:payload].present?
+      payload_param = params[:payload]
+      payload_hash = payload_param.is_a?(ActionController::Parameters) ? payload_param.to_unsafe_h : payload_param
+      computed_source_id = Digest::SHA256.hexdigest(payload_hash.to_json)
+    end
+
+    { card_type: params[:card_type], source_id: computed_source_id }
+  end
+
+  def bookmark_params
+    params.permit(:collection_name, :reminder_interval_days).tap do |permitted|
+      if params.key?(:payload)
+        payload_param = params[:payload]
+        permitted[:payload] = payload_param.is_a?(ActionController::Parameters) ? payload_param.to_unsafe_h : payload_param
+      end
+    end
+  end
+
+  def serialize_bookmark(bookmark)
+    bookmark.as_json(only: [:id, :card_type, :collection_name, :source_id, :payload, :last_viewed_at, :last_reminded_at, :next_reminder_at, :reminder_interval_days, :created_at, :updated_at])
+  end
+end

--- a/app/javascript/components/Knowledge/BookmarkToggle.jsx
+++ b/app/javascript/components/Knowledge/BookmarkToggle.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { FaRegStar, FaStar } from "react-icons/fa";
+
+export default function BookmarkToggle({
+  isBookmarked,
+  onToggle,
+  collectionName,
+  disabled = false,
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={(event) => {
+        event.stopPropagation();
+        if (disabled) return;
+        onToggle?.();
+      }}
+      className={`inline-flex items-center justify-center rounded-full border px-3 py-1 text-sm font-medium transition-colors ${
+        isBookmarked
+          ? "bg-yellow-100 border-yellow-400 text-yellow-700 hover:bg-yellow-200"
+          : "bg-gray-100 border-gray-300 text-gray-600 hover:bg-gray-200"
+      } ${disabled ? "opacity-60 cursor-not-allowed" : "cursor-pointer"}`}
+      aria-pressed={isBookmarked}
+    >
+      {isBookmarked ? (
+        <FaStar className="mr-2 text-yellow-500" />
+      ) : (
+        <FaRegStar className="mr-2" />
+      )}
+      {isBookmarked ? collectionName || "Saved" : "Save"}
+    </button>
+  );
+}

--- a/app/javascript/components/Knowledge/CommonEnglishWordCard.jsx
+++ b/app/javascript/components/Knowledge/CommonEnglishWordCard.jsx
@@ -1,33 +1,76 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-export default function CommonEnglishWordCard() {
-  const [word, setWord] = useState("");
-  const [loading, setLoading] = useState(true);
+export default function CommonEnglishWordCard({
+  cardType = "common_english_word",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [wordData, setWordData] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     async function loadWord() {
       try {
         const res = await fetch("/api/english_word");
         if (!res.ok) throw new Error("Network error");
         const data = await res.json();
-        setWord(data.word);
+        setWordData({ ...data, fetched_at: new Date().toISOString() });
       } catch (err) {
-        setWord("Unable to fetch word");
+        setWordData({ word: "Unable to fetch word" });
       } finally {
         setLoading(false);
       }
     }
 
     loadWord();
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!wordData?.word) return null;
+    return {
+      cardType,
+      sourceId: wordData.word,
+      payload: wordData,
+      title: "Common English Word",
+      subtitle: wordData.word,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, wordData, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
-      <h2 className="text-lg font-semibold mb-2">Common English Word</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[160px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">Common English Word</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : (
-        <div className="text-sm text-gray-700">{word}</div>
+        <div className="text-sm text-gray-700 font-medium">{wordData?.word}</div>
       )}
     </div>
   );

--- a/app/javascript/components/Knowledge/DailyFactCard.jsx
+++ b/app/javascript/components/Knowledge/DailyFactCard.jsx
@@ -1,11 +1,21 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
 const FACT_COUNT = 5;
 
-export default function DailyFactCard() {
-  const [facts, setFacts] = useState([]);
-  
+export default function DailyFactCard({
+  cardType = "daily_fact",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [facts, setFacts] = useState(() => (hasInitialData ? initialData?.facts || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
+
   useEffect(() => {
+    if (hasInitialData) return;
+
     async function loadFacts() {
       try {
         const requests = Array.from({ length: FACT_COUNT }).map(() =>
@@ -17,23 +27,60 @@ export default function DailyFactCard() {
         setFacts(results);
       } catch (err) {
         console.error("Fact fetch failed", err);
+        setFacts(["Unable to load facts today. Try again later."]);
+      } finally {
+        setLoading(false);
       }
     }
 
     loadFacts();
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!facts.length) return null;
+    return {
+      cardType,
+      sourceId: facts[0],
+      payload: { facts },
+      title: "Daily Facts",
+      subtitle: facts[0],
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, facts, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
-      <h2 className="text-lg font-semibold mb-2">💡 Daily Fact</h2>
-      {facts.length ? (
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[220px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">💡 Daily Fact</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
+      {loading ? (
+        <div className="text-sm text-gray-500">Loading...</div>
+      ) : (
         <ul className="text-sm text-gray-700 italic space-y-1">
-          {facts.map((f, idx) => (
-            <li key={idx}>• {f}</li>
+          {facts.map((fact, idx) => (
+            <li key={idx}>• {fact}</li>
           ))}
         </ul>
-      ) : (
-        <div className="text-sm text-gray-500">Loading...</div>
       )}
     </div>
   );

--- a/app/javascript/components/Knowledge/EnglishPhraseCard.jsx
+++ b/app/javascript/components/Knowledge/EnglishPhraseCard.jsx
@@ -1,16 +1,25 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-export default function EnglishPhraseCard() {
-  const [phrase, setPhrase] = useState(null);
-  const [loading, setLoading] = useState(true);
+export default function EnglishPhraseCard({
+  cardType = "english_phrase",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [phrase, setPhrase] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     async function loadPhrase() {
       try {
         const res = await fetch("/api/english_phrase");
         if (!res.ok) throw new Error("Network error");
         const data = await res.json();
-        setPhrase(data);
+        setPhrase({ ...data, fetched_at: new Date().toISOString() });
       } catch (err) {
         setPhrase({ phrase: "Unable to fetch phrase" });
       } finally {
@@ -19,19 +28,51 @@ export default function EnglishPhraseCard() {
     }
 
     loadPhrase();
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!phrase?.phrase) return null;
+    return {
+      cardType,
+      sourceId: phrase.phrase,
+      payload: phrase,
+      title: "English Phrase",
+      subtitle: phrase.author ? `${phrase.phrase} — ${phrase.author}` : phrase.phrase,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, phrase, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
-      <h2 className="text-lg font-semibold mb-2">English Phrase</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[200px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">English Phrase</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : (
-        <div className="text-sm text-gray-700">
-          <p>“{phrase.phrase}”</p>
-          {phrase.author && (
-            <p className="text-right text-gray-500">— {phrase.author}</p>
-          )}
+        <div className="text-sm text-gray-700 space-y-2">
+          <p className="italic">“{phrase?.phrase}”</p>
+          {phrase?.author && <p className="text-right text-gray-500">— {phrase.author}</p>}
         </div>
       )}
     </div>

--- a/app/javascript/components/Knowledge/EnglishTenseCard.jsx
+++ b/app/javascript/components/Knowledge/EnglishTenseCard.jsx
@@ -1,16 +1,25 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-export default function EnglishTenseCard() {
-  const [tense, setTense] = useState(null);
-  const [loading, setLoading] = useState(true);
+export default function EnglishTenseCard({
+  cardType = "english_tense",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [tense, setTense] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     async function loadTense() {
       try {
         const res = await fetch("/api/english_tense");
         if (!res.ok) throw new Error("Network error");
         const data = await res.json();
-        setTense(data);
+        setTense({ ...data, fetched_at: new Date().toISOString() });
       } catch (err) {
         setTense({ tense: "Unable to fetch tense" });
       } finally {
@@ -19,17 +28,51 @@ export default function EnglishTenseCard() {
     }
 
     loadTense();
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!tense?.tense) return null;
+    return {
+      cardType,
+      sourceId: tense.tense,
+      payload: tense,
+      title: "English Tense",
+      subtitle: tense.example ? `${tense.tense} — ${tense.example}` : tense.tense,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, tense, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
-      <h2 className="text-lg font-semibold mb-2">English Tense</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[180px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">English Tense</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : (
-        <div className="text-sm text-gray-700 space-y-1">
-          <div className="font-medium">{tense.tense}</div>
-          {tense.example && <div className="italic">Example: {tense.example}</div>}
+        <div className="text-sm text-gray-700 space-y-2">
+          <div className="font-medium">{tense?.tense}</div>
+          {tense?.example && <div className="italic">Example: {tense.example}</div>}
         </div>
       )}
     </div>

--- a/app/javascript/components/Knowledge/ImageOfTheDayCard.jsx
+++ b/app/javascript/components/Knowledge/ImageOfTheDayCard.jsx
@@ -1,17 +1,15 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
 const fetchers = [
-  // 1) NASA Astronomy Picture of the Day
   () =>
     fetch("https://api.nasa.gov/planetary/apod?api_key=DEMO_KEY")
       .then((res) => res.json())
       .then((data) => {
         if (data?.url && data.media_type === "image")
-          return { url: data.url, title: data.title };
+          return { url: data.url, title: data.title, copyright: data.copyright };
         throw new Error("Invalid NASA APOD response");
       }),
-
-  // 2) Bing Image of the Day
   () =>
     fetch("https://www.bing.com/HPImageArchive.aspx?format=js&idx=0&n=1")
       .then((res) => res.json())
@@ -24,8 +22,6 @@ const fetchers = [
           };
         throw new Error("Invalid Bing response");
       }),
-
-  // 3) Picsum random image
   () =>
     Promise.resolve({
       url: "https://picsum.photos/800/600",
@@ -38,11 +34,19 @@ const fallbackImage = {
   title: "No image available",
 };
 
-export default function ImageOfTheDayCard() {
-  const [image, setImage] = useState(null);
-  const [loading, setLoading] = useState(true);
+export default function ImageOfTheDayCard({
+  cardType = "image_of_the_day",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [image, setImage] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
@@ -51,12 +55,12 @@ export default function ImageOfTheDayCard() {
         try {
           const result = await fetcher();
           if (mounted) {
-            setImage(result);
+            setImage({ ...result, fetched_at: new Date().toISOString() });
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Image fetch failed, trying next:", e.message);
+        } catch (error) {
+          console.warn("Image fetch failed, trying next:", error.message);
         }
       }
       if (mounted) {
@@ -69,26 +73,56 @@ export default function ImageOfTheDayCard() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!image?.url) return null;
+    return {
+      cardType,
+      sourceId: image.url,
+      payload: image,
+      title: "Image of the Day",
+      subtitle: image.title,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, image, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">🖼️ Image of the Day</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[260px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🖼️ Image of the Day</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : (
         <div className="flex-1 flex flex-col">
           <img
-            src={image.url}
-            alt={image.title}
+            src={image?.url}
+            alt={image?.title || "Image of the day"}
             className="rounded-md object-cover mb-2 w-full h-48"
             loading="lazy"
           />
-          {image.title && (
-            <p className="text-sm text-gray-700">
-              {image.title}
-            </p>
-          )}
+          {image?.title && <p className="text-sm text-gray-700">{image.title}</p>}
         </div>
       )}
     </div>

--- a/app/javascript/components/Knowledge/IndianStockNewsCard.jsx
+++ b/app/javascript/components/Knowledge/IndianStockNewsCard.jsx
@@ -1,13 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-// API keys for optional fallbacks
 const API_KEYS = {
-  NEWSDATA: "YOUR_NEWSDATA_API_KEY", // https://newsdata.io/
+  NEWSDATA: "YOUR_NEWSDATA_API_KEY",
 };
 
-// Try multiple sources in order
 const fetchers = [
-  // 1) Inshorts unofficial API
   () =>
     fetch("https://inshorts.vercel.app/api/news?category=business")
       .then((res) => res.json())
@@ -16,12 +14,8 @@ const fetchers = [
           return data.data.slice(0, 5).map((a) => ({ title: a.title, url: a.url }));
         throw new Error("Invalid Inshorts response");
       }),
-
-  // 2) NewsData.io fallback
   () =>
-    fetch(
-      `https://newsdata.io/api/1/news?apikey=${API_KEYS.NEWSDATA}&country=in&category=business`
-    )
+    fetch(`https://newsdata.io/api/1/news?apikey=${API_KEYS.NEWSDATA}&country=in&category=business`)
       .then((res) => res.json())
       .then((data) => {
         const arr = data?.results;
@@ -31,11 +25,19 @@ const fetchers = [
       }),
 ];
 
-export default function IndianStockNewsCard() {
-  const [articles, setArticles] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function IndianStockNewsCard({
+  cardType = "indian_stock_news",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [articles, setArticles] = useState(() => (hasInitialData ? initialData?.articles || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
@@ -47,8 +49,8 @@ export default function IndianStockNewsCard() {
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Indian news fetch failed:", e.message);
+        } catch (error) {
+          console.warn("Indian news fetch failed:", error.message);
         }
       }
       if (mounted) {
@@ -61,11 +63,45 @@ export default function IndianStockNewsCard() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!articles.length) return null;
+    return {
+      cardType,
+      sourceId: articles[0]?.title || "indian-market-news",
+      payload: { articles },
+      title: "Indian Market News",
+      subtitle: articles[0]?.title,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, articles, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">🇮🇳 Market News</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[220px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🇮🇳 Market News</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : articles.length ? (

--- a/app/javascript/components/Knowledge/QuoteOfTheDayCard.jsx
+++ b/app/javascript/components/Knowledge/QuoteOfTheDayCard.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
 const fetchers = [
-  // 1) ZenQuotes
   () =>
     fetch("https://zenquotes.io/api/today")
       .then((res) => res.json())
@@ -9,8 +9,6 @@ const fetchers = [
         if (data && data[0]?.q) return data[0];
         throw new Error("Invalid ZenQuotes response");
       }),
-
-  // 2) Quotable API
   () =>
     fetch("https://api.quotable.io/random")
       .then((res) => res.json())
@@ -18,8 +16,6 @@ const fetchers = [
         if (data?.content) return { q: data.content, a: data.author };
         throw new Error("Invalid Quotable response");
       }),
-
-  // 3) They Said So Quotes API (free tier)
   () =>
     fetch("https://quotes.rest/qod?language=en")
       .then((res) => res.json())
@@ -37,11 +33,19 @@ const fallbackQuotes = [
   { q: "Any fool can write code that a computer can understand. Good programmers write code that humans can understand.", a: "Martin Fowler" },
 ];
 
-export default function QuoteOfTheDayCard() {
-  const [quote, setQuote] = useState(null);
-  const [loading, setLoading] = useState(true);
+export default function QuoteOfTheDayCard({
+  cardType = "quote_of_the_day",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [quote, setQuote] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
@@ -50,37 +54,70 @@ export default function QuoteOfTheDayCard() {
         try {
           const result = await fetcher();
           if (mounted) {
-            setQuote(result);
+            setQuote({ ...result, fetched_at: new Date().toISOString() });
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Quote fetch failed, trying next:", e.message);
+        } catch (error) {
+          console.warn("Quote fetch failed, trying next:", error.message);
         }
       }
-      // all failed fallback
       if (mounted) {
-        setQuote(fallbackQuotes[Math.floor(Math.random() * fallbackQuotes.length)]);
+        const fallback = fallbackQuotes[Math.floor(Math.random() * fallbackQuotes.length)];
+        setQuote({ ...fallback, fetched_at: new Date().toISOString(), fallback: true });
         setLoading(false);
       }
     }
 
     fetchWithFallback();
-
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!quote?.q) return null;
+    return {
+      cardType,
+      sourceId: `${quote.q}-${quote.a || "unknown"}`,
+      payload: quote,
+      title: "Quote of the Day",
+      subtitle: quote.a ? `${quote.q} — ${quote.a}` : quote.q,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, quote, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between">
-      <h2 className="text-lg font-semibold mb-2">🧘 Quote of the Day</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[200px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🧘 Quote of the Day</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : (
-        <blockquote className="text-sm italic text-gray-700">
-          “{quote.q}”
-          {quote.a && <footer className="mt-2 text-right text-gray-500">– {quote.a}</footer>}
+        <blockquote className="text-sm italic text-gray-700 space-y-2">
+          <p>“{quote?.q}”</p>
+          {quote?.a && <footer className="text-right text-gray-500">– {quote.a}</footer>}
         </blockquote>
       )}
     </div>

--- a/app/javascript/components/Knowledge/RandomCodingTipCard.jsx
+++ b/app/javascript/components/Knowledge/RandomCodingTipCard.jsx
@@ -1,10 +1,19 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-export default function RandomCodingTipCard() {
-  const [tip, setTip] = useState("");
-  const [loading, setLoading] = useState(true);
+export default function RandomCodingTipCard({
+  cardType = "coding_tip",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [tipData, setTipData] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     async function fetchCodingTip() {
       setLoading(true);
       try {
@@ -12,24 +21,58 @@ export default function RandomCodingTipCard() {
         if (!res.ok) throw new Error("Network error");
 
         const data = await res.json();
-        setTip(data.tip);
+        setTipData({ ...data, fetched_at: new Date().toISOString() });
       } catch (error) {
-        setTip("Unable to fetch tip. Please try again later.");
+        setTipData({ tip: "Unable to fetch tip. Please try again later." });
       } finally {
         setLoading(false);
       }
     }
 
     fetchCodingTip();
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!tipData?.tip) return null;
+    return {
+      cardType,
+      sourceId: tipData.tip,
+      payload: tipData,
+      title: "AI Coding Tip of the Day",
+      subtitle: tipData.tip,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, tipData, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-center">
-      <h2 className="text-lg font-semibold mb-2">💡 AI Coding Tip of the Day</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[180px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">💡 AI Coding Tip of the Day</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <p className="text-sm text-gray-500">Loading AI-generated tip...</p>
       ) : (
-        <p className="text-sm text-gray-700">{tip}</p>
+        <p className="text-sm text-gray-700 leading-relaxed">{tipData?.tip}</p>
       )}
     </div>
   );

--- a/app/javascript/components/Knowledge/ScienceNewsCard.jsx
+++ b/app/javascript/components/Knowledge/ScienceNewsCard.jsx
@@ -1,11 +1,11 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
 const API_KEYS = {
-  GUARDIAN: "YOUR_GUARDIAN_KEY", // secondary
+  GUARDIAN: "YOUR_GUARDIAN_KEY",
 };
 
 const fetchers = [
-  // 1) Spaceflight News API (no key required)
   () =>
     fetch("https://api.spaceflightnewsapi.net/v4/articles/?limit=5")
       .then((res) => res.json())
@@ -14,32 +14,22 @@ const fetchers = [
           return data.results.map((a) => ({ title: a.title, url: a.url }));
         throw new Error("Invalid Spaceflight News response");
       }),
-
-  // 2) ScienceDaily RSS via rss2json
   () =>
-    fetch(
-      "https://api.rss2json.com/v1/api.json?rss_url=https://www.sciencedaily.com/rss/top/science.xml"
-    )
+    fetch("https://api.rss2json.com/v1/api.json?rss_url=https://www.sciencedaily.com/rss/top/science.xml")
       .then((res) => res.json())
       .then((data) => {
         if (data?.items?.length)
           return data.items.slice(0, 5).map((a) => ({ title: a.title, url: a.link }));
         throw new Error("Invalid ScienceDaily response");
       }),
-
-  // 3) The Guardian science section
   () =>
-    fetch(
-      `https://content.guardianapis.com/search?section=science&page-size=5&api-key=${API_KEYS.GUARDIAN}`
-    )
+    fetch(`https://content.guardianapis.com/search?section=science&page-size=5&api-key=${API_KEYS.GUARDIAN}`)
       .then((res) => res.json())
       .then((data) => {
         if (data?.response?.results?.length)
           return data.response.results.map((a) => ({ title: a.webTitle, url: a.webUrl }));
         throw new Error("Invalid Guardian response");
       }),
-
-  // 4) Inshorts science news (unofficial)
   () =>
     fetch("https://inshorts.vercel.app/api/news?category=science")
       .then((res) => res.json())
@@ -50,11 +40,19 @@ const fetchers = [
       }),
 ];
 
-export default function ScienceNewsCard() {
-  const [articles, setArticles] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function ScienceNewsCard({
+  cardType = "science_news",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [articles, setArticles] = useState(() => (hasInitialData ? initialData?.articles || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
@@ -67,8 +65,8 @@ export default function ScienceNewsCard() {
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Science news fetch failed:", e.message);
+        } catch (error) {
+          console.warn("Science news fetch failed:", error.message);
         }
       }
       if (mounted) {
@@ -81,11 +79,45 @@ export default function ScienceNewsCard() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!articles.length) return null;
+    return {
+      cardType,
+      sourceId: articles[0]?.title || "science-news",
+      payload: { articles },
+      title: "Science News",
+      subtitle: articles[0]?.title,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, articles, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">🔬 Science News</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[220px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🔬 Science News</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : articles.length ? (

--- a/app/javascript/components/Knowledge/TechNewsCard.jsx
+++ b/app/javascript/components/Knowledge/TechNewsCard.jsx
@@ -1,39 +1,29 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
 const API_KEYS = {
-  NEWSAPI: "YOUR_NEWSAPI_KEY", // secondary
+  NEWSAPI: "YOUR_NEWSAPI_KEY",
 };
 
 const fetchers = [
-  // 1) Hacker News Algolia API
   () =>
-    fetch(
-      "https://hn.algolia.com/api/v1/search?tags=story&query=technology&hitsPerPage=5"
-    )
+    fetch("https://hn.algolia.com/api/v1/search?tags=story&query=technology&hitsPerPage=5")
       .then((res) => res.json())
       .then((data) => {
         if (data?.hits?.length)
           return data.hits.map((a) => ({ title: a.title, url: a.url }));
         throw new Error("Invalid Hacker News response");
       }),
-
-  // 2) NewsAPI technology headlines
   () =>
-    fetch(
-      `https://newsapi.org/v2/top-headlines?country=us&category=technology&apiKey=${API_KEYS.NEWSAPI}`
-    )
+    fetch(`https://newsapi.org/v2/top-headlines?country=us&category=technology&apiKey=${API_KEYS.NEWSAPI}`)
       .then((res) => res.json())
       .then((data) => {
         if (data?.articles?.length)
           return data.articles.slice(0, 5).map((a) => ({ title: a.title, url: a.url }));
         throw new Error("Invalid NewsAPI response");
       }),
-
-  // 3) Ars Technica RSS via rss2json
   () =>
-    fetch(
-      "https://api.rss2json.com/v1/api.json?rss_url=https://feeds.arstechnica.com/arstechnica/index"
-    )
+    fetch("https://api.rss2json.com/v1/api.json?rss_url=https://feeds.arstechnica.com/arstechnica/index")
       .then((res) => res.json())
       .then((data) => {
         if (data?.items?.length)
@@ -42,11 +32,19 @@ const fetchers = [
       }),
 ];
 
-export default function TechNewsCard() {
-  const [articles, setArticles] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function TechNewsCard({
+  cardType = "tech_news",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [articles, setArticles] = useState(() => (hasInitialData ? initialData?.articles || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
@@ -59,8 +57,8 @@ export default function TechNewsCard() {
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Tech news fetch failed:", e.message);
+        } catch (error) {
+          console.warn("Tech news fetch failed:", error.message);
         }
       }
       if (mounted) {
@@ -73,11 +71,45 @@ export default function TechNewsCard() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!articles.length) return null;
+    return {
+      cardType,
+      sourceId: articles[0]?.title || "tech-news",
+      payload: { articles },
+      title: "Tech News",
+      subtitle: articles[0]?.title,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, articles, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">💻 Tech News</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[220px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">💻 Tech News</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : articles.length ? (

--- a/app/javascript/components/Knowledge/TodayInHistoryCard.jsx
+++ b/app/javascript/components/Knowledge/TodayInHistoryCard.jsx
@@ -1,25 +1,77 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-export default function TodayInHistoryCard() {
-  const [events, setEvents] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function TodayInHistoryCard({
+  cardType = "today_in_history",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [events, setEvents] = useState(() => (hasInitialData ? initialData?.events || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     const today = new Date();
     const month = today.getMonth() + 1;
     const day = today.getDate();
 
-    fetch(`https://byabbe.se/on-this-day/${month}/${day}/events.json`)
-      .then(res => res.json())
-      .then(data => {
-        setEvents(data.events.slice(0, 5)); // Limit to 5 items
+    async function fetchEvents() {
+      setLoading(true);
+      try {
+        const res = await fetch(`https://byabbe.se/on-this-day/${month}/${day}/events.json`);
+        const data = await res.json();
+        setEvents((data?.events || []).slice(0, 5));
+      } catch (error) {
+        console.error("Today in history fetch failed", error);
+        setEvents([]);
+      } finally {
         setLoading(false);
-      });
-  }, []);
+      }
+    }
+
+    fetchEvents();
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!events.length) return null;
+    return {
+      cardType,
+      sourceId: `${events[0]?.year}-${events[0]?.description?.slice(0, 20)}`,
+      payload: { events },
+      title: "Today in History",
+      subtitle: events[0] ? `${events[0].year}: ${events[0].description}` : "",
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, events, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">📅 Today in History</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[220px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">📅 Today in History</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : (

--- a/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
+++ b/app/javascript/components/Knowledge/TopBuyingStocksCard.jsx
@@ -1,17 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-// API keys for buy volume data
 const API_KEYS = {
-  FMP: "e5ye9VH06cq5TTNyyA6z2gd2S8pf9sBV", // Financial Modeling Prep
-  ALPHA: "YOUR_ALPHA_VANTAGE_KEY", // AlphaVantage fallback
+  FMP: "e5ye9VH06cq5TTNyyA6z2gd2S8pf9sBV",
+  ALPHA: "YOUR_ALPHA_VANTAGE_KEY",
 };
 
 const fetchers = [
-  // 1) Financial Modeling Prep actives endpoint (NSE) as a proxy for heavy buying
   () =>
-    fetch(
-      `https://financialmodelingprep.com/api/v3/stock_market/actives?exchange=NSE&apikey=${API_KEYS.FMP}`
-    )
+    fetch(`https://financialmodelingprep.com/api/v3/stock_market/actives?exchange=NSE&apikey=${API_KEYS.FMP}`)
       .then((res) => res.json())
       .then((data) => {
         if (Array.isArray(data) && data.length)
@@ -21,12 +18,8 @@ const fetchers = [
           }));
         throw new Error("Invalid FMP response");
       }),
-
-  // 2) AlphaVantage market movers for most active Indian stocks
   () =>
-    fetch(
-      `https://www.alphavantage.co/query?function=TOP_GAINERS_LOSERS&market=IN&apikey=${API_KEYS.ALPHA}`
-    )
+    fetch(`https://www.alphavantage.co/query?function=TOP_GAINERS_LOSERS&market=IN&apikey=${API_KEYS.ALPHA}`)
       .then((res) => res.json())
       .then((data) => {
         const arr = data?.most_actively_traded || data?.mostActiveStock;
@@ -39,11 +32,19 @@ const fetchers = [
       }),
 ];
 
-export default function TopBuyingStocksCard() {
-  const [stocks, setStocks] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function TopBuyingStocksCard({
+  cardType = "top_buying",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [stocks, setStocks] = useState(() => (hasInitialData ? initialData?.stocks || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
@@ -56,8 +57,8 @@ export default function TopBuyingStocksCard() {
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Top buying fetch failed:", e.message);
+        } catch (error) {
+          console.warn("Top buying fetch failed:", error.message);
         }
       }
       if (mounted) {
@@ -67,21 +68,54 @@ export default function TopBuyingStocksCard() {
     }
 
     fetchWithFallback();
-
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!stocks.length) return null;
+    return {
+      cardType,
+      sourceId: stocks[0]?.symbol || "top-buying",
+      payload: { stocks },
+      title: "Top Buying",
+      subtitle: `${stocks[0]?.symbol} • ${stocks[0]?.qty}`,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, stocks, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">🇮🇳 Top Buying</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[200px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🇮🇳 Top Buying</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : stocks.length ? (
         <ul className="text-sm space-y-1 text-gray-700 overflow-auto">
-          {stocks.map((s, idx) => (
-            <li key={idx}>• {s.symbol} - {s.qty}</li>
+          {stocks.map((stock, idx) => (
+            <li key={idx}>• {stock.symbol} - {stock.qty}</li>
           ))}
         </ul>
       ) : (

--- a/app/javascript/components/Knowledge/TopNewsCard.jsx
+++ b/app/javascript/components/Knowledge/TopNewsCard.jsx
@@ -1,62 +1,67 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
 const API_KEYS = {
-  GNEWS: "d098827abeb336616016d7585e1931e9",          // primary
-  NEWSAPI: "YOUR_NEWSAPI_KEY",          // secondary
+  GNEWS: "d098827abeb336616016d7585e1931e9",
+  NEWSAPI: "YOUR_NEWSAPI_KEY",
 };
 
-export default function TopNewsCard() {
-  const [articles, setArticles] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function TopNewsCard({
+  cardType = "top_news",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [articles, setArticles] = useState(() => (hasInitialData ? initialData?.articles || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
 
-  // API URLs in priority order with fetch functions
-  const fetchers = [
-    // 1) GNews API
-    () =>
-      fetch(`https://gnews.io/api/v4/top-headlines?lang=en&token=${API_KEYS.GNEWS}`)
-        .then((res) => res.json())
-        .then((data) => {
-          if (data.articles && data.articles.length) return data.articles.slice(0, 5);
-          throw new Error("No articles in GNews response");
-        }),
-
-    // 2) NewsAPI.org
-    () =>
-      fetch(`https://newsapi.org/v2/top-headlines?country=us&apiKey=${API_KEYS.NEWSAPI}`)
-        .then((res) => res.json())
-        .then((data) => {
-          if (data.articles && data.articles.length) return data.articles.slice(0, 5);
-          throw new Error("No articles in NewsAPI response");
-        }),
-
-    // 3) Backup public RSS to JSON (example)
-    () =>
-      fetch("https://api.rss2json.com/v1/api.json?rss_url=https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml")
-        .then((res) => res.json())
-        .then((data) => {
-          if (data.items && data.items.length) return data.items.slice(0, 5);
-          throw new Error("No articles in RSS backup");
-        }),
-  ];
+  const fetchers = useMemo(
+    () => [
+      () =>
+        fetch(`https://gnews.io/api/v4/top-headlines?lang=en&token=${API_KEYS.GNEWS}`)
+          .then((res) => res.json())
+          .then((data) => {
+            if (data.articles && data.articles.length) return data.articles.slice(0, 5);
+            throw new Error("No articles in GNews response");
+          }),
+      () =>
+        fetch(`https://newsapi.org/v2/top-headlines?country=us&apiKey=${API_KEYS.NEWSAPI}`)
+          .then((res) => res.json())
+          .then((data) => {
+            if (data.articles && data.articles.length) return data.articles.slice(0, 5);
+            throw new Error("No articles in NewsAPI response");
+          }),
+      () =>
+        fetch("https://api.rss2json.com/v1/api.json?rss_url=https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml")
+          .then((res) => res.json())
+          .then((data) => {
+            if (data.items && data.items.length) return data.items.slice(0, 5);
+            throw new Error("No articles in RSS backup");
+          }),
+    ],
+    []
+  );
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
       setLoading(true);
-      for (let fetcher of fetchers) {
+      for (const fetcher of fetchers) {
         try {
-          const articles = await fetcher();
+          const latestArticles = await fetcher();
           if (mounted) {
-            setArticles(articles);
+            setArticles(latestArticles);
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Fetch failed, trying next API:", e.message);
+        } catch (error) {
+          console.warn("Fetch failed, trying next API:", error.message);
         }
       }
-      // all failed
       if (mounted) {
         setArticles([]);
         setLoading(false);
@@ -64,15 +69,48 @@ export default function TopNewsCard() {
     }
 
     fetchWithFallback();
-
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [fetchers, hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!articles.length) return null;
+    return {
+      cardType,
+      sourceId: articles[0]?.title || articles[0]?.title_no_format || "top-news",
+      payload: { articles },
+      title: "Top News",
+      subtitle: articles[0]?.title || "Top headlines",
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, articles, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">📰 Top News</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[220px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">📰 Top News</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : articles.length ? (

--- a/app/javascript/components/Knowledge/TopVolumeStocksCard.jsx
+++ b/app/javascript/components/Knowledge/TopVolumeStocksCard.jsx
@@ -1,18 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
 
-// API keys for external stock data sources
 const API_KEYS = {
-  FMP: "e5ye9VH06cq5TTNyyA6z2gd2S8pf9sBV", // Financial Modeling Prep
-  ALPHA: "YOUR_ALPHA_VANTAGE_KEY", // AlphaVantage fallback
+  FMP: "e5ye9VH06cq5TTNyyA6z2gd2S8pf9sBV",
+  ALPHA: "YOUR_ALPHA_VANTAGE_KEY",
 };
 
-// Functions that fetch stock data in priority order
 const fetchers = [
-  // 1) Financial Modeling Prep - most active NSE stocks (high volume)
   () =>
-    fetch(
-      `https://financialmodelingprep.com/api/v3/stock_market/actives?exchange=NSE&apikey=${API_KEYS.FMP}`
-    )
+    fetch(`https://financialmodelingprep.com/api/v3/stock_market/actives?exchange=NSE&apikey=${API_KEYS.FMP}`)
       .then((res) => res.json())
       .then((data) => {
         if (Array.isArray(data) && data.length)
@@ -22,12 +18,8 @@ const fetchers = [
           }));
         throw new Error("Invalid FMP response");
       }),
-
-  // 2) AlphaVantage market movers endpoint for India
   () =>
-    fetch(
-      `https://www.alphavantage.co/query?function=TOP_GAINERS_LOSERS&market=IN&apikey=${API_KEYS.ALPHA}`
-    )
+    fetch(`https://www.alphavantage.co/query?function=TOP_GAINERS_LOSERS&market=IN&apikey=${API_KEYS.ALPHA}`)
       .then((res) => res.json())
       .then((data) => {
         const arr = data?.most_actively_traded || data?.mostActiveStock;
@@ -40,11 +32,19 @@ const fetchers = [
       }),
 ];
 
-export default function TopVolumeStocksCard() {
-  const [stocks, setStocks] = useState([]);
-  const [loading, setLoading] = useState(true);
+export default function TopVolumeStocksCard({
+  cardType = "top_volume",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [stocks, setStocks] = useState(() => (hasInitialData ? initialData?.stocks || [] : []));
+  const [loading, setLoading] = useState(!hasInitialData);
 
   useEffect(() => {
+    if (hasInitialData) return;
+
     let mounted = true;
 
     async function fetchWithFallback() {
@@ -57,8 +57,8 @@ export default function TopVolumeStocksCard() {
             setLoading(false);
           }
           return;
-        } catch (e) {
-          console.warn("Top volume fetch failed:", e.message);
+        } catch (error) {
+          console.warn("Top volume fetch failed:", error.message);
         }
       }
       if (mounted) {
@@ -68,21 +68,54 @@ export default function TopVolumeStocksCard() {
     }
 
     fetchWithFallback();
-
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!stocks.length) return null;
+    return {
+      cardType,
+      sourceId: stocks[0]?.symbol || "top-volume",
+      payload: { stocks },
+      title: "Top Volume",
+      subtitle: `${stocks[0]?.symbol} • ${stocks[0]?.volume}`,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, stocks, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
 
   return (
-    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col">
-      <h2 className="text-lg font-semibold mb-2">🇮🇳 Top Volume</h2>
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[200px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🇮🇳 Top Volume</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
       {loading ? (
         <div className="text-sm text-gray-500">Loading...</div>
       ) : stocks.length ? (
         <ul className="text-sm space-y-1 text-gray-700 overflow-auto">
-          {stocks.map((s, idx) => (
-            <li key={idx}>• {s.symbol} - {s.volume}</li>
+          {stocks.map((stock, idx) => (
+            <li key={idx}>• {stock.symbol} - {stock.volume}</li>
           ))}
         </ul>
       ) : (

--- a/app/javascript/context/KnowledgeBookmarksContext.jsx
+++ b/app/javascript/context/KnowledgeBookmarksContext.jsx
@@ -1,0 +1,198 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+const KnowledgeBookmarksContext = createContext();
+
+function getCSRFToken() {
+  const meta = document.querySelector("meta[name='csrf-token']");
+  return meta?.getAttribute("content");
+}
+
+export function KnowledgeBookmarksProvider({ children }) {
+  const [bookmarks, setBookmarks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const fetchBookmarks = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetch("/api/knowledge_bookmarks", { credentials: "include" });
+      if (!response.ok) throw new Error("Unable to load bookmarks");
+      const data = await response.json();
+      setBookmarks(data);
+      setError(null);
+    } catch (err) {
+      console.error(err);
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBookmarks();
+  }, [fetchBookmarks]);
+
+  const collections = useMemo(() => {
+    return Array.from(new Set(bookmarks.map((b) => b.collection_name).filter(Boolean))).sort();
+  }, [bookmarks]);
+
+  const upsertBookmarkInState = useCallback((bookmark) => {
+    setBookmarks((prev) => {
+      const existingIndex = prev.findIndex((b) => b.id === bookmark.id);
+      if (existingIndex >= 0) {
+        const clone = [...prev];
+        clone[existingIndex] = bookmark;
+        return clone;
+      }
+      return [bookmark, ...prev];
+    });
+  }, []);
+
+  const removeBookmarkFromState = useCallback((id) => {
+    setBookmarks((prev) => prev.filter((bookmark) => bookmark.id !== id));
+  }, []);
+
+  const findBookmark = useCallback(
+    ({ cardType, sourceId, payload }) => {
+      return bookmarks.find((bookmark) => {
+        if (bookmark.card_type !== cardType) return false;
+        if (sourceId && bookmark.source_id) {
+          return bookmark.source_id === sourceId;
+        }
+        if (sourceId && !bookmark.source_id) {
+          return false;
+        }
+        if (!sourceId && bookmark.source_id) {
+          return false;
+        }
+        return JSON.stringify(bookmark.payload) === JSON.stringify(payload);
+      });
+    },
+    [bookmarks]
+  );
+
+  const createBookmark = useCallback(
+    async ({ cardType, sourceId, payload, collectionName, reminderIntervalDays }) => {
+      const response = await fetch("/api/knowledge_bookmarks", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": getCSRFToken(),
+          Accept: "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify({
+          card_type: cardType,
+          source_id: sourceId,
+          payload,
+          collection_name: collectionName,
+          reminder_interval_days: reminderIntervalDays,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.errors?.join(", ") || "Unable to save bookmark");
+      }
+
+      const data = await response.json();
+      upsertBookmarkInState(data);
+      return data;
+    },
+    [upsertBookmarkInState]
+  );
+
+  const deleteBookmark = useCallback(async (id) => {
+    const response = await fetch(`/api/knowledge_bookmarks/${id}`, {
+      method: "DELETE",
+      headers: {
+        "X-CSRF-Token": getCSRFToken(),
+      },
+      credentials: "include",
+    });
+
+    if (!response.ok) {
+      throw new Error("Unable to delete bookmark");
+    }
+
+    removeBookmarkFromState(id);
+  }, [removeBookmarkFromState]);
+
+  const updateBookmark = useCallback(
+    async (id, payload) => {
+      const response = await fetch(`/api/knowledge_bookmarks/${id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRF-Token": getCSRFToken(),
+          Accept: "application/json",
+        },
+        credentials: "include",
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.errors?.join(", ") || "Unable to update bookmark");
+      }
+
+      const data = await response.json();
+      upsertBookmarkInState(data);
+      return data;
+    },
+    [upsertBookmarkInState]
+  );
+
+  const markReviewed = useCallback(
+    async (id) => {
+      const response = await fetch(`/api/knowledge_bookmarks/${id}/mark_reviewed`, {
+        method: "POST",
+        headers: {
+          "X-CSRF-Token": getCSRFToken(),
+          Accept: "application/json",
+        },
+        credentials: "include",
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.errors?.join(", ") || "Unable to mark bookmark as reviewed");
+      }
+
+      const data = await response.json();
+      upsertBookmarkInState(data);
+      return data;
+    },
+    [upsertBookmarkInState]
+  );
+
+  const value = useMemo(
+    () => ({
+      bookmarks,
+      collections,
+      loading,
+      error,
+      findBookmark,
+      createBookmark,
+      deleteBookmark,
+      updateBookmark,
+      markReviewed,
+      refresh: fetchBookmarks,
+    }),
+    [bookmarks, collections, loading, error, findBookmark, createBookmark, deleteBookmark, updateBookmark, markReviewed, fetchBookmarks]
+  );
+
+  return (
+    <KnowledgeBookmarksContext.Provider value={value}>
+      {children}
+    </KnowledgeBookmarksContext.Provider>
+  );
+}
+
+export function useKnowledgeBookmarks() {
+  const context = useContext(KnowledgeBookmarksContext);
+  if (!context) {
+    throw new Error("useKnowledgeBookmarks must be used within a KnowledgeBookmarksProvider");
+  }
+  return context;
+}

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import TodayInHistoryCard from "../components/Knowledge/TodayInHistoryCard";
 import QuoteOfTheDayCard from "../components/Knowledge/QuoteOfTheDayCard";
@@ -16,51 +16,174 @@ import CommonEnglishWordCard from "../components/Knowledge/CommonEnglishWordCard
 import EnglishTenseCard from "../components/Knowledge/EnglishTenseCard";
 import EnglishPhraseCard from "../components/Knowledge/EnglishPhraseCard";
 import ImageOfTheDayCard from "../components/Knowledge/ImageOfTheDayCard";
+import { KnowledgeBookmarksProvider, useKnowledgeBookmarks } from "../context/KnowledgeBookmarksContext";
 
-export default function KnowledgeDashboard() {
+function KnowledgeDashboardContent() {
   const [activeCategory, setActiveCategory] = useState("all");
-  const [isLoading, setIsLoading] = useState(true);
+  const [uiLoading, setUiLoading] = useState(true);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [pendingBookmark, setPendingBookmark] = useState(null);
+  const [collectionName, setCollectionName] = useState("");
+  const [lastCollectionName, setLastCollectionName] = useState("");
+  const [reminderIntervalDays, setReminderIntervalDays] = useState(7);
+  const [feedback, setFeedback] = useState(null);
 
-  // Simulate loading
+  const {
+    bookmarks,
+    collections,
+    loading: bookmarksLoading,
+    createBookmark,
+    deleteBookmark,
+    findBookmark,
+    markReviewed,
+  } = useKnowledgeBookmarks();
+
   useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 1500);
+    const timer = setTimeout(() => setUiLoading(false), 600);
     return () => clearTimeout(timer);
   }, []);
 
-  const categories = [
-    { id: "all", name: "All", icon: "🌐" },
-    { id: "news", name: "News", icon: "📰" },
-    { id: "learning", name: "Learning", icon: "🎓" },
-    { id: "stocks", name: "Stocks", icon: "📈" },
-    { id: "tech", name: "Tech", icon: "💻" },
-  ];
+  const dueBookmarks = useMemo(() => {
+    const now = new Date();
+    return bookmarks.filter((bookmark) => bookmark.next_reminder_at && new Date(bookmark.next_reminder_at) <= now);
+  }, [bookmarks]);
 
-  const cards = [
-    { component: <TodayInHistoryCard />, category: "learning" },
-    { component: <QuoteOfTheDayCard />, category: "learning" },
-    { component: <ImageOfTheDayCard />, category: "learning" },
-    { component: <TopNewsCard />, category: "news" },
-    { component: <DailyFactCard />, category: "learning" },
-    { component: <WordOfTheDayCard />, category: "learning" },
-    { component: <CommonEnglishWordCard />, category: "learning" },
-    { component: <EnglishTenseCard />, category: "learning" },
-    { component: <EnglishPhraseCard />, category: "learning" },
-    { component: <RandomCodingTipCard />, category: "tech" },
-    { component: <ScienceNewsCard />, category: "news" },
-    { component: <TechNewsCard />, category: "tech" },
-    { component: <TopGainersCard />, category: "stocks" },
-    { component: <TopVolumeStocksCard />, category: "stocks" },
-    { component: <TopBuyingStocksCard />, category: "stocks" },
-    { component: <IndianStockNewsCard />, category: "stocks" },
-  ];
+  const savedCount = bookmarks.length;
+  const dueCount = dueBookmarks.length;
 
-  const filteredCards = activeCategory === "all" 
-    ? cards 
-    : cards.filter(card => card.category === activeCategory);
+  const categories = useMemo(
+    () => [
+      { id: "all", name: "All", icon: "🌐" },
+      { id: "news", name: "News", icon: "📰" },
+      { id: "learning", name: "Learning", icon: "🎓" },
+      { id: "stocks", name: "Stocks", icon: "📈" },
+      { id: "tech", name: "Tech", icon: "💻" },
+      { id: "saved", name: `Saved (${savedCount})`, icon: "⭐" },
+      { id: "due", name: `Due (${dueCount})`, icon: "🔔" },
+    ],
+    [savedCount, dueCount]
+  );
+
+  const cardDefinitions = useMemo(
+    () => [
+      { key: "today-history", cardType: "today_in_history", category: "learning", Component: TodayInHistoryCard },
+      { key: "quote-of-day", cardType: "quote_of_the_day", category: "learning", Component: QuoteOfTheDayCard },
+      { key: "image-day", cardType: "image_of_the_day", category: "learning", Component: ImageOfTheDayCard },
+      { key: "top-news", cardType: "top_news", category: "news", Component: TopNewsCard },
+      { key: "daily-fact", cardType: "daily_fact", category: "learning", Component: DailyFactCard },
+      { key: "word-day", cardType: "word_of_the_day", category: "learning", Component: WordOfTheDayCard },
+      { key: "common-word", cardType: "common_english_word", category: "learning", Component: CommonEnglishWordCard },
+      { key: "english-tense", cardType: "english_tense", category: "learning", Component: EnglishTenseCard },
+      { key: "english-phrase", cardType: "english_phrase", category: "learning", Component: EnglishPhraseCard },
+      { key: "coding-tip", cardType: "coding_tip", category: "tech", Component: RandomCodingTipCard },
+      { key: "science-news", cardType: "science_news", category: "news", Component: ScienceNewsCard },
+      { key: "tech-news", cardType: "tech_news", category: "tech", Component: TechNewsCard },
+      { key: "top-gainers", cardType: "top_gainers", category: "stocks", Component: TopGainersCard },
+      { key: "top-volume", cardType: "top_volume", category: "stocks", Component: TopVolumeStocksCard },
+      { key: "top-buying", cardType: "top_buying", category: "stocks", Component: TopBuyingStocksCard },
+      { key: "indian-news", cardType: "indian_stock_news", category: "stocks", Component: IndianStockNewsCard },
+    ],
+    []
+  );
+
+  const cardTypeMap = useMemo(() => {
+    const map = new Map();
+    cardDefinitions.forEach((definition) => {
+      map.set(definition.cardType, definition);
+    });
+    return map;
+  }, [cardDefinitions]);
+
+  const handleBookmarkToggle = async (bookmarkData) => {
+    if (!bookmarkData) return;
+    const existing = findBookmark(bookmarkData);
+    try {
+      if (existing) {
+        await deleteBookmark(existing.id);
+        setFeedback({ type: "info", message: "Removed from saved" });
+      } else {
+        setPendingBookmark(bookmarkData);
+        setCollectionName(bookmarkData.collectionName || lastCollectionName || "");
+        setReminderIntervalDays(bookmarkData.reminderIntervalDays || 7);
+        setModalOpen(true);
+      }
+    } catch (err) {
+      setFeedback({ type: "error", message: err.message });
+    }
+  };
+
+  const bookmarkHelpers = useMemo(
+    () => ({
+      toggle: handleBookmarkToggle,
+      find: (bookmarkPayload) => findBookmark(bookmarkPayload),
+      markReviewed: async (bookmark) => {
+        try {
+          await markReviewed(bookmark.id);
+          setFeedback({ type: "success", message: "Marked as reviewed" });
+        } catch (err) {
+          setFeedback({ type: "error", message: err.message });
+        }
+      },
+    }),
+    [findBookmark, handleBookmarkToggle, markReviewed]
+  );
+
+  const filteredCards = useMemo(() => {
+    if (activeCategory === "saved") {
+      return bookmarks.map((bookmark) => {
+        const definition = cardTypeMap.get(bookmark.card_type);
+        return {
+          key: `bookmark-${bookmark.id}`,
+          Component: definition?.Component ?? SavedBookmarkFallback,
+          cardType: bookmark.card_type,
+          props: {
+            bookmarkHelpers,
+            initialData: bookmark.payload,
+            savedBookmark: bookmark,
+            isSavedView: true,
+            cardType: bookmark.card_type,
+          },
+          bookmark,
+        };
+      });
+    }
+
+    if (activeCategory === "due") {
+      return dueBookmarks.map((bookmark) => {
+        const definition = cardTypeMap.get(bookmark.card_type);
+        return {
+          key: `due-${bookmark.id}`,
+          Component: definition?.Component ?? SavedBookmarkFallback,
+          cardType: bookmark.card_type,
+          props: {
+            bookmarkHelpers,
+            initialData: bookmark.payload,
+            savedBookmark: bookmark,
+            isSavedView: true,
+            cardType: bookmark.card_type,
+          },
+          bookmark,
+        };
+      });
+    }
+
+    return cardDefinitions
+      .filter((definition) => activeCategory === "all" || definition.category === activeCategory)
+      .map((definition) => ({
+        key: definition.key,
+        Component: definition.Component,
+        cardType: definition.cardType,
+        props: {
+          bookmarkHelpers,
+          cardType: definition.cardType,
+        },
+      }));
+  }, [activeCategory, bookmarks, bookmarkHelpers, cardDefinitions, cardTypeMap, dueBookmarks]);
+
+  const isLoading = uiLoading || (bookmarksLoading && activeCategory !== "saved" && activeCategory !== "due");
 
   return (
     <div className="min-h-screen transition-colors duration-300 bg-[rgb(var(--theme-color-rgb)/0.1)] text-gray-900">
-      {/* Header */}
       <header className="sticky top-0 z-10 backdrop-blur-md bg-white/80 border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-6 py-4 flex flex-col sm:flex-row justify-between items-center">
           <div className="flex items-center mb-4 sm:mb-0">
@@ -76,8 +199,8 @@ export default function KnowledgeDashboard() {
                 onClick={() => setActiveCategory(cat.id)}
                 className={`px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors ${
                   activeCategory === cat.id
-                    ? 'bg-[var(--theme-color)] text-white'
-                    : 'bg-gray-200 hover:bg-gray-300'
+                    ? "bg-[var(--theme-color)] text-white"
+                    : "bg-gray-200 hover:bg-gray-300"
                 }`}
               >
                 {cat.icon} {cat.name}
@@ -86,6 +209,25 @@ export default function KnowledgeDashboard() {
           </div>
         </div>
       </header>
+
+      {feedback && (
+        <div className="max-w-7xl mx-auto px-6 pt-4">
+          <div
+            className={`rounded-xl px-4 py-3 text-sm ${
+              feedback.type === "error"
+                ? "bg-red-100 text-red-700"
+                : feedback.type === "info"
+                ? "bg-blue-100 text-blue-700"
+                : "bg-emerald-100 text-emerald-700"
+            }`}
+          >
+            {feedback.message}
+            <button className="ml-4 text-xs underline" onClick={() => setFeedback(null)}>
+              dismiss
+            </button>
+          </div>
+        </div>
+      )}
 
       <main className="max-w-7xl mx-auto px-6 py-8">
         {isLoading ? (
@@ -101,14 +243,11 @@ export default function KnowledgeDashboard() {
             ))}
           </div>
         ) : (
-          <motion.div
-            layout
-            className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-6"
-          >
+          <motion.div layout className="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 gap-6">
             <AnimatePresence>
-              {filteredCards.map((item, index) => (
+              {filteredCards.map((item) => (
                 <motion.div
-                  key={index}
+                  key={item.key}
                   layout
                   initial={{ opacity: 0, y: 20 }}
                   animate={{ opacity: 1, y: 0 }}
@@ -117,8 +256,19 @@ export default function KnowledgeDashboard() {
                   whileHover={{ y: -5 }}
                   className="mb-6 break-inside-avoid rounded-2xl overflow-hidden"
                 >
-                  <div className="border bg-white border-gray-200 hover:border-gray-300 rounded-2xl shadow-sm hover:shadow-md transition-all duration-300">
-                    {item.component}
+                  <div className="border bg-white border-gray-200 hover:border-gray-300 rounded-2xl shadow-sm hover:shadow-md transition-all duration-300 flex flex-col">
+                    <item.Component {...item.props} />
+                    {item.bookmark && (
+                      <SavedBookmarkFooter
+                        bookmark={item.bookmark}
+                        onRemove={() => handleBookmarkToggle({
+                          cardType: item.bookmark.card_type,
+                          sourceId: item.bookmark.source_id,
+                          payload: item.bookmark.payload,
+                        })}
+                        onMarkReviewed={() => bookmarkHelpers.markReviewed(item.bookmark)}
+                      />
+                    )}
                   </div>
                 </motion.div>
               ))}
@@ -126,13 +276,11 @@ export default function KnowledgeDashboard() {
           </motion.div>
         )}
 
-        {filteredCards.length === 0 && (
+        {filteredCards.length === 0 && !isLoading && (
           <div className="text-center py-16">
             <div className="text-6xl mb-4">🧐</div>
             <h3 className="text-xl font-medium mb-2">No items in this category</h3>
-            <p className="text-gray-500">
-              Try selecting a different category above
-            </p>
+            <p className="text-gray-500">Try selecting a different category above</p>
           </div>
         )}
       </main>
@@ -142,6 +290,181 @@ export default function KnowledgeDashboard() {
           <p>Knowledge Hub • Updated daily • {new Date().toLocaleDateString()}</p>
         </div>
       </footer>
+
+      <BookmarkModal
+        open={modalOpen}
+        bookmark={pendingBookmark}
+        collectionName={collectionName}
+        reminderIntervalDays={reminderIntervalDays}
+        collections={collections}
+        onCollectionChange={setCollectionName}
+        onReminderChange={setReminderIntervalDays}
+        onClose={() => {
+          setModalOpen(false);
+          setPendingBookmark(null);
+        }}
+        onSubmit={async () => {
+          if (!pendingBookmark) return;
+          try {
+            const created = await createBookmark({
+              cardType: pendingBookmark.cardType,
+              sourceId: pendingBookmark.sourceId,
+              payload: pendingBookmark.payload,
+              collectionName: collectionName || null,
+              reminderIntervalDays,
+            });
+            setModalOpen(false);
+            setPendingBookmark(null);
+            setLastCollectionName(collectionName || "");
+            setFeedback({ type: "success", message: "Saved to your knowledge collections" });
+            return created;
+          } catch (err) {
+            setFeedback({ type: "error", message: err.message });
+          }
+        }}
+      />
     </div>
+  );
+}
+
+function SavedBookmarkFooter({ bookmark, onRemove, onMarkReviewed }) {
+  const nextReminder = bookmark.next_reminder_at ? new Date(bookmark.next_reminder_at) : null;
+  const lastViewed = bookmark.last_viewed_at ? new Date(bookmark.last_viewed_at) : null;
+  const isDue = nextReminder ? nextReminder <= new Date() : false;
+
+  return (
+    <div className="border-t border-gray-100 px-4 py-3 text-sm text-gray-600 bg-gray-50 rounded-b-2xl">
+      <div className="flex flex-wrap justify-between gap-2">
+        <div className="space-y-1">
+          {bookmark.collection_name && <div className="font-medium">Collection: {bookmark.collection_name}</div>}
+          {lastViewed && <div>Last reviewed: {lastViewed.toLocaleDateString()}</div>}
+          {nextReminder && (
+            <div className={isDue ? "text-red-600 font-medium" : ""}>
+              Next reminder: {nextReminder.toLocaleDateString()}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onMarkReviewed}
+            className="px-3 py-1 rounded-full bg-emerald-100 text-emerald-700 text-xs font-medium hover:bg-emerald-200 transition"
+          >
+            Mark reviewed
+          </button>
+          <button
+            type="button"
+            onClick={onRemove}
+            className="px-3 py-1 rounded-full bg-red-100 text-red-700 text-xs font-medium hover:bg-red-200 transition"
+          >
+            Remove
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function BookmarkModal({
+  open,
+  bookmark,
+  collectionName,
+  reminderIntervalDays,
+  collections,
+  onCollectionChange,
+  onReminderChange,
+  onClose,
+  onSubmit,
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center px-4">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full p-6 space-y-4">
+        <div className="flex justify-between items-start">
+          <div>
+            <h2 className="text-xl font-semibold">Save to your collection</h2>
+            <p className="text-sm text-gray-500">Organize this card and choose how often you want reminders.</p>
+          </div>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">✕</button>
+        </div>
+
+        {bookmark?.title && <div className="text-sm font-medium">{bookmark.title}</div>}
+        {bookmark?.subtitle && <div className="text-xs text-gray-500">{bookmark.subtitle}</div>}
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">Collection</label>
+          <select
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+            value={collectionName || ""}
+            onChange={(event) => onCollectionChange(event.target.value)}
+          >
+            <option value="">No collection</option>
+            {collections.map((name) => (
+              <option key={name} value={name}>
+                {name}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            className="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm"
+            placeholder="Or create a new collection"
+            value={collectionName || ""}
+            onChange={(event) => onCollectionChange(event.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-gray-700">Reminder frequency (days)</label>
+          <input
+            type="number"
+            min="1"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+            value={reminderIntervalDays}
+            onChange={(event) => onReminderChange(Number(event.target.value) || 1)}
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onSubmit}
+            className="px-4 py-2 text-sm font-semibold text-white bg-[var(--theme-color)] rounded-lg hover:opacity-90"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SavedBookmarkFallback({ savedBookmark }) {
+  return (
+    <div className="p-4 space-y-2">
+      <div className="flex justify-between items-start">
+        <div>
+          <h3 className="text-lg font-semibold">Saved item</h3>
+          <p className="text-sm text-gray-500">We couldn't find a renderer for this card type.</p>
+        </div>
+      </div>
+      <pre className="bg-gray-100 rounded-lg p-3 text-xs overflow-auto max-h-60">{JSON.stringify(savedBookmark?.payload, null, 2)}</pre>
+    </div>
+  );
+}
+
+export default function KnowledgeDashboard() {
+  return (
+    <KnowledgeBookmarksProvider>
+      <KnowledgeDashboardContent />
+    </KnowledgeBookmarksProvider>
   );
 }

--- a/app/jobs/knowledge_bookmark_reminder_job.rb
+++ b/app/jobs/knowledge_bookmark_reminder_job.rb
@@ -1,0 +1,12 @@
+class KnowledgeBookmarkReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    KnowledgeBookmark.due_for_reminder.includes(:user).find_each do |bookmark|
+      next if bookmark.user.email.blank?
+
+      KnowledgeBookmarkMailer.reminder(bookmark).deliver_later
+      bookmark.schedule_next_reminder!
+    end
+  end
+end

--- a/app/mailers/knowledge_bookmark_mailer.rb
+++ b/app/mailers/knowledge_bookmark_mailer.rb
@@ -1,0 +1,9 @@
+class KnowledgeBookmarkMailer < ApplicationMailer
+  default from: "knowledge-hub@example.com"
+
+  def reminder(bookmark)
+    @bookmark = bookmark
+    @user = bookmark.user
+    mail(to: @user.email, subject: "It's time to review your saved #{bookmark.card_type.humanize}")
+  end
+end

--- a/app/models/knowledge_bookmark.rb
+++ b/app/models/knowledge_bookmark.rb
@@ -1,0 +1,27 @@
+class KnowledgeBookmark < ApplicationRecord
+  belongs_to :user
+
+  validates :card_type, presence: true
+  validates :payload, presence: true
+  validates :reminder_interval_days, numericality: { greater_than: 0 }
+
+  before_validation :initialize_tracking_fields, on: :create
+
+  scope :due_for_reminder, -> { where.not(next_reminder_at: nil).where('next_reminder_at <= ?', Time.current) }
+
+  def mark_reviewed!
+    touch(:last_viewed_at)
+    update!(next_reminder_at: Time.current + reminder_interval_days.days)
+  end
+
+  def schedule_next_reminder!
+    update!(next_reminder_at: Time.current + reminder_interval_days.days, last_reminded_at: Time.current)
+  end
+
+  private
+
+  def initialize_tracking_fields
+    self.last_viewed_at ||= Time.current
+    self.next_reminder_at ||= Time.current + reminder_interval_days.days
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,7 @@ class User < ApplicationRecord
   has_many :user_skills, dependent: :destroy
   has_many :skills, through: :user_skills
   has_many :learning_goals, dependent: :destroy
+  has_many :knowledge_bookmarks, dependent: :destroy
   has_many :given_skill_endorsements, class_name: 'SkillEndorsement', foreign_key: :endorser_id, dependent: :destroy
   has_many :received_skill_endorsements, through: :user_skills, source: :skill_endorsements
 

--- a/app/views/knowledge_bookmark_mailer/reminder.html.erb
+++ b/app/views/knowledge_bookmark_mailer/reminder.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Hi <%= @user.first_name.presence || @user.email %>,</h1>
+    <p>It's time to revisit one of your saved Knowledge Hub items.</p>
+    <p><strong>Category:</strong> <%= @bookmark.card_type.humanize %></p>
+    <% if @bookmark.collection_name.present? %>
+      <p><strong>Collection:</strong> <%= @bookmark.collection_name %></p>
+    <% end %>
+    <p><strong>Saved on:</strong> <%= @bookmark.created_at.strftime('%B %d, %Y') %></p>
+    <hr />
+    <p><strong>Details:</strong></p>
+    <pre style="background:#f4f4f4;padding:12px;border-radius:8px;white-space:pre-wrap;word-break:break-word;">
+<%= JSON.pretty_generate(@bookmark.payload) %>
+    </pre>
+    <p>Open the Knowledge Hub to review and mark it as done.</p>
+  </body>
+</html>

--- a/app/views/knowledge_bookmark_mailer/reminder.text.erb
+++ b/app/views/knowledge_bookmark_mailer/reminder.text.erb
@@ -1,0 +1,13 @@
+Hi <%= @user.first_name.presence || @user.email %>,
+
+It's time to revisit one of your saved Knowledge Hub items.
+Category: <%= @bookmark.card_type.humanize %>
+<% if @bookmark.collection_name.present? %>
+Collection: <%= @bookmark.collection_name %>
+<% end %>
+Saved on: <%= @bookmark.created_at.strftime('%B %d, %Y') %>
+
+Details:
+<%= JSON.pretty_generate(@bookmark.payload) %>
+
+Open the Knowledge Hub to review and mark it as done.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -96,6 +96,12 @@ Rails.application.routes.draw do
 
     resources :items, only: [:index, :create, :update, :destroy]
 
+    resources :knowledge_bookmarks, only: [:index, :create, :update, :destroy] do
+      member do
+        post :mark_reviewed
+      end
+    end
+
     resources :roles, only: [:index]
 
     resources :work_categories, only: [:index, :create, :update, :destroy]

--- a/db/migrate/20260902004700_create_knowledge_bookmarks.rb
+++ b/db/migrate/20260902004700_create_knowledge_bookmarks.rb
@@ -1,0 +1,21 @@
+class CreateKnowledgeBookmarks < ActiveRecord::Migration[7.1]
+  def change
+    create_table :knowledge_bookmarks do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :card_type, null: false
+      t.string :collection_name
+      t.string :source_id
+      t.jsonb :payload, null: false, default: {}
+      t.datetime :last_viewed_at
+      t.datetime :last_reminded_at
+      t.datetime :next_reminder_at
+      t.integer :reminder_interval_days, null: false, default: 7
+
+      t.timestamps
+    end
+
+    add_index :knowledge_bookmarks, [:user_id, :card_type, :source_id], unique: true, name: "index_knowledge_bookmarks_on_identity"
+    add_index :knowledge_bookmarks, :next_reminder_at
+    add_index :knowledge_bookmarks, :collection_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_09_02_004600) do
+ActiveRecord::Schema[7.1].define(version: 2026_09_02_004700) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,23 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_02_004600) do
     t.datetime "updated_at", null: false
     t.index ["team_id"], name: "index_learning_goals_on_team_id"
     t.index ["user_id"], name: "index_learning_goals_on_user_id"
+  end
+
+  create_table "knowledge_bookmarks", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "card_type", null: false
+    t.string "collection_name"
+    t.string "source_id"
+    t.jsonb "payload", default: {}, null: false
+    t.datetime "last_viewed_at"
+    t.datetime "last_reminded_at"
+    t.datetime "next_reminder_at"
+    t.integer "reminder_interval_days", default: 7, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["collection_name"], name: "index_knowledge_bookmarks_on_collection_name"
+    t.index ["next_reminder_at"], name: "index_knowledge_bookmarks_on_next_reminder_at"
+    t.index ["user_id", "card_type", "source_id"], name: "index_knowledge_bookmarks_on_identity", unique: true
   end
 
   create_table "post_likes", force: :cascade do |t|
@@ -382,6 +399,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_02_004600) do
   add_foreign_key "comments", "posts"
   add_foreign_key "comments", "users"
   add_foreign_key "items", "users"
+  add_foreign_key "knowledge_bookmarks", "users"
   add_foreign_key "learning_checkpoints", "learning_goals"
   add_foreign_key "learning_goals", "teams"
   add_foreign_key "learning_goals", "users"


### PR DESCRIPTION
## Summary
- add a knowledge bookmark model, API controller, reminder job, and mailer for personalized review nudges
- layer a bookmark context, modal, and saved/due dashboards into the knowledge hub UI
- retrofit every knowledge card with bookmark toggles so payloads can be persisted and replayed from storage

## Testing
- bin/rails db:migrate *(fails: Ruby 3.3.0 required in Gemfile, container provides 3.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_6901e3c4cdc483228a7868b419c559cc