### PR TITLE
Allow projects to have optional end dates

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -14,7 +14,6 @@ class Project < ApplicationRecord
   }, _default: 'running'
 
   validates :name, presence: true
-  validates :end_date, presence: true
   validate :end_date_not_before_start_date
 
   before_save :set_status_from_dates


### PR DESCRIPTION
## Summary
- remove required validation for project end dates so updates can omit an end date
- keep date order validation while allowing blank end_date

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69257b2ce9a08322b2e650e6649233f2)