### PR TITLE
Add rss gem dependency for news feed services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,7 @@ gem 'faraday', '~> 2.7'
 gem 'jwt'
 gem 'bcrypt'
 gem 'rqrcode'
+gem 'rss'
 gem 'dotenv-rails', groups: [:development, :test]
 
 # Access Google Sheets from Rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,7 @@ GEM
       chunky_png (~> 1.0)
       rqrcode_core (~> 2.0)
     rqrcode_core (2.0.0)
+    rss (0.2.9)
     ruby-openai (5.2.0)
       event_stream_parser (>= 0.3.0, < 1.0.0)
       faraday (>= 1)
@@ -457,6 +458,7 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.1.3)
   rqrcode
+  rss
   ruby-openai (~> 5.0)
   selenium-webdriver
   sqlite3 (~> 1.4)


### PR DESCRIPTION
## Summary
- add the rss gem to the application's dependencies so RSS parsing libraries can load in production
- update Gemfile.lock to include the rss gem specification

## Testing
- bundle exec ruby -e 'require "rss"' *(fails: Ruby version 3.2.3, but Gemfile specifies 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_6908583e78148322a7dfbdf32d216cf0