### PR TITLE
Fix sprint selection when no active sprint

### DIFF
--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -59,17 +59,27 @@ export default function SprintDashboard() {
     fetch(`/api/sprints.json${query}`)
       .then(res => res.json())
       .then(data => {
-        setSprints(data || []);
-        if (data && data.length) {
+        const list = Array.isArray(data) ? data : [];
+        const sorted = [...list].sort((a, b) => new Date(a.end_date) - new Date(b.end_date));
+
+        setSprints(sorted);
+
+        if (sorted.length) {
           const reference = selectedDate;
-          const current = data.find(s => {
+          const current = sorted.find(s => {
             const start = new Date(s.start_date);
             const end = new Date(s.end_date);
             return reference >= start && reference <= end;
-          }) || data[0];
+          });
 
-          setSprint(current);
-          setSprintId(prev => (prev !== null ? prev : current.id));
+          const mostRecentPast = sorted
+            .filter(s => new Date(s.end_date) < reference)
+            .sort((a, b) => new Date(b.end_date) - new Date(a.end_date))[0];
+
+          const sprintToSelect = current || mostRecentPast || sorted[0];
+
+          setSprint(sprintToSelect || null);
+          setSprintId(sprintToSelect ? sprintToSelect.id : null);
         } else {
           setSprintId(null);
         }


### PR DESCRIPTION
## Summary
- sort sprints by end date before selection
- default to most recent completed sprint when none active, falling back to first available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a6b013b4832294c7fb213c0fbe69)