### PR TITLE
Refine knowledge dashboard filters and layout

### DIFF
--- a/app/javascript/components/Knowledge/KnowledgeCardQuickActions.jsx
+++ b/app/javascript/components/Knowledge/KnowledgeCardQuickActions.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { FaBell, FaBookmark, FaRegBell, FaRegBookmark } from "react-icons/fa";
+
+export default function KnowledgeCardQuickActions({
+  isBookmarked = false,
+  onToggleBookmark,
+  hasReminder = false,
+  reminderDue = false,
+  onOpenReminder,
+}) {
+  if (!onToggleBookmark && !onOpenReminder) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none absolute right-3 top-3 flex gap-2 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+      {onToggleBookmark && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onToggleBookmark?.();
+          }}
+          className={`pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full border text-sm shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+            isBookmarked
+              ? "border-yellow-400 bg-yellow-100 text-yellow-700 hover:bg-yellow-200"
+              : "border-gray-200 bg-white text-gray-500 hover:bg-gray-100"
+          }`}
+          aria-pressed={isBookmarked}
+          title={isBookmarked ? "Remove bookmark" : "Save bookmark"}
+        >
+          {isBookmarked ? <FaBookmark aria-hidden="true" /> : <FaRegBookmark aria-hidden="true" />}
+        </button>
+      )}
+
+      {onOpenReminder && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onOpenReminder?.();
+          }}
+          className={`pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full border text-sm shadow-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+            reminderDue
+              ? "border-red-400 bg-red-50 text-red-600 hover:bg-red-100"
+              : hasReminder
+              ? "border-emerald-300 bg-emerald-50 text-emerald-600 hover:bg-emerald-100"
+              : "border-gray-200 bg-white text-gray-500 hover:bg-gray-100"
+          }`}
+          title={hasReminder ? "Edit reminder" : "Add reminder"}
+        >
+          {hasReminder ? <FaBell aria-hidden="true" /> : <FaRegBell aria-hidden="true" />}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/javascript/components/Knowledge/KnowledgeFilterControls.jsx
+++ b/app/javascript/components/Knowledge/KnowledgeFilterControls.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { FaChevronDown, FaChevronUp, FaFilter } from "react-icons/fa";
+
+export default function KnowledgeFilterControls({ options, filters, onToggle }) {
+  const activeOptions = useMemo(
+    () => options.filter((option) => filters[option.key]),
+    [options, filters]
+  );
+  const [expanded, setExpanded] = useState(() => activeOptions.length > 0);
+
+  useEffect(() => {
+    if (activeOptions.length > 0) {
+      setExpanded(true);
+    }
+  }, [activeOptions.length]);
+
+  const toggleExpanded = () => {
+    setExpanded((prev) => !prev);
+  };
+
+  const summaryLabel = activeOptions.length
+    ? `${activeOptions.length} active: ${activeOptions.map((option) => option.label).join(", ")}`
+    : "No filters applied";
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <button
+        type="button"
+        onClick={toggleExpanded}
+        className="inline-flex items-center gap-2 rounded-full border border-gray-300 bg-white px-3 py-2 text-xs font-medium text-gray-600 transition-colors hover:bg-gray-100"
+        aria-expanded={expanded}
+      >
+        <FaFilter aria-hidden="true" />
+        {expanded ? "Hide filters" : "Show filters"}
+        {expanded ? <FaChevronUp aria-hidden="true" /> : <FaChevronDown aria-hidden="true" />}
+      </button>
+
+      {expanded ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {options.map((option) => {
+            const isActive = Boolean(filters[option.key]);
+            return (
+              <button
+                key={option.key}
+                type="button"
+                onClick={() => onToggle(option.key)}
+                className={`inline-flex items-center gap-1 rounded-full border px-3 py-2 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1 ${
+                  isActive
+                    ? "border-[var(--theme-color)] bg-[var(--theme-color)] text-white"
+                    : "border-gray-300 bg-white text-gray-600 hover:bg-gray-100"
+                }`}
+                aria-pressed={isActive}
+              >
+                <span aria-hidden="true">{option.icon}</span>
+                {option.label}
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={toggleExpanded}
+          className="rounded-full border border-dashed border-gray-300 bg-white px-3 py-2 text-xs font-medium text-gray-500 hover:border-gray-400"
+        >
+          {summaryLabel}
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- replace inline filter chips with a reusable control that can collapse into an active-filter summary pill
- add list/tile layout switching, updated grid breakpoints, and card-level quick actions for saved reminders
- enhance the bookmark modal flow to support editing reminder settings in place

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_69088f2436608322a71f581217bc1e51