### PR TITLE
Add migration to ensure qa mode enabled column

### DIFF
--- a/db/migrate/20261101000000_ensure_qa_mode_enabled_on_projects.rb
+++ b/db/migrate/20261101000000_ensure_qa_mode_enabled_on_projects.rb
@@ -1,0 +1,7 @@
+class EnsureQaModeEnabledOnProjects < ActiveRecord::Migration[7.1]
+  def change
+    unless column_exists?(:projects, :qa_mode_enabled)
+      add_column :projects, :qa_mode_enabled, :boolean, default: false, null: false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add migration that ensures the projects table has the `qa_mode_enabled` column with the expected defaults

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256d5b2bf483228ad81e993cb959eb)