### PR TITLE
Define missing Active Record relationships across models

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,8 +1,8 @@
 class Comment < ApplicationRecord
   include UserStampable
 
-  belongs_to :post, counter_cache: true
-  belongs_to :user
+  belongs_to :post, counter_cache: true, inverse_of: :comments
+  belongs_to :user, inverse_of: :comments
 
   validates :body, presence: true
 end

--- a/app/models/developer.rb
+++ b/app/models/developer.rb
@@ -1,3 +1,7 @@
 class Developer < ApplicationRecord
   include UserStampable
+
+  has_many :tasks, dependent: :nullify, inverse_of: :developer
+  has_many :task_logs, dependent: :destroy, inverse_of: :developer
+  has_many :projects, -> { distinct }, through: :tasks, source: :project
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,5 @@
 class Item < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, inverse_of: :items
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/models/knowledge_bookmark.rb
+++ b/app/models/knowledge_bookmark.rb
@@ -1,5 +1,5 @@
 class KnowledgeBookmark < ApplicationRecord
-  belongs_to :user
+  belongs_to :user, inverse_of: :knowledge_bookmarks
 
   validates :card_type, presence: true
   validates :payload, presence: true

--- a/app/models/learning_checkpoint.rb
+++ b/app/models/learning_checkpoint.rb
@@ -1,5 +1,5 @@
 class LearningCheckpoint < ApplicationRecord
-  belongs_to :learning_goal
+  belongs_to :learning_goal, inverse_of: :learning_checkpoints
 
   validates :title, presence: true
 

--- a/app/models/learning_goal.rb
+++ b/app/models/learning_goal.rb
@@ -1,7 +1,7 @@
 class LearningGoal < ApplicationRecord
-  belongs_to :user
-  belongs_to :team, optional: true
-  has_many :learning_checkpoints, dependent: :destroy
+  belongs_to :user, inverse_of: :learning_goals
+  belongs_to :team, optional: true, inverse_of: :learning_goals
+  has_many :learning_checkpoints, dependent: :destroy, inverse_of: :learning_goal
 
   validates :title, presence: true
   validates :progress, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,10 +1,10 @@
 class Post < ApplicationRecord
   include UserStampable
 
-  belongs_to :user
+  belongs_to :user, inverse_of: :posts
   has_one_attached :image
-  has_many :post_likes, dependent: :destroy
+  has_many :post_likes, dependent: :destroy, inverse_of: :post
   has_many :liked_users, through: :post_likes, source: :user
-  has_many :comments, dependent: :destroy
+  has_many :comments, dependent: :destroy, inverse_of: :post
   validates :message, presence: true, unless: -> { image.attached? }
 end

--- a/app/models/post_like.rb
+++ b/app/models/post_like.rb
@@ -1,6 +1,6 @@
 class PostLike < ApplicationRecord
-  belongs_to :post
-  belongs_to :user
+  belongs_to :post, inverse_of: :post_likes
+  belongs_to :user, inverse_of: :post_likes
 
   validates :user_id, uniqueness: { scope: :post_id }
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,9 +1,11 @@
 class Project < ApplicationRecord
-  belongs_to :owner, class_name: 'User', optional: true
+  belongs_to :owner, class_name: 'User', optional: true, inverse_of: :owned_projects
 
-  has_many :project_users, dependent: :destroy
+  has_many :project_users, dependent: :destroy, inverse_of: :project
   has_many :users, through: :project_users
-  has_many :sprints, dependent: :destroy
+  has_many :sprints, dependent: :destroy, inverse_of: :project
+  has_many :tasks, dependent: :nullify, inverse_of: :project
+  has_many :developers, -> { distinct }, through: :tasks, source: :developer
 
   enum status: {
     upcoming: 'upcoming',

--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -1,6 +1,6 @@
 class ProjectUser < ApplicationRecord
-  belongs_to :project
-  belongs_to :user
+  belongs_to :project, inverse_of: :project_users
+  belongs_to :user, inverse_of: :project_users
 
   enum role: {
     owner: 'owner',

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,7 +1,7 @@
 class Role < ApplicationRecord
   NAMES = %w[owner admin member project_manager team_leader].freeze
 
-  has_many :user_roles, dependent: :destroy
+  has_many :user_roles, dependent: :destroy, inverse_of: :role
   has_many :users, through: :user_roles
 
   validates :name, presence: true, uniqueness: true, inclusion: { in: NAMES }

--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,5 +1,6 @@
 class Skill < ApplicationRecord
-  has_many :user_skills, dependent: :destroy
+  has_many :user_skills, dependent: :destroy, inverse_of: :skill
+  has_many :users, through: :user_skills
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
 

--- a/app/models/skill_endorsement.rb
+++ b/app/models/skill_endorsement.rb
@@ -1,7 +1,7 @@
 class SkillEndorsement < ApplicationRecord
-  belongs_to :user_skill, counter_cache: true
-  belongs_to :endorser, class_name: 'User'
-  belongs_to :team, optional: true
+  belongs_to :user_skill, counter_cache: true, inverse_of: :skill_endorsements
+  belongs_to :endorser, class_name: 'User', inverse_of: :given_skill_endorsements
+  belongs_to :team, optional: true, inverse_of: :skill_endorsements
 
   delegate :user, :skill, to: :user_skill
 

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -1,4 +1,6 @@
 class Sprint < ApplicationRecord
   include UserStampable
-  belongs_to :project
+
+  belongs_to :project, inverse_of: :sprints
+  has_many :tasks, dependent: :nullify, inverse_of: :sprint
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,12 +1,12 @@
 class Task < ApplicationRecord
   include UserStampable
 
-  belongs_to :sprint, optional: true
-  belongs_to :developer, optional: true
-  belongs_to :project, optional: true
-  belongs_to :assigned_user, class_name: 'User', foreign_key: :assigned_to_user, optional: true
+  belongs_to :sprint, optional: true, inverse_of: :tasks
+  belongs_to :developer, optional: true, inverse_of: :tasks
+  belongs_to :project, optional: true, inverse_of: :tasks
+  belongs_to :assigned_user, class_name: 'User', foreign_key: :assigned_to_user, optional: true, inverse_of: :tasks
 
-  has_many :task_logs, dependent: :destroy
+  has_many :task_logs, dependent: :destroy, inverse_of: :task
 
   # This tells ActiveRecord NOT to use the 'type' column for Single Table Inheritance.
   self.inheritance_column = 'non_existent_type_column'

--- a/app/models/task_log.rb
+++ b/app/models/task_log.rb
@@ -1,8 +1,8 @@
 class TaskLog < ApplicationRecord
   include UserStampable
 
-  belongs_to :task
-  belongs_to :developer
+  belongs_to :task, inverse_of: :task_logs
+  belongs_to :developer, inverse_of: :task_logs
 
   self.inheritance_column = 'non_existent_type_column'
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -1,9 +1,10 @@
 class Team < ApplicationRecord
-  belongs_to :owner, class_name: 'User', optional: true
+  belongs_to :owner, class_name: 'User', optional: true, inverse_of: :owned_teams
 
-  has_many :team_users, dependent: :destroy
+  has_many :team_users, dependent: :destroy, inverse_of: :team
   has_many :users, through: :team_users
-  has_many :learning_goals, dependent: :destroy
+  has_many :learning_goals, dependent: :destroy, inverse_of: :team
+  has_many :skill_endorsements, dependent: :nullify, inverse_of: :team
 
   validates :name, presence: true
 end

--- a/app/models/team_user.rb
+++ b/app/models/team_user.rb
@@ -1,6 +1,6 @@
 class TeamUser < ApplicationRecord
-  belongs_to :team
-  belongs_to :user
+  belongs_to :team, inverse_of: :team_users
+  belongs_to :user, inverse_of: :team_users
 
   enum role: {
     admin: 'admin',

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,24 +15,27 @@ class User < ApplicationRecord
 
   has_one_attached :profile_picture
   has_one_attached :cover_photo
-  has_many :posts, dependent: :destroy
-  has_many :tasks, foreign_key: :assigned_to_user
-  has_many :items
-  has_many :work_logs, dependent: :destroy
-  has_many :work_notes, dependent: :destroy
-  has_many :post_likes, dependent: :destroy
+  has_many :posts, dependent: :destroy, inverse_of: :user
+  has_many :tasks, foreign_key: :assigned_to_user, inverse_of: :assigned_user
+  has_many :items, inverse_of: :user
+  has_many :comments, dependent: :destroy, inverse_of: :user
+  has_many :work_logs, dependent: :destroy, inverse_of: :user
+  has_many :work_notes, dependent: :destroy, inverse_of: :user
+  has_many :post_likes, dependent: :destroy, inverse_of: :user
   has_many :liked_posts, through: :post_likes, source: :post
-  has_many :team_users, dependent: :destroy
+  has_many :team_users, dependent: :destroy, inverse_of: :user
   has_many :teams, through: :team_users
-  has_many :user_roles, dependent: :destroy
+  has_many :owned_teams, class_name: 'Team', foreign_key: :owner_id, inverse_of: :owner, dependent: :nullify
+  has_many :user_roles, dependent: :destroy, inverse_of: :user
   has_many :roles, through: :user_roles
-  has_many :project_users, dependent: :destroy
+  has_many :project_users, dependent: :destroy, inverse_of: :user
   has_many :projects, through: :project_users
+  has_many :owned_projects, class_name: 'Project', foreign_key: :owner_id, inverse_of: :owner, dependent: :nullify
   has_many :user_skills, dependent: :destroy
   has_many :skills, through: :user_skills
-  has_many :learning_goals, dependent: :destroy
-  has_many :knowledge_bookmarks, dependent: :destroy
-  has_many :given_skill_endorsements, class_name: 'SkillEndorsement', foreign_key: :endorser_id, dependent: :destroy
+  has_many :learning_goals, dependent: :destroy, inverse_of: :user
+  has_many :knowledge_bookmarks, dependent: :destroy, inverse_of: :user
+  has_many :given_skill_endorsements, class_name: 'SkillEndorsement', foreign_key: :endorser_id, dependent: :destroy, inverse_of: :endorser
   has_many :received_skill_endorsements, through: :user_skills, source: :skill_endorsements
 
   enum availability_status: {

--- a/app/models/user_role.rb
+++ b/app/models/user_role.rb
@@ -1,4 +1,4 @@
 class UserRole < ApplicationRecord
-  belongs_to :user
-  belongs_to :role
+  belongs_to :user, inverse_of: :user_roles
+  belongs_to :role, inverse_of: :user_roles
 end

--- a/app/models/user_skill.rb
+++ b/app/models/user_skill.rb
@@ -1,7 +1,7 @@
 class UserSkill < ApplicationRecord
-  belongs_to :user
-  belongs_to :skill
-  has_many :skill_endorsements, dependent: :destroy
+  belongs_to :user, inverse_of: :user_skills
+  belongs_to :skill, inverse_of: :user_skills
+  has_many :skill_endorsements, dependent: :destroy, inverse_of: :user_skill
 
   PROFICIENCY_LEVELS = %w[beginner intermediate advanced expert].freeze
 

--- a/app/models/work_category.rb
+++ b/app/models/work_category.rb
@@ -1,7 +1,7 @@
 class WorkCategory < ApplicationRecord
   include UserStampable
 
-  has_many :work_logs, dependent: :nullify
+  has_many :work_logs, dependent: :nullify, inverse_of: :category
 
   validates :name, presence: true
 end

--- a/app/models/work_log.rb
+++ b/app/models/work_log.rb
@@ -1,11 +1,11 @@
 class WorkLog < ApplicationRecord
   include UserStampable
 
-  belongs_to :user
-  belongs_to :category, class_name: 'WorkCategory', optional: true
-  belongs_to :priority, class_name: 'WorkPriority', optional: true
+  belongs_to :user, inverse_of: :work_logs
+  belongs_to :category, class_name: 'WorkCategory', optional: true, inverse_of: :work_logs
+  belongs_to :priority, class_name: 'WorkPriority', optional: true, inverse_of: :work_logs
 
-  has_many :work_log_tags, dependent: :destroy
+  has_many :work_log_tags, dependent: :destroy, inverse_of: :work_log
   has_many :tags, through: :work_log_tags, source: :work_tag, class_name: 'WorkTag'
 
   validates :title, :log_date, :start_time, :end_time, presence: true

--- a/app/models/work_log_tag.rb
+++ b/app/models/work_log_tag.rb
@@ -1,4 +1,4 @@
 class WorkLogTag < ApplicationRecord
-  belongs_to :work_log
-  belongs_to :work_tag
+  belongs_to :work_log, inverse_of: :work_log_tags
+  belongs_to :work_tag, inverse_of: :work_log_tags
 end

--- a/app/models/work_note.rb
+++ b/app/models/work_note.rb
@@ -1,7 +1,7 @@
 class WorkNote < ApplicationRecord
   include UserStampable
 
-  belongs_to :user
+  belongs_to :user, inverse_of: :work_notes
 
   validates :note_date, presence: true
 end

--- a/app/models/work_priority.rb
+++ b/app/models/work_priority.rb
@@ -1,7 +1,7 @@
 class WorkPriority < ApplicationRecord
   include UserStampable
 
-  has_many :work_logs, dependent: :nullify
+  has_many :work_logs, dependent: :nullify, inverse_of: :priority
 
   validates :name, presence: true
 end

--- a/app/models/work_tag.rb
+++ b/app/models/work_tag.rb
@@ -1,7 +1,7 @@
 class WorkTag < ApplicationRecord
   include UserStampable
 
-  has_many :work_log_tags, dependent: :destroy
+  has_many :work_log_tags, dependent: :destroy, inverse_of: :work_tag
   has_many :work_logs, through: :work_log_tags
 
   validates :name, presence: true, uniqueness: true


### PR DESCRIPTION
## Summary
- add missing Active Record relationships and inverse references across domain models
- connect projects, developers, sprints, teams, and skills through explicit associations
- update join models to enforce bidirectional ownership and support counter caches

## Testing
- bundle exec rubocop app/models *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_6904892537c88322aac1ec26349ef684