### PR TITLE
Add dev tool and open issue cards to knowledge dashboard

### DIFF
--- a/app/controllers/api/dev_tools_controller.rb
+++ b/app/controllers/api/dev_tools_controller.rb
@@ -1,0 +1,40 @@
+class Api::DevToolsController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+
+  TOOLS = [
+    {
+      name: 'HTTPie',
+      description: 'A friendly command-line HTTP client that makes testing and debugging APIs delightful.',
+      url: 'https://httpie.io/'
+    },
+    {
+      name: 'ngrok',
+      description: 'Instantly expose your localhost to securely share demos and receive webhooks.',
+      url: 'https://ngrok.com/'
+    },
+    {
+      name: 'Tuple',
+      description: 'Low-latency remote pair programming designed specifically for developers.',
+      url: 'https://tuple.app/'
+    },
+    {
+      name: 'Warp',
+      description: 'A modern Rust-based terminal with AI features, collaboration, and command workflows.',
+      url: 'https://www.warp.dev/'
+    },
+    {
+      name: 'Raycast',
+      description: 'A fast launcher for macOS that automates developer workflows with powerful extensions.',
+      url: 'https://www.raycast.com/'
+    },
+  ].freeze
+
+  def show
+    tool = TOOLS.sample
+    Rails.logger.info("DevTools success: #{tool[:name]}")
+    render json: tool.merge(fetched_at: Time.current.iso8601)
+  rescue StandardError => e
+    Rails.logger.error("DevTools error: #{e.message}")
+    render json: { error: 'Failed to load developer tool' }, status: :internal_server_error
+  end
+end

--- a/app/controllers/api/open_source_issues_controller.rb
+++ b/app/controllers/api/open_source_issues_controller.rb
@@ -1,0 +1,45 @@
+class Api::OpenSourceIssuesController < Api::BaseController
+  skip_before_action :authenticate_user!, only: [:show]
+
+  ISSUES = [
+    {
+      repository: 'vercel/next.js',
+      title: 'Improve error overlay formatting for server actions',
+      url: 'https://github.com/vercel/next.js/issues/56307',
+      summary: 'The development error overlay truncates stack traces for server actions. Help polish the DX by improving the renderer.'
+    },
+    {
+      repository: 'facebook/react',
+      title: 'Docs: Clarify rules of hooks for custom hooks',
+      url: 'https://github.com/facebook/react/issues/28319',
+      summary: 'Review the Rules of Hooks documentation and contribute clarifying guidance or examples for library authors.'
+    },
+    {
+      repository: 'rails/rails',
+      title: 'Active Job enqueue logging should include job arguments',
+      url: 'https://github.com/rails/rails/issues/50761',
+      summary: 'Improve observability by ensuring job arguments are included when Active Job logs enqueue operations.'
+    },
+    {
+      repository: 'tailwindlabs/tailwindcss',
+      title: 'Add configuration docs for container queries plugin',
+      url: 'https://github.com/tailwindlabs/tailwindcss/issues/12969',
+      summary: 'Write documentation covering setup and examples for the new container queries plugin released in Tailwind CSS v3.4.'
+    },
+    {
+      repository: 'pnpm/pnpm',
+      title: 'Feature request: workspace-level npm scripts summary command',
+      url: 'https://github.com/pnpm/pnpm/issues/7439',
+      summary: 'Contribute a CLI enhancement that lists package.json scripts available across a workspace to ease discovery.'
+    },
+  ].freeze
+
+  def show
+    issue = ISSUES.sample
+    Rails.logger.info("OpenSourceIssues success: #{issue[:repository]} -> #{issue[:title]}")
+    render json: issue.merge(fetched_at: Time.current.iso8601)
+  rescue StandardError => e
+    Rails.logger.error("OpenSourceIssues error: #{e.message}")
+    render json: { error: 'Failed to load open source issue' }, status: :internal_server_error
+  end
+end

--- a/app/javascript/components/Knowledge/DevToolOfTheDayCard.jsx
+++ b/app/javascript/components/Knowledge/DevToolOfTheDayCard.jsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
+
+export default function DevToolOfTheDayCard({
+  cardType = "dev_tool_of_the_day",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [tool, setTool] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (hasInitialData) return;
+
+    let active = true;
+
+    async function fetchTool() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/dev_tool_of_the_day");
+        if (!response.ok) throw new Error("Network response was not ok");
+        const data = await response.json();
+        if (active) {
+          setTool(data);
+        }
+      } catch (err) {
+        console.error("Dev tool fetch failed", err);
+        if (active) {
+          setError("Unable to load a developer tool right now.");
+          setTool(null);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchTool();
+    return () => {
+      active = false;
+    };
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!tool?.name) return null;
+    return {
+      cardType,
+      sourceId: tool.url || tool.name,
+      payload: tool,
+      title: `Dev Tool: ${tool.name}`,
+      subtitle: tool.description,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, tool, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[200px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🛠️ Dev Tool of the Day</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
+      {loading ? (
+        <p className="text-sm text-gray-500">Loading a developer productivity boost...</p>
+      ) : error ? (
+        <p className="text-sm text-red-500">{error}</p>
+      ) : tool ? (
+        <div className="space-y-2">
+          <p className="text-base font-semibold text-gray-900">{tool.name}</p>
+          <p className="text-sm text-gray-700 leading-relaxed">{tool.description}</p>
+          {tool.url && (
+            <a
+              href={tool.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-blue-600 hover:underline"
+            >
+              Explore {tool.name}
+            </a>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">No developer tool spotlight available.</p>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/components/Knowledge/OpenIssueSpotlightCard.jsx
+++ b/app/javascript/components/Knowledge/OpenIssueSpotlightCard.jsx
@@ -1,0 +1,108 @@
+import React, { useEffect, useMemo, useState } from "react";
+import BookmarkToggle from "./BookmarkToggle";
+
+export default function OpenIssueSpotlightCard({
+  cardType = "open_issue_spotlight",
+  bookmarkHelpers,
+  initialData = null,
+  savedBookmark = null,
+}) {
+  const hasInitialData = initialData !== null && initialData !== undefined;
+  const [issue, setIssue] = useState(() => (hasInitialData ? initialData : null));
+  const [loading, setLoading] = useState(!hasInitialData);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (hasInitialData) return;
+
+    let active = true;
+
+    async function fetchIssue() {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch("/api/open_issue_spotlight");
+        if (!response.ok) throw new Error("Network response was not ok");
+        const data = await response.json();
+        if (active) {
+          setIssue(data);
+        }
+      } catch (err) {
+        console.error("Open issue fetch failed", err);
+        if (active) {
+          setError("Unable to load an open source issue right now.");
+          setIssue(null);
+        }
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchIssue();
+    return () => {
+      active = false;
+    };
+  }, [hasInitialData]);
+
+  const bookmarkPayload = useMemo(() => {
+    if (!issue?.url) return null;
+    return {
+      cardType,
+      sourceId: issue.url,
+      payload: issue,
+      title: `Open Source Issue: ${issue.title}`,
+      subtitle: issue.summary,
+      collectionName: savedBookmark?.collection_name,
+      reminderIntervalDays: savedBookmark?.reminder_interval_days,
+    };
+  }, [cardType, issue, savedBookmark]);
+
+  const existingBookmark = bookmarkPayload
+    ? bookmarkHelpers?.find?.(bookmarkPayload) || savedBookmark
+    : savedBookmark;
+  const isBookmarked = Boolean(existingBookmark);
+
+  const handleToggle = () => {
+    if (!bookmarkPayload) return;
+    bookmarkHelpers?.toggle?.({
+      ...bookmarkPayload,
+      collectionName: existingBookmark?.collection_name ?? bookmarkPayload.collectionName,
+    });
+  };
+
+  return (
+    <div className="bg-white shadow-md rounded-2xl p-4 flex flex-col justify-between min-h-[200px]">
+      <div className="flex items-start justify-between mb-3">
+        <h2 className="text-lg font-semibold">🐙 Open Issue Spotlight</h2>
+        <BookmarkToggle
+          isBookmarked={isBookmarked}
+          onToggle={handleToggle}
+          collectionName={existingBookmark?.collection_name}
+          disabled={!bookmarkPayload}
+        />
+      </div>
+      {loading ? (
+        <p className="text-sm text-gray-500">Finding a community issue to tackle...</p>
+      ) : error ? (
+        <p className="text-sm text-red-500">{error}</p>
+      ) : issue ? (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-gray-800 uppercase tracking-wide">{issue.repository}</p>
+          <a
+            href={issue.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-base font-semibold text-blue-600 hover:underline"
+          >
+            {issue.title}
+          </a>
+          <p className="text-sm text-gray-700 leading-relaxed">{issue.summary}</p>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">No open issue spotlight available.</p>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -8,6 +8,8 @@ import WordOfTheDayCard from "../components/Knowledge/WordOfTheDayCard";
 import RandomCodingTipCard from "../components/Knowledge/RandomCodingTipCard";
 import ScienceNewsCard from "../components/Knowledge/ScienceNewsCard";
 import TechNewsCard from "../components/Knowledge/TechNewsCard";
+import DevToolOfTheDayCard from "../components/Knowledge/DevToolOfTheDayCard";
+import OpenIssueSpotlightCard from "../components/Knowledge/OpenIssueSpotlightCard";
 import TopGainersCard from "../components/Knowledge/TopGainersCard";
 import TopVolumeStocksCard from "../components/Knowledge/TopVolumeStocksCard";
 import TopBuyingStocksCard from "../components/Knowledge/TopBuyingStocksCard";
@@ -149,6 +151,14 @@ function KnowledgeDashboardContent() {
         summary: "Sharpen your skills with a bite-sized coding tip.",
       },
       {
+        key: "dev-tool-of-day",
+        cardType: "dev_tool_of_the_day",
+        category: "tech",
+        Component: DevToolOfTheDayCard,
+        title: "Dev Tool of the Day",
+        summary: "Discover a developer tool to streamline your workflow.",
+      },
+      {
         key: "science-news",
         cardType: "science_news",
         category: "news",
@@ -163,6 +173,14 @@ function KnowledgeDashboardContent() {
         Component: TechNewsCard,
         title: "Tech News",
         summary: "Follow the newest stories in technology.",
+      },
+      {
+        key: "open-issue-spotlight",
+        cardType: "open_issue_spotlight",
+        category: "tech",
+        Component: OpenIssueSpotlightCard,
+        title: "Open Issue Spotlight",
+        summary: "Tackle a curated open source issue and give back.",
       },
       {
         key: "top-gainers",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,9 +49,11 @@ Rails.application.routes.draw do
     get 'view_profile', to: 'auth#view_profile'
     post 'update_profile', to: 'auth#update_profile'
     get 'coding_tip', to: 'coding_tips#show'
+    get 'dev_tool_of_the_day', to: 'dev_tools#show'
     get 'english_word', to: 'english_words#show'
     get 'english_tense', to: 'english_tenses#show'
     get 'english_phrase', to: 'english_phrases#show'
+    get 'open_issue_spotlight', to: 'open_source_issues#show'
     get 'sheet', to: 'sheets#show'
 
     resources :users, only: [:index, :update, :destroy]


### PR DESCRIPTION
## Summary
- add API endpoints that surface curated developer tools and open source issues for the tech dashboard cards
- implement DevToolOfTheDayCard and OpenIssueSpotlightCard components with loading and error handling
- register the new cards within the tech category of the knowledge dashboard

## Testing
- yarn lint *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_e_690853f62a648322b8d10e1721c55bd2