### PR TITLE
Add daily quiz and study reminder knowledge cards

### DIFF
--- a/app/javascript/components/Knowledge/DailyQuizCard.jsx
+++ b/app/javascript/components/Knowledge/DailyQuizCard.jsx
@@ -1,0 +1,225 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
+import { useKnowledgeBookmarks } from "../../context/KnowledgeBookmarksContext";
+
+const OPEN_TRIVIA_URL = "https://opentdb.com/api.php?amount=1&type=multiple";
+
+function shuffleOptions(options) {
+  const array = [...options];
+  for (let index = array.length - 1; index > 0; index -= 1) {
+    const randomIndex = Math.floor(Math.random() * (index + 1));
+    [array[index], array[randomIndex]] = [array[randomIndex], array[index]];
+  }
+  return array;
+}
+
+function decodeHtml(text) {
+  if (!text) return "";
+  if (typeof document === "undefined") return text;
+  const textarea = document.createElement("textarea");
+  textarea.innerHTML = text;
+  return textarea.value;
+}
+
+async function fetchOpenTriviaQuiz() {
+  const response = await fetch(OPEN_TRIVIA_URL);
+  if (!response.ok) {
+    throw new Error("Unable to fetch quiz question");
+  }
+  const data = await response.json();
+  const result = data?.results?.[0];
+  if (!result) {
+    throw new Error("Quiz service returned no questions");
+  }
+
+  const correct = decodeHtml(result.correct_answer);
+  const options = shuffleOptions(
+    [correct, ...(result.incorrect_answers || []).map((answer) => decodeHtml(answer))].filter(Boolean)
+  );
+
+  return {
+    id: `opentdb-${result.question}`,
+    question: decodeHtml(result.question),
+    options,
+    correctAnswer: correct,
+    explanation: result.category ? `Category: ${result.category}` : undefined,
+    source: "Open Trivia DB",
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export default function DailyQuizCard({
+  cardType = "daily_quiz",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const { getLearningQuizQuestion } = useKnowledgeBookmarks();
+  const hasInitialData = Boolean(initialData?.question);
+  const [quiz, setQuiz] = useState(() => (hasInitialData ? initialData : null));
+  const [status, setStatus] = useState(hasInitialData ? "ready" : "loading");
+  const [selectedOption, setSelectedOption] = useState(null);
+  const [result, setResult] = useState(null);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const loadQuiz = useCallback(async () => {
+    setStatus("loading");
+    setErrorMessage("");
+    setSelectedOption(null);
+    setResult(null);
+
+    try {
+      const bookmarkQuiz = await getLearningQuizQuestion?.();
+      if (bookmarkQuiz) {
+        setQuiz(bookmarkQuiz);
+        setStatus("ready");
+        return;
+      }
+
+      const fallbackQuiz = await fetchOpenTriviaQuiz();
+      setQuiz(fallbackQuiz);
+      setStatus("ready");
+    } catch (error) {
+      console.error("DailyQuizCard: unable to load quiz", error);
+      setQuiz(null);
+      setStatus("error");
+      setErrorMessage(error.message || "We couldn't load a quiz right now.");
+    }
+  }, [getLearningQuizQuestion]);
+
+  useEffect(() => {
+    if (!hasInitialData) {
+      loadQuiz();
+    }
+  }, [hasInitialData, loadQuiz]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!quiz) return null;
+    return {
+      cardType,
+      sourceId: quiz.id || quiz.question,
+      payload: quiz,
+      title: "Daily Quiz",
+      subtitle: quiz.question,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, quiz, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
+
+  const handleOptionSelect = (option) => {
+    if (status !== "ready" || !quiz || result) return;
+    setSelectedOption(option);
+    setResult(option === quiz.correctAnswer ? "correct" : "incorrect");
+  };
+
+  const sourceLabel = useMemo(() => {
+    if (!quiz?.source) return null;
+    if (quiz.source === "bookmarks") {
+      return "Based on your saved learning cards";
+    }
+    return quiz.source;
+  }, [quiz]);
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[260px]">
+      <div className="flex items-start justify-between mb-3">
+        <div>
+          <h2 className="text-lg font-semibold">📝 Daily Quiz</h2>
+          {sourceLabel && <p className="text-xs text-gray-500 mt-1">{sourceLabel}</p>}
+        </div>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
+
+      {status === "loading" && (
+        <div className="flex-1 flex items-center justify-center text-sm text-gray-500">Fetching a quiz…</div>
+      )}
+
+      {status === "error" && (
+        <div className="flex-1 flex flex-col items-start gap-3 text-sm text-red-600">
+          <p>{errorMessage}</p>
+          <button
+            type="button"
+            onClick={loadQuiz}
+            className="px-3 py-1.5 rounded-lg bg-red-100 text-red-700 text-xs font-medium hover:bg-red-200 transition"
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {status === "ready" && quiz && (
+        <div className="flex-1 flex flex-col gap-4">
+          <p className="text-sm text-gray-800 font-medium whitespace-pre-line">{quiz.question}</p>
+          <div className="space-y-2">
+            {quiz.options?.map((option) => {
+              const isSelected = selectedOption === option;
+              const isCorrect = result === "correct" && option === quiz.correctAnswer;
+              const isIncorrect = result === "incorrect" && isSelected;
+              return (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => handleOptionSelect(option)}
+                  disabled={Boolean(result)}
+                  className={`w-full text-left text-sm border rounded-xl px-3 py-2 transition focus:outline-none focus:ring-2 ${
+                    isCorrect
+                      ? "border-emerald-500 bg-emerald-50 text-emerald-700"
+                      : isIncorrect
+                      ? "border-red-500 bg-red-50 text-red-700"
+                      : isSelected
+                      ? "border-[var(--theme-color)] bg-[var(--theme-color)/0.1] text-[var(--theme-color-dark)]"
+                      : "border-gray-200 hover:border-[var(--theme-color)]"
+                  }`}
+                >
+                  {option}
+                </button>
+              );
+            })}
+          </div>
+
+          <div className="flex items-center justify-between text-xs text-gray-500">
+            {result ? (
+              <span className={result === "correct" ? "text-emerald-600" : "text-red-600"}>
+                {result === "correct" ? "Nice! That's correct." : `Correct answer: ${quiz.correctAnswer}`}
+              </span>
+            ) : (
+              <span>Choose the best answer.</span>
+            )}
+            <button
+              type="button"
+              onClick={loadQuiz}
+              disabled={status === "loading"}
+              className="text-[var(--theme-color)] font-medium disabled:opacity-50"
+            >
+              New quiz
+            </button>
+          </div>
+
+          {quiz.explanation && result && (
+            <div className="text-xs text-gray-600 bg-gray-50 border border-gray-100 rounded-xl px-3 py-2">
+              {quiz.explanation}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/components/Knowledge/StudyReminderCard.jsx
+++ b/app/javascript/components/Knowledge/StudyReminderCard.jsx
@@ -1,0 +1,147 @@
+import React, { useMemo, useState } from "react";
+import { useKnowledgeBookmarks } from "../../context/KnowledgeBookmarksContext";
+
+function formatRelativeTime(dateInput) {
+  if (!dateInput) return "No reminder set";
+  const target = new Date(dateInput);
+  if (Number.isNaN(target.getTime())) return "Unknown date";
+
+  const now = new Date();
+  const diffMs = target.getTime() - now.getTime();
+  const absMinutes = Math.round(Math.abs(diffMs) / 60000);
+
+  if (absMinutes === 0) {
+    return diffMs >= 0 ? "due now" : "just overdue";
+  }
+  if (absMinutes < 60) {
+    return diffMs >= 0 ? `due in ${absMinutes} min` : `${absMinutes} min overdue`;
+  }
+
+  const absHours = Math.round(absMinutes / 60);
+  if (absHours < 24) {
+    return diffMs >= 0 ? `due in ${absHours} hr` : `${absHours} hr overdue`;
+  }
+
+  const absDays = Math.round(absHours / 24);
+  return diffMs >= 0 ? `due in ${absDays} day${absDays === 1 ? "" : "s"}` : `${absDays} day${absDays === 1 ? "" : "s"} overdue`;
+}
+
+function formatAbsoluteDate(dateInput) {
+  if (!dateInput) return "";
+  const target = new Date(dateInput);
+  if (Number.isNaN(target.getTime())) return "";
+  return target.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function getBookmarkLabel(bookmark) {
+  return (
+    bookmark?.payload?.title ||
+    bookmark?.payload?.word ||
+    bookmark?.payload?.phrase ||
+    bookmark?.payload?.tense ||
+    bookmark?.payload?.headline ||
+    (Array.isArray(bookmark?.payload?.facts) ? bookmark.payload.facts[0] : null) ||
+    bookmark?.payload?.note ||
+    bookmark?.card_type?.replace(/_/g, " ") ||
+    "Saved item"
+  );
+}
+
+export default function StudyReminderCard({ cardType = "study_reminder", bookmarkHelpers }) {
+  const { dueBookmarks, upcomingReminders } = useKnowledgeBookmarks();
+  const [processingId, setProcessingId] = useState(null);
+
+  const duePreview = useMemo(() => dueBookmarks.slice(0, 3), [dueBookmarks]);
+  const upcomingPreview = useMemo(() => upcomingReminders.slice(0, 3), [upcomingReminders]);
+
+  const handleMarkReviewed = async (bookmark) => {
+    if (!bookmark) return;
+    setProcessingId(bookmark.id);
+    try {
+      await bookmarkHelpers?.markReviewed?.(bookmark);
+    } catch (error) {
+      console.error("StudyReminderCard: unable to mark reviewed", error);
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col min-h-[240px]">
+      <div className="flex items-start justify-between mb-4">
+        <div>
+          <h2 className="text-lg font-semibold">🔔 Study Reminders</h2>
+          <p className="text-xs text-gray-500 mt-1">
+            {dueBookmarks.length} due · {upcomingReminders.length} upcoming
+          </p>
+        </div>
+        <span className="text-[10px] uppercase tracking-wide text-gray-400 font-semibold">Stay on track</span>
+      </div>
+
+      <div className="space-y-5">
+        <section>
+          <div className="flex items-center justify-between mb-2">
+            <h3 className="text-sm font-semibold text-gray-700">Due now</h3>
+            {dueBookmarks.length > 0 && <span className="text-xs text-red-500 font-medium">Action needed</span>}
+          </div>
+          {duePreview.length === 0 ? (
+            <div className="text-sm text-gray-500 bg-gray-50 border border-gray-100 rounded-xl px-3 py-2">
+              You're all caught up! 🎉
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {duePreview.map((bookmark) => (
+                <li key={bookmark.id} className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-gray-800">{getBookmarkLabel(bookmark)}</p>
+                    <p className="text-xs text-red-600">{formatRelativeTime(bookmark.next_reminder_at)}</p>
+                    {bookmark.collection_name && (
+                      <p className="text-[10px] uppercase tracking-wide text-gray-400">{bookmark.collection_name}</p>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleMarkReviewed(bookmark)}
+                    disabled={processingId === bookmark.id}
+                    className="px-3 py-1.5 rounded-lg bg-emerald-100 text-emerald-700 text-xs font-medium hover:bg-emerald-200 transition disabled:opacity-50"
+                  >
+                    {processingId === bookmark.id ? "Updating…" : "Mark reviewed"}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section>
+          <h3 className="text-sm font-semibold text-gray-700 mb-2">Coming up</h3>
+          {upcomingPreview.length === 0 ? (
+            <div className="text-xs text-gray-500 bg-gray-50 border border-gray-100 rounded-xl px-3 py-2">
+              No reminders scheduled in the next week.
+            </div>
+          ) : (
+            <ul className="space-y-3">
+              {upcomingPreview.map((bookmark) => (
+                <li key={bookmark.id} className="flex items-start justify-between gap-3">
+                  <div className="space-y-1">
+                    <p className="text-sm font-medium text-gray-800">{getBookmarkLabel(bookmark)}</p>
+                    <p className="text-xs text-gray-500">{formatRelativeTime(bookmark.next_reminder_at)}</p>
+                    <p className="text-[10px] text-gray-400">{formatAbsoluteDate(bookmark.next_reminder_at)}</p>
+                  </div>
+                  <span className="text-xs text-gray-400 font-medium uppercase tracking-wide">
+                    Every {bookmark.reminder_interval_days}d
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -16,6 +16,8 @@ import CommonEnglishWordCard from "../components/Knowledge/CommonEnglishWordCard
 import EnglishTenseCard from "../components/Knowledge/EnglishTenseCard";
 import EnglishPhraseCard from "../components/Knowledge/EnglishPhraseCard";
 import ImageOfTheDayCard from "../components/Knowledge/ImageOfTheDayCard";
+import DailyQuizCard from "../components/Knowledge/DailyQuizCard";
+import StudyReminderCard from "../components/Knowledge/StudyReminderCard";
 import { KnowledgeBookmarksProvider, useKnowledgeBookmarks } from "../context/KnowledgeBookmarksContext";
 
 function KnowledgeDashboardContent() {
@@ -32,6 +34,7 @@ function KnowledgeDashboardContent() {
 
   const {
     bookmarks,
+    dueBookmarks,
     collections,
     loading: bookmarksLoading,
     createBookmark,
@@ -44,11 +47,6 @@ function KnowledgeDashboardContent() {
     const timer = setTimeout(() => setUiLoading(false), 600);
     return () => clearTimeout(timer);
   }, []);
-
-  const dueBookmarks = useMemo(() => {
-    const now = new Date();
-    return bookmarks.filter((bookmark) => bookmark.next_reminder_at && new Date(bookmark.next_reminder_at) <= now);
-  }, [bookmarks]);
 
   const savedCount = bookmarks.length;
   const dueCount = dueBookmarks.length;
@@ -91,6 +89,22 @@ function KnowledgeDashboardContent() {
         Component: ImageOfTheDayCard,
         title: "Image of the Day",
         summary: "Discover a stunning astronomy image curated daily.",
+      },
+      {
+        key: "daily-quiz",
+        cardType: "daily_quiz",
+        category: "learning",
+        Component: DailyQuizCard,
+        title: "Daily Quiz",
+        summary: "Test yourself with a quick knowledge check.",
+      },
+      {
+        key: "study-reminder",
+        cardType: "study_reminder",
+        category: "learning",
+        Component: StudyReminderCard,
+        title: "Study Reminders",
+        summary: "Review what you've saved before reminders are due.",
       },
       {
         key: "top-news",


### PR DESCRIPTION
## Summary
- add DailyQuizCard and StudyReminderCard components to the knowledge hub
- surface due and upcoming reminders plus quiz generation helpers from the bookmarks context
- register the new cards in the knowledge dashboard so they appear in the learning category

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_690853f5cd3c832293c790577d913f54