### PR TITLE
Add suggested topics sidebar with follow interactions

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,8 @@
+class PostsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @posts = Post.includes(:user).order(created_at: :desc).limit(20)
+    @suggested_topics = Topic.suggested_for(current_user, limit: 8)
+  end
+end

--- a/app/controllers/suggested_topics_controller.rb
+++ b/app/controllers/suggested_topics_controller.rb
@@ -1,0 +1,35 @@
+class SuggestedTopicsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @suggested_topics = Topic.suggested_for(current_user, limit: limit_param)
+
+    respond_to do |format|
+      format.html do
+        render partial: "posts/suggested_topics",
+               locals: { topics: @suggested_topics },
+               status: :ok
+      end
+      format.json do
+        render json: @suggested_topics.map { |topic| serialize_topic(topic) }
+      end
+    end
+  end
+
+  private
+
+  def limit_param
+    params.fetch(:limit, 8).to_i.clamp(1, 24)
+  end
+
+  def serialize_topic(topic)
+    {
+      id: topic.id,
+      name: topic.name,
+      description: topic.description,
+      follows_count: topic.follows_count,
+      followed: topic.followed_by?(current_user),
+      follow_path: topic_follow_path(topic)
+    }
+  end
+end

--- a/app/controllers/topic_follows_controller.rb
+++ b/app/controllers/topic_follows_controller.rb
@@ -1,0 +1,49 @@
+class TopicFollowsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_topic
+
+  def create
+    current_user.topic_follows.find_or_create_by!(topic: @topic)
+    respond_with_topic(:created)
+  rescue ActiveRecord::RecordInvalid => e
+    respond_to do |format|
+      format.html do
+        redirect_back fallback_location: posts_path,
+                      alert: e.record.errors.full_messages.to_sentence
+      end
+      format.json do
+        render json: { error: e.record.errors.full_messages.to_sentence }, status: :unprocessable_entity
+      end
+    end
+  end
+
+  def destroy
+    follow = current_user.topic_follows.find_by(topic: @topic)
+    follow&.destroy
+    respond_with_topic(:ok)
+  end
+
+  private
+
+  def set_topic
+    @topic = Topic.find(params[:topic_id])
+  end
+
+  def respond_with_topic(status)
+    respond_to do |format|
+      format.html do
+        redirect_back fallback_location: posts_path,
+                      notice: status == :created ? "You are now following #{@topic.name}." : "You have unfollowed #{@topic.name}."
+      end
+      format.json do
+        @topic.reload
+        render json: {
+          id: @topic.id,
+          name: @topic.name,
+          follows_count: @topic.follows_count,
+          followed: current_user.following_topic?(@topic)
+        }, status: status
+      end
+    end
+  end
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import TopicFollowController from "./topic_follow_controller"
+application.register("topic-follow", TopicFollowController)

--- a/app/javascript/controllers/topic_follow_controller.js
+++ b/app/javascript/controllers/topic_follow_controller.js
@@ -1,0 +1,92 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Handles follow/unfollow button interactions for suggested topics.
+export default class extends Controller {
+  static values = {
+    followUrl: String,
+    following: Boolean
+  }
+
+  static targets = ["button", "count"]
+
+  connect() {
+    this.updateButton()
+  }
+
+  toggle(event) {
+    event.preventDefault()
+    this.followingValue ? this.unfollow() : this.follow()
+  }
+
+  follow() {
+    this.request("POST")
+  }
+
+  unfollow() {
+    this.request("DELETE")
+  }
+
+  request(method) {
+    const headers = { ...this.headers }
+    if (method === "POST") {
+      headers["Content-Type"] = "application/json"
+    }
+
+    fetch(this.followUrlValue, {
+      method,
+      headers,
+      body: method === "POST" ? JSON.stringify({}) : null
+    })
+      .then((response) => {
+        if (!response.ok) throw response
+        return response.json()
+      })
+      .then((payload) => {
+        this.followingValue = payload.followed
+        this.updateButton()
+        if (this.hasCountTarget) {
+          this.countTarget.textContent = this.formatFollowers(payload.follows_count)
+        }
+      })
+      .catch(async (error) => {
+        let message = "Something went wrong"
+        try {
+          const data = await error.json()
+          if (data.error) message = data.error
+        } catch (_) {
+          // Ignore JSON parsing errors.
+        }
+        this.notify(message)
+      })
+  }
+
+  updateButton() {
+    if (!this.hasButtonTarget) return
+
+    this.buttonTarget.classList.toggle("topic-chip__button--following", this.followingValue)
+    this.buttonTarget.querySelector(".topic-chip__button-text").textContent = this.followingValue ? "Following" : "Follow"
+    this.buttonTarget.setAttribute("aria-pressed", this.followingValue)
+  }
+
+  formatFollowers(count) {
+    if (!count || count === 0) return "No followers yet"
+    return count === 1 ? "1 follower" : `${count} followers`
+  }
+
+  notify(message) {
+    if (window?.Toastify) {
+      window.Toastify({ text: message, duration: 3000, gravity: "bottom", position: "right", className: "toast-error" }).showToast()
+    } else {
+      // Fallback alert for when Toastify or other notification helpers are unavailable.
+      window.alert(message)
+    }
+  }
+
+  get headers() {
+    const token = document.querySelector("meta[name='csrf-token']")?.getAttribute("content")
+    return {
+      "Accept": "application/json",
+      "X-CSRF-Token": token
+    }
+  }
+}

--- a/app/javascript/entrypoints/application.jsx
+++ b/app/javascript/entrypoints/application.jsx
@@ -15,6 +15,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "../components/App";
 import "../stylesheets/application.css";
+import "../application";
 
 
 const rootElement = document.getElementById("root");

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -13,6 +13,179 @@ body {
   background: linear-gradient(to bottom right, var(--theme-color-light), white);
 }
 
+.posts-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 2rem;
+  padding: 2rem clamp(1rem, 4vw, 3rem);
+  align-items: start;
+}
+
+.posts-layout__heading {
+  font-size: clamp(1.5rem, 2vw, 2rem);
+  font-weight: 700;
+  margin-bottom: 1.5rem;
+}
+
+.posts-layout__sidebar {
+  position: sticky;
+  top: 1.5rem;
+}
+
+.posts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.post-card {
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.post-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.post-card__author {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.post-card__timestamp {
+  color: #64748b;
+  font-size: 0.875rem;
+}
+
+.post-card__body {
+  margin: 0;
+  color: #0f172a;
+  line-height: 1.6;
+}
+
+.posts-list__empty {
+  color: #64748b;
+}
+
+.suggested-topics {
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 12px 36px rgba(15, 23, 42, 0.08);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.suggested-topics__title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.suggested-topics__list {
+  display: grid;
+  gap: 1rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.suggested-topics__item {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.suggested-topics__followers {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.suggested-topics--empty {
+  text-align: center;
+}
+
+.suggested-topics__empty-message {
+  color: #64748b;
+  margin: 0;
+}
+
+.topic-chip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.topic-chip__label {
+  background: rgba(var(--theme-color-rgb), 0.08);
+  color: var(--theme-color-dark);
+  padding: 0.35rem 0.85rem;
+  border-radius: 9999px;
+  font-weight: 500;
+}
+
+.topic-chip__button {
+  background: var(--theme-color);
+  border: none;
+  border-radius: 9999px;
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+  padding: 0.4rem 1.1rem;
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.topic-chip__button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(59, 130, 246, 0.24);
+}
+
+.topic-chip__button--following {
+  background: white;
+  color: var(--theme-color-dark);
+  border: 2px solid rgba(var(--theme-color-rgb), 0.4);
+}
+
+.topic-chip__button--following:hover {
+  box-shadow: none;
+}
+
+.topic-chip__button-text {
+  display: inline-block;
+}
+
+@media (max-width: 1024px) {
+  .posts-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .posts-layout__sidebar {
+    position: static;
+    order: -1;
+  }
+}
+
+@media (max-width: 640px) {
+  .posts-layout {
+    padding-inline: clamp(0.75rem, 4vw, 1.5rem);
+  }
+
+  .post-card {
+    padding: 1.25rem;
+  }
+}
+
 .bg-theme {
   background-color: var(--theme-color);
 }

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -1,0 +1,27 @@
+class Topic < ApplicationRecord
+  has_many :topic_follows, dependent: :destroy
+  has_many :followers, through: :topic_follows, source: :user
+
+  validates :name, presence: true, uniqueness: true
+
+  scope :alphabetical, -> { order(:name) }
+
+  def self.suggested_for(user, limit: 8)
+    scope = order(topic_follows_count: :desc, name: :asc)
+    if user&.persisted?
+      followed_ids = user.topic_follows.select(:topic_id)
+      scope = scope.where.not(id: followed_ids)
+    end
+    scope.limit(limit)
+  end
+
+  def follows_count
+    topic_follows_count
+  end
+
+  def followed_by?(user)
+    return false unless user
+
+    user.following_topic?(self)
+  end
+end

--- a/app/models/topic_follow.rb
+++ b/app/models/topic_follow.rb
@@ -1,0 +1,6 @@
+class TopicFollow < ApplicationRecord
+  belongs_to :user
+  belongs_to :topic, counter_cache: true
+
+  validates :user_id, uniqueness: { scope: :topic_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,6 +34,8 @@ class User < ApplicationRecord
   has_many :knowledge_bookmarks, dependent: :destroy
   has_many :given_skill_endorsements, class_name: 'SkillEndorsement', foreign_key: :endorser_id, dependent: :destroy
   has_many :received_skill_endorsements, through: :user_skills, source: :skill_endorsements
+  has_many :topic_follows, dependent: :destroy
+  has_many :followed_topics, through: :topic_follows, source: :topic
 
   enum availability_status: {
     available_now: 'available_now',
@@ -79,6 +81,12 @@ class User < ApplicationRecord
 
   def availability_label
     AVAILABILITY_LABELS[availability_status] || availability_status.to_s.humanize
+  end
+
+  def following_topic?(topic)
+    return false unless topic
+
+    followed_topics.exists?(topic.id)
   end
 
   private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,5 +15,6 @@
 
   <body>
     <div id="root"></div>
+    <%= yield %>
   </body>
 </html>

--- a/app/views/posts/_suggested_topics.html.erb
+++ b/app/views/posts/_suggested_topics.html.erb
@@ -1,0 +1,32 @@
+<% if topics.present? %>
+  <div class="suggested-topics">
+    <h2 class="suggested-topics__title">Suggested Topics</h2>
+    <ul class="suggested-topics__list">
+      <% topics.each do |topic| %>
+        <% following = current_user&.following_topic?(topic) %>
+        <li class="suggested-topics__item" data-controller="topic-follow"
+            data-topic-follow-follow-url-value="<%= topic_follow_path(topic) %>"
+            data-topic-follow-following-value="<%= following ? 'true' : 'false' %>">
+          <div class="topic-chip">
+            <span class="topic-chip__label"><%= topic.name %></span>
+            <button type="button"
+                    class="topic-chip__button"
+                    data-topic-follow-target="button"
+                    data-action="click->topic-follow#toggle"
+                    aria-pressed="<%= following ? 'true' : 'false' %>">
+              <span class="topic-chip__button-text"><%= following ? "Following" : "Follow" %></span>
+            </button>
+          </div>
+          <span class="suggested-topics__followers" data-topic-follow-target="count">
+            <%= pluralize(topic.follows_count, 'follower') %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% else %>
+  <div class="suggested-topics suggested-topics--empty">
+    <h2 class="suggested-topics__title">Suggested Topics</h2>
+    <p class="suggested-topics__empty-message">Follow a few topics to personalize your feed.</p>
+  </div>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,27 @@
+<div class="posts-layout">
+  <section class="posts-layout__main">
+    <h1 class="posts-layout__heading">Latest Posts</h1>
+    <% if @posts.present? %>
+      <ul class="posts-list">
+        <% @posts.each do |post| %>
+          <li class="posts-list__item">
+            <article class="post-card">
+              <header class="post-card__header">
+                <h2 class="post-card__author"><%= post.user&.full_name || post.user&.email %></h2>
+                <time class="post-card__timestamp" datetime="<%= post.created_at.iso8601 %>">
+                  <%= time_ago_in_words(post.created_at) %> ago
+                </time>
+              </header>
+              <p class="post-card__body"><%= simple_format(post.message) %></p>
+            </article>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="posts-list__empty">No posts yet.</p>
+    <% end %>
+  </section>
+  <aside class="posts-layout__sidebar">
+    <%= render partial: "posts/suggested_topics", locals: { topics: @suggested_topics } %>
+  </aside>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,12 @@ Rails.application.routes.draw do
 
   root "pages#index"
 
+  resources :posts, only: [:index]
+  resources :suggested_topics, only: [:index]
+  resources :topics, only: [] do
+    resource :follow, only: [:create, :destroy], controller: :topic_follows
+  end
+
   # PDF
   post "/upload_pdf", to: "pdfs#upload_pdf"
   post "/reset_pdf", to: "pdfs#reset"

--- a/db/migrate/20260902004800_create_topics.rb
+++ b/db/migrate/20260902004800_create_topics.rb
@@ -1,0 +1,13 @@
+class CreateTopics < ActiveRecord::Migration[7.1]
+  def change
+    create_table :topics do |t|
+      t.string :name, null: false
+      t.text :description
+      t.integer :topic_follows_count, null: false, default: 0
+
+      t.timestamps
+    end
+
+    add_index :topics, :name, unique: true
+  end
+end

--- a/db/migrate/20260902004900_create_topic_follows.rb
+++ b/db/migrate/20260902004900_create_topic_follows.rb
@@ -1,0 +1,12 @@
+class CreateTopicFollows < ActiveRecord::Migration[7.1]
+  def change
+    create_table :topic_follows do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :topic, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :topic_follows, [:user_id, :topic_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -251,6 +251,25 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_02_004700) do
     t.index ["type"], name: "index_tasks_on_type"
   end
 
+  create_table "topic_follows", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "topic_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["topic_id"], name: "index_topic_follows_on_topic_id"
+    t.index ["user_id", "topic_id"], name: "index_topic_follows_on_user_id_and_topic_id", unique: true
+    t.index ["user_id"], name: "index_topic_follows_on_user_id"
+  end
+
+  create_table "topics", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.integer "topic_follows_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_topics_on_name", unique: true
+  end
+
   create_table "team_users", force: :cascade do |t|
     t.bigint "team_id", null: false
     t.bigint "user_id", null: false
@@ -421,6 +440,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_09_02_004700) do
   add_foreign_key "team_users", "teams"
   add_foreign_key "team_users", "users"
   add_foreign_key "teams", "users", column: "owner_id"
+  add_foreign_key "topic_follows", "topics"
+  add_foreign_key "topic_follows", "users"
   add_foreign_key "user_roles", "roles"
   add_foreign_key "user_roles", "users"
   add_foreign_key "user_skills", "skills"


### PR DESCRIPTION
## Summary
- add topics and topic follows data model plus follow endpoints
- render a suggested topics sidebar on the posts index with responsive styling
- add Stimulus controller to handle follow/unfollow interactions and expose suggested topics via a controller endpoint

## Testing
- not run (Ruby 3.2.3 runtime available, project requires Ruby 3.3.0)

------
https://chatgpt.com/codex/tasks/task_e_69037d9bfce88322b23cc561f8a0d66e