### PR TITLE
Add responsive feature grid to pages index

### DIFF
--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -1,2 +1,45 @@
 <h1>Welcome to My Rails + Vite + React App</h1>
 <p>This is a Rails page before React fully takes over.</p>
+
+<section class="mt-12">
+  <div class="grid gap-6 md:grid-cols-3">
+    <article class="flex items-start space-x-4 rounded-lg bg-white/80 p-6 shadow">
+      <div class="flex h-12 w-12 items-center justify-center rounded-full bg-indigo-100 text-indigo-600">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-7 w-7">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 14.25c3.727 0 6.75-1.007 6.75-2.25S15.727 9.75 12 9.75 5.25 10.757 5.25 12s3.023 2.25 6.75 2.25z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 14.25c3.727 0 6.75-1.007 6.75-2.25V18c0 1.243-3.023 2.25-6.75 2.25S5.25 19.243 5.25 18v-5.25" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 9.75c3.727 0 6.75-1.007 6.75-2.25S15.727 5.25 12 5.25 5.25 6.257 5.25 7.5 8.273 9.75 12 9.75z" />
+        </svg>
+      </div>
+      <div>
+        <h3 class="text-lg font-semibold text-slate-900">Full-Stack Ready</h3>
+        <p class="mt-2 text-sm text-slate-600">Blend Rails APIs with modern React interfaces using a single streamlined toolchain.</p>
+      </div>
+    </article>
+
+    <article class="flex items-start space-x-4 rounded-lg bg-white/80 p-6 shadow">
+      <div class="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-7 w-7">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 13.5l7.5 7.5 9-18-16.5 10.5z" />
+        </svg>
+      </div>
+      <div>
+        <h3 class="text-lg font-semibold text-slate-900">Lightning Fast Builds</h3>
+        <p class="mt-2 text-sm text-slate-600">Leverage Vite&rsquo;s instant hot module reloading for rapid feedback during development.</p>
+      </div>
+    </article>
+
+    <article class="flex items-start space-x-4 rounded-lg bg-white/80 p-6 shadow">
+      <div class="flex h-12 w-12 items-center justify-center rounded-full bg-sky-100 text-sky-600">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-7 w-7">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75l2.25 2.25L15 9.75" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+      </div>
+      <div>
+        <h3 class="text-lg font-semibold text-slate-900">Production Ready</h3>
+        <p class="mt-2 text-sm text-slate-600">Ship reliable experiences with a security-first Rails backend powering every release.</p>
+      </div>
+    </article>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- add a responsive feature grid section to the pages index view
- include heroicon-inspired SVG icons and descriptive copy for each feature
- ensure the layout stacks to a single column on small screens with Tailwind classes

## Testing
- bin/rails test *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_690372dc998883229b8ae45f979bb66e