### PR TITLE
Improve layout handling for skill-heavy team pages

### DIFF
--- a/app/javascript/components/teams/SkillDirectory.jsx
+++ b/app/javascript/components/teams/SkillDirectory.jsx
@@ -64,7 +64,7 @@ const SkillDirectory = ({
   };
 
   return (
-    <div className="bg-white rounded-xl shadow-md p-6 space-y-6">
+    <div className="bg-white rounded-xl shadow-md p-6 space-y-6 overflow-hidden min-w-0">
       <div>
         <h2 className="text-xl font-bold text-gray-800">Find Team Experts</h2>
         <p className="text-gray-500 text-sm mt-1">Search by name, role, skill or availability to find the right collaborator.</p>
@@ -107,9 +107,9 @@ const SkillDirectory = ({
         </div>
       </div>
 
-      <div>
+      <div className="min-w-0">
         <label className="block text-sm font-medium text-gray-700 mb-2">Filter by Skills</label>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 max-h-36 overflow-y-auto pr-1">
           {skillNames.map((skillName) => {
             const isSelected = selectedSkills.includes(skillName);
             return (
@@ -128,7 +128,7 @@ const SkillDirectory = ({
         </div>
       </div>
 
-      <div className="flex justify-between items-center">
+      <div className="flex justify-between items-center flex-wrap gap-2">
         <p className="text-gray-600 text-sm">
           {filteredMembers.length} {filteredMembers.length === 1 ? "expert found" : "experts found"}
         </p>

--- a/app/javascript/components/teams/TeamSkillMatrix.jsx
+++ b/app/javascript/components/teams/TeamSkillMatrix.jsx
@@ -85,7 +85,7 @@ const TeamSkillMatrix = ({ members = [], skills = [], roles = [] }) => {
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-md p-6 space-y-6">
+    <div className="bg-white rounded-xl shadow-md p-6 space-y-6 overflow-hidden min-w-0">
       <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
         <div>
           <h2 className="text-xl font-bold text-gray-800">Team Skill Matrix</h2>
@@ -113,11 +113,11 @@ const TeamSkillMatrix = ({ members = [], skills = [], roles = [] }) => {
         </div>
       </div>
 
-      <div className="relative overflow-hidden">
+      <div className="relative">
         <div className="pointer-events-none absolute inset-y-0 left-0 w-8 bg-gradient-to-r from-white via-white/80 to-transparent z-10" />
         <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-white via-white/80 to-transparent z-10" />
-        <div className="overflow-x-auto rounded-lg border border-gray-100 shadow-inner scrollbar-thin">
-          <table className="min-w-max w-full border-collapse">
+        <div className="overflow-x-auto rounded-lg border border-gray-100 shadow-inner scrollbar-thin max-w-full">
+          <table className="w-full min-w-full border-collapse">
             <thead className="bg-gray-50 sticky top-0 z-20">
               <tr>
                 <th className="border border-gray-200 px-4 py-3 text-left text-sm font-semibold text-gray-700 sticky left-0 top-0 bg-gray-50 z-30">


### PR DESCRIPTION
## Summary
- ensure the Team Skill Matrix card keeps to the main layout width while providing horizontal scrolling for large tables
- constrain the Find Team Experts filters so long skill lists remain contained within the card

## Testing
- yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c6ed98048322ae74d5119b1b9ab1)