### PR TITLE
Enhance team sidebar and insights tabs

### DIFF
--- a/app/javascript/components/teams/TeamListItem.jsx
+++ b/app/javascript/components/teams/TeamListItem.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useMemo } from "react";
+import { FiAward, FiChevronRight, FiFlag, FiLoader, FiTrendingUp, FiUsers } from "react-icons/fi";
+import Avatar from "../ui/Avatar";
+
+const KPIBadge = ({ icon: Icon, label, value, isLoading }) => (
+  <span className="inline-flex items-center gap-1.5 rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-600">
+    {isLoading ? (
+      <FiLoader className="h-3.5 w-3.5 animate-spin text-slate-500" />
+    ) : (
+      Icon && <Icon className="h-3.5 w-3.5 text-slate-500" />
+    )}
+    <span className="uppercase tracking-wide">{label}</span>
+    <span className="font-semibold text-slate-800">{isLoading ? "…" : value ?? "—"}</span>
+  </span>
+);
+
+const TeamListItem = ({ team, isSelected, onSelect, metrics, onEnsureMetrics }) => {
+  const memberPreview = useMemo(() => (Array.isArray(team.users) ? team.users.slice(0, 3) : []), [team.users]);
+  const totalMembers = Array.isArray(team.users) ? team.users.length : 0;
+  const remainingMembers = Math.max(totalMembers - memberPreview.length, 0);
+
+  useEffect(() => {
+    if (!onEnsureMetrics || isSelected) return;
+    const needsMetrics =
+      !metrics ||
+      metrics.skillCount == null ||
+      metrics.endorsementCount == null ||
+      metrics.learningGoalsCount == null;
+    if (needsMetrics && !metrics?.isFetching && !metrics?.error) {
+      onEnsureMetrics(team.id);
+    }
+  }, [isSelected, metrics, onEnsureMetrics, team.id]);
+
+  const handleClick = () => {
+    if (onSelect) {
+      onSelect(team.id);
+    }
+  };
+
+  const badgeValue = (value) => (typeof value === "number" ? value : value ?? "—");
+
+  return (
+    <li className="border-b border-gray-100 last:border-b-0">
+      <button
+        type="button"
+        onClick={handleClick}
+        className={`w-full text-left transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--theme-color)] ${
+          isSelected
+            ? "bg-[rgb(var(--theme-color-rgb)/0.12)] text-[var(--theme-color)] border-l-4 border-[var(--theme-color)]"
+            : "hover:bg-slate-50"
+        }`}
+        aria-current={isSelected ? "true" : undefined}
+      >
+        <div className="flex items-start justify-between gap-3 p-4">
+          <div className="flex flex-1 items-start gap-3">
+            <div className="flex -space-x-2">
+              {memberPreview.length > 0 ? (
+                memberPreview.map((member) => (
+                  <Avatar
+                    key={member.id}
+                    name={member.name}
+                    src={member.profile_picture}
+                    className="h-8 w-8 border-2 border-white text-xs shadow-sm first:ml-0"
+                  />
+                ))
+              ) : (
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200 text-xs font-semibold text-slate-600">
+                  <FiUsers aria-hidden="true" />
+                </div>
+              )}
+              {remainingMembers > 0 && (
+                <span className="ml-2 rounded-full bg-slate-200 px-2 py-1 text-[11px] font-medium text-slate-600">
+                  +{remainingMembers}
+                </span>
+              )}
+            </div>
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-base font-semibold text-gray-900">{team.name}</p>
+              {team.description && (
+                <p className="mt-1 line-clamp-2 text-xs text-gray-500">{team.description}</p>
+              )}
+              <div className="mt-2 flex flex-wrap gap-2">
+                <KPIBadge
+                  icon={FiUsers}
+                  label="Members"
+                  value={badgeValue(metrics?.memberCount ?? totalMembers)}
+                  isLoading={Boolean(metrics?.isFetching && metrics?.memberCount == null)}
+                />
+                <KPIBadge
+                  icon={FiAward}
+                  label="Skills"
+                  value={badgeValue(metrics?.skillCount)}
+                  isLoading={Boolean(metrics?.isFetching && metrics?.skillCount == null)}
+                />
+                <KPIBadge
+                  icon={FiFlag}
+                  label="Goals"
+                  value={badgeValue(metrics?.learningGoalsCount)}
+                  isLoading={Boolean(metrics?.isFetching && metrics?.learningGoalsCount == null)}
+                />
+                <KPIBadge
+                  icon={FiTrendingUp}
+                  label="Endorsements"
+                  value={badgeValue(metrics?.endorsementCount)}
+                  isLoading={Boolean(metrics?.isFetching && metrics?.endorsementCount == null)}
+                />
+              </div>
+            </div>
+          </div>
+          <FiChevronRight
+            className={`mt-1 h-4 w-4 transition-transform duration-200 ${
+              isSelected ? "translate-x-1 text-[var(--theme-color)]" : "text-gray-400"
+            }`}
+            aria-hidden="true"
+          />
+        </div>
+      </button>
+    </li>
+  );
+};
+
+export default TeamListItem;

--- a/app/javascript/components/ui/tabs.jsx
+++ b/app/javascript/components/ui/tabs.jsx
@@ -1,0 +1,248 @@
+import React, { createContext, forwardRef, useCallback, useContext, useEffect, useId, useMemo, useRef, useState } from "react";
+
+const TabsContext = createContext(null);
+
+const sanitizeValue = (value) => String(value).replace(/\s+/g, "-");
+
+export const Tabs = ({
+  children,
+  className = "",
+  defaultValue,
+  value: controlledValue,
+  onValueChange,
+  orientation = "horizontal",
+}) => {
+  const baseId = useId();
+  const [uncontrolledValue, setUncontrolledValue] = useState(defaultValue);
+  const isControlled = typeof controlledValue !== "undefined";
+  const activeValue = isControlled ? controlledValue : uncontrolledValue;
+
+  const triggersRef = useRef([]);
+
+  const setValue = useCallback(
+    (nextValue) => {
+      if (!isControlled) {
+        setUncontrolledValue(nextValue);
+      }
+      if (onValueChange) {
+        onValueChange(nextValue);
+      }
+    },
+    [isControlled, onValueChange]
+  );
+
+  const registerTrigger = useCallback((value, node, id) => {
+    triggersRef.current = [
+      ...triggersRef.current.filter((entry) => entry.value !== value),
+      { value, node, id },
+    ];
+  }, []);
+
+  const unregisterTrigger = useCallback((value) => {
+    triggersRef.current = triggersRef.current.filter((entry) => entry.value !== value);
+  }, []);
+
+  const focusRelative = useCallback(
+    (currentValue, offset) => {
+      const items = triggersRef.current;
+      if (items.length === 0) return;
+
+      const currentIndex = items.findIndex((item) => item.value === currentValue);
+      const startingIndex = currentIndex === -1 ? 0 : currentIndex;
+      const nextIndex = (startingIndex + offset + items.length) % items.length;
+      const target = items[nextIndex];
+
+      if (target) {
+        setValue(target.value);
+        target.node?.focus();
+      }
+    },
+    [setValue]
+  );
+
+  const focusFirst = useCallback(() => {
+    const [first] = triggersRef.current;
+    if (first) {
+      setValue(first.value);
+      first.node?.focus();
+    }
+  }, [setValue]);
+
+  const focusLast = useCallback(() => {
+    const items = triggersRef.current;
+    if (items.length > 0) {
+      const last = items[items.length - 1];
+      setValue(last.value);
+      last.node?.focus();
+    }
+  }, [setValue]);
+
+  const contextValue = useMemo(
+    () => ({
+      activeValue,
+      baseId,
+      orientation,
+      setValue,
+      registerTrigger,
+      unregisterTrigger,
+      focusRelative,
+      focusFirst,
+      focusLast,
+    }),
+    [activeValue, baseId, orientation, setValue, registerTrigger, unregisterTrigger, focusRelative, focusFirst, focusLast]
+  );
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+};
+
+const useTabsContext = () => {
+  const context = useContext(TabsContext);
+  if (!context) {
+    throw new Error("Tabs components must be used within a Tabs provider");
+  }
+  return context;
+};
+
+export const TabsList = forwardRef(({ className = "", orientation: orientationOverride, ...props }, ref) => {
+  const { orientation } = useTabsContext();
+  const currentOrientation = orientationOverride || orientation;
+  const orientationClass = currentOrientation === "vertical" ? "flex-col" : "flex-row";
+
+  return (
+    <div
+      {...props}
+      ref={ref}
+      role="tablist"
+      aria-orientation={currentOrientation}
+      className={`flex ${orientationClass} ${className}`.trim()}
+    />
+  );
+});
+
+export const TabsTrigger = forwardRef(({ value, className = "", disabled = false, children, ...props }, ref) => {
+  const { activeValue, baseId, setValue, registerTrigger, unregisterTrigger, focusRelative, focusFirst, focusLast } =
+    useTabsContext();
+  const internalRef = useRef(null);
+  const mergedRef = useCallback(
+    (node) => {
+      internalRef.current = node;
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+    },
+    [ref]
+  );
+
+  const normalizedValue = sanitizeValue(value);
+  const triggerId = `${baseId}-${normalizedValue}-trigger`;
+  const contentId = `${baseId}-${normalizedValue}-content`;
+
+  useEffect(() => {
+    const node = internalRef.current;
+    if (!node) return;
+    registerTrigger(value, node, triggerId);
+    return () => unregisterTrigger(value);
+  }, [registerTrigger, unregisterTrigger, triggerId, value]);
+
+  const isActive = value === activeValue;
+
+  const handleKeyDown = (event) => {
+    if (disabled) return;
+
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        event.preventDefault();
+        focusRelative(value, 1);
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        event.preventDefault();
+        focusRelative(value, -1);
+        break;
+      case "Home":
+        event.preventDefault();
+        focusFirst();
+        break;
+      case "End":
+        event.preventDefault();
+        focusLast();
+        break;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <button
+      {...props}
+      ref={mergedRef}
+      id={triggerId}
+      type="button"
+      role="tab"
+      aria-selected={isActive}
+      aria-controls={contentId}
+      tabIndex={isActive ? 0 : -1}
+      data-state={isActive ? "active" : "inactive"}
+      disabled={disabled}
+      className={className}
+      onClick={(event) => {
+        if (disabled) return;
+        setValue(value);
+        if (props.onClick) {
+          props.onClick(event);
+        }
+      }}
+      onKeyDown={(event) => {
+        handleKeyDown(event);
+        if (props.onKeyDown) {
+          props.onKeyDown(event);
+        }
+      }}
+    >
+      {children}
+    </button>
+  );
+});
+
+export const TabsContent = forwardRef(
+  ({ value, className = "", children, forceMount = false, lazyMount = false, ...props }, ref) => {
+    const { activeValue, baseId } = useTabsContext();
+    const normalizedValue = sanitizeValue(value);
+    const contentId = `${baseId}-${normalizedValue}-content`;
+    const triggerId = `${baseId}-${normalizedValue}-trigger`;
+    const isActive = value === activeValue;
+    const [hasBeenActive, setHasBeenActive] = useState(isActive);
+
+    useEffect(() => {
+      if (isActive) {
+        setHasBeenActive(true);
+      }
+    }, [isActive]);
+
+    const shouldRenderChildren = forceMount || !lazyMount || isActive || hasBeenActive;
+
+    return (
+      <div
+        {...props}
+        ref={ref}
+        role="tabpanel"
+        id={contentId}
+        aria-labelledby={triggerId}
+        tabIndex={0}
+        hidden={!isActive && !forceMount}
+        className={`${className} ${!isActive && !forceMount ? "hidden" : ""}`.trim()}
+      >
+        {shouldRenderChildren ? children : null}
+      </div>
+    );
+  }
+);
+
+export default Tabs;


### PR DESCRIPTION
## Summary
- add a reusable Tabs component with keyboard support for insights panes
- introduce a richer TeamListItem that shows member avatars and KPI badges while preloading metrics
- refactor the Teams page to use the new components, cache metrics, and gate insights behind lazy-loaded tabs

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69088f1fedbc8322a99bf61a30a4fea9