### PR TITLE
Refresh sprint tasks after sheet import

### DIFF
--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -813,6 +813,9 @@ const SprintOverview = ({ sprintId, onSprintChange, projectId, sheetIntegrationE
         try {
             setProcessing(true);
             await SchedulerAPI.importSprintTasks(selectedSprintId);
+            const res = await SchedulerAPI.getTasks({ sprint_id: selectedSprintId, project_id: projectId });
+            const mapped = res.data.map(mapTask);
+            setTasks(mapped);
             toast.success('Imported tasks from sheet');
         } catch (e) {
             toast.error('Import failed');


### PR DESCRIPTION
## Summary
- refresh sprint task list after importing tasks from a sheet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925af4765f08322b7703d0b7126b28a)