### PR TITLE
Handle missing QA mode flag during project serialization

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -64,7 +64,7 @@ class Api::ProjectsController < Api::BaseController
       status: project.status,
       sheet_integration_enabled: project.sheet_integration_enabled,
       sheet_id: project.sheet_id,
-      qa_mode_enabled: project.qa_mode_enabled,
+      qa_mode_enabled: project.try(:qa_mode_enabled) || false,
       users: project.project_users.map do |pu|
         {
           id: pu.user_id,


### PR DESCRIPTION
## Summary
- Guard project serialization to tolerate missing qa_mode_enabled attribute and default to false, preventing API errors when the column is absent.

## Testing
- bundle exec rails test *(fails: bundler: command not found: rails)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692565fd3058832299203acf60c06ee0)