### PR TITLE
Adjust admin badge positioning over avatar

### DIFF
--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -288,7 +288,7 @@ const Navbar = () => {
               >
                 <HolographicAvatar user={user} />
                 {hasAdminRole && (
-                  <div className="absolute -bottom-1 -right-1 bg-gradient-to-r from-blue-500 to-sky-600 text-white text-xs px-1.5 py-0.5 rounded-full border-2 border-white dark:border-zinc-900">
+                  <div className="absolute -top-1 -right-1 z-20 bg-gradient-to-r from-blue-500 to-sky-600 text-white text-xs px-1.5 py-0.5 rounded-full border-2 border-white dark:border-zinc-900 shadow-md">
                     <FiAward className="h-3 w-3" />
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- reposition the admin trophy badge so it sits above the profile avatar instead of behind it
- add a higher z-index and subtle shadow so the badge remains visible against the avatar

## Testing
- no tests were run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_6901ff2844408322a1996c2855d50fa7