### PR TITLE
Add quick actions widget to posts feed

### DIFF
--- a/app/javascript/components/quick_actions/QuickActions.jsx
+++ b/app/javascript/components/quick_actions/QuickActions.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  FiPenTool,
+  FiUploadCloud,
+  FiFolderPlus,
+  FiUsers,
+} from "react-icons/fi";
+
+const QuickActions = ({ onCreatePost }) => {
+  const navigate = useNavigate();
+
+  const actions = [
+    {
+      title: "New Post",
+      description: "Share an update or ask a question.",
+      icon: <FiPenTool className="text-lg" />, 
+      onClick: () => {
+        if (typeof onCreatePost === "function") {
+          onCreatePost();
+        }
+      },
+    },
+    {
+      title: "Upload Media",
+      description: "Manage PDFs and shared resources.",
+      icon: <FiUploadCloud className="text-lg" />,
+      onClick: () => navigate("/pdf"),
+    },
+    {
+      title: "New Project",
+      description: "Kick off a collaboration space.",
+      icon: <FiFolderPlus className="text-lg" />,
+      onClick: () => navigate("/projects"),
+    },
+    {
+      title: "Invite Teammates",
+      description: "Grow your workspace community.",
+      icon: <FiUsers className="text-lg" />,
+      onClick: () => navigate("/teams"),
+    },
+  ];
+
+  return (
+    <section className="bg-white border border-slate-200 rounded-2xl shadow-sm overflow-hidden">
+      <div className="bg-gradient-to-r from-blue-600 via-indigo-500 to-purple-500 px-6 py-4">
+        <h2 className="text-white text-lg font-semibold">Quick Actions</h2>
+        <p className="text-white/80 text-sm mt-1">
+          Jump straight into the work that matters most right now.
+        </p>
+      </div>
+      <div className="grid sm:grid-cols-2 gap-2 p-4">
+        {actions.map((action) => (
+          <button
+            key={action.title}
+            type="button"
+            onClick={action.onClick}
+            className="group flex items-start gap-3 rounded-xl border border-transparent bg-slate-50 px-4 py-3 text-left transition-all hover:border-blue-200 hover:bg-white hover:shadow-sm"
+          >
+            <span className="mt-1 flex h-10 w-10 items-center justify-center rounded-lg bg-blue-100 text-blue-600 transition-colors group-hover:bg-blue-600 group-hover:text-white">
+              {action.icon}
+            </span>
+            <span>
+              <span className="block text-sm font-semibold text-slate-800">
+                {action.title}
+              </span>
+              <span className="mt-1 block text-xs text-slate-500">
+                {action.description}
+              </span>
+            </span>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default QuickActions;

--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useContext } from "react";
+import React, { useEffect, useState, useCallback, useContext, useRef } from "react";
 import { Link } from "react-router-dom";
 import { fetchPosts, SchedulerAPI, fetchProjects, getUsers } from "../components/api";
 import { AuthContext } from "../context/AuthContext";
@@ -7,6 +7,7 @@ import PostList from "../components/PostList";
 import { Toaster } from "react-hot-toast";
 import { motion, AnimatePresence } from "framer-motion";
 import { Helmet } from "react-helmet";
+import QuickActions from "../components/quick_actions/QuickActions";
 
 // --- Icon Imports ---
 import {
@@ -99,6 +100,17 @@ const PostPage = () => {
   const [projects, setProjects] = useState([]);
   const [birthdays, setBirthdays] = useState([]);
   const [generalTasks, setGeneralTasks] = useState([]);
+  const postFormRef = useRef(null);
+
+  const handleQuickPost = useCallback(() => {
+    if (postFormRef.current) {
+      postFormRef.current.scrollIntoView({ behavior: "smooth", block: "center" });
+      const textarea = postFormRef.current.querySelector("textarea");
+      if (textarea) {
+        textarea.focus();
+      }
+    }
+  }, []);
 
   const handlePostUpdate = useCallback((postId, updater) => {
     setPosts((prevPosts) =>
@@ -278,7 +290,11 @@ const PostPage = () => {
             </header>
             
             <main className="space-y-8">
-                <PostForm refreshPosts={refreshPosts} />
+                <QuickActions onCreatePost={handleQuickPost} />
+
+                <div ref={postFormRef}>
+                  <PostForm refreshPosts={refreshPosts} />
+                </div>
                 
                 <AnimatePresence>
                     {isLoading ? (


### PR DESCRIPTION
## Summary
- add a QuickActions React component that surfaces common navigation shortcuts
- place the quick actions widget ahead of the post composer and focus the editor when requested

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69037d9d404c8322a9c3689bffb32971