### PR TITLE
Add filtering and sorting controls to Vault

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -2,12 +2,16 @@ class Api::ItemsController < Api::BaseController
   before_action :set_item, only: [:update, :destroy]
 
   def index
-    items = current_user.items
-    if params[:q].present?
-      query = "%#{params[:q]}%"
-      items = items.where("title ILIKE ? OR content ILIKE ?", query, query)
-    end
-    render json: items.order(:id)
+    scope = current_user.items
+    filtered_items = apply_filters(scope)
+
+    render json: {
+      items: filtered_items,
+      filters: {
+        categories: available_categories(scope),
+        tags: available_tags(scope)
+      }
+    }
   end
 
   def create
@@ -40,5 +44,75 @@ class Api::ItemsController < Api::BaseController
 
   def item_params
     params.require(:item).permit(:title, :category, :content)
+  end
+
+  def apply_filters(scope)
+    items = scope
+
+    if params[:q].present?
+      query = "%#{params[:q]}%"
+      items = items.where("title ILIKE :query OR content ILIKE :query", query: query)
+    end
+
+    if params[:categories].present?
+      categories = Array(params[:categories]).reject(&:blank?)
+      items = items.where(category: categories) if categories.any?
+    end
+
+    if params[:tags].present?
+      tags = Array(params[:tags]).reject(&:blank?)
+      items = filter_by_tags(items, tags) if tags.any?
+    end
+
+    apply_sort(items)
+  end
+
+  def filter_by_tags(scope, tags)
+    return scope unless Item.column_names.include?("tags")
+
+    column = Item.columns_hash["tags"]
+    if column&.type == :json || column&.type == :jsonb
+      tags.reduce(scope) do |relation, tag|
+        relation.where("EXISTS (SELECT 1 FROM jsonb_array_elements_text(items.tags::jsonb) AS tag WHERE tag = ?)", tag)
+      end
+    elsif column&.array
+      scope.where("items.tags @> ARRAY[?]::varchar[]", tags)
+    else
+      patterns = tags.map { |tag| "%#{tag}%" }
+      scope.where("COALESCE(items.tags, '') ILIKE ANY (ARRAY[?])", patterns)
+    end
+  end
+
+  def apply_sort(scope)
+    case params[:sort]
+    when "title_asc"
+      scope.order(Arel.sql("LOWER(title) ASC"))
+    when "title_desc"
+      scope.order(Arel.sql("LOWER(title) DESC"))
+    when "oldest"
+      scope.order(:created_at)
+    else
+      scope.order(created_at: :desc)
+    end
+  end
+
+  def available_categories(scope)
+    scope.distinct.where.not(category: [nil, ""]).order(:category).pluck(:category)
+  end
+
+  def available_tags(scope)
+    return [] unless Item.column_names.include?("tags")
+
+    raw = scope.pluck(:tags).compact
+    raw.flat_map do |value|
+      case value
+      when Array
+        value
+      when String
+        value.split(",").map(&:strip)
+      else
+        []
+      end
+    end.compact.uniq.sort
   end
 end

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -104,7 +104,7 @@ export const deleteComment = (postId, commentId) => api.delete(`/posts/${postId}
 
 
 // ITEM ENDPOINTS
-export const fetchItems = (q) => api.get('/items.json', { params: q ? { q } : {} });
+export const fetchItems = (params = {}) => api.get('/items.json', { params });
 export const createItem = (d) => api.post('/items.json', { item: d });
 export const updateItem = (id, d) => api.patch(`/items/${id}.json`, { item: d });
 export const deleteItem = (id) => api.delete(`/items/${id}.json`);


### PR DESCRIPTION
## Summary
- extend the Vault page with category and tag selection state, sort options, and active filter chips wired into item loading
- allow the client to pass structured filter and sort params when fetching vault items and refresh available filter metadata from the response
- update the items API index action to apply search/category/tag filters, support sorting, and return category/tag options for the UI

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69045ba1b644832294564b32b4b9af7b