### PR TITLE
Avoid CSRF errors on API auth endpoints

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,4 +1,5 @@
 class Api::BaseController < ApplicationController
+  protect_from_forgery with: :null_session
   before_action :authenticate_user!
 
   attr_reader :current_user


### PR DESCRIPTION
## Summary
- add null-session forgery protection to API base controller to avoid CSRF exceptions on auth endpoints

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924361b159c83229f68040b04cf53fc)