### PR TITLE
Handle missing captcha params in contacts API

### DIFF
--- a/app/controllers/api/contacts_controller.rb
+++ b/app/controllers/api/contacts_controller.rb
@@ -21,7 +21,14 @@ class Api::ContactsController < ApplicationController
   end
 
   def valid_captcha?
-    params[:contact][:captcha_answer].to_i ==
-      params[:contact][:captcha_num1].to_i + params[:contact][:captcha_num2].to_i
+    contact_params = params[:contact]
+
+    answer = contact_params&.dig(:captcha_answer)
+    num1 = contact_params&.dig(:captcha_num1)
+    num2 = contact_params&.dig(:captcha_num2)
+
+    return false if [answer, num1, num2].any?(&:blank?)
+
+    answer.to_i == num1.to_i + num2.to_i
   end
 end

--- a/test/controllers/api/contacts_controller_test.rb
+++ b/test/controllers/api/contacts_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Api::ContactsControllerTest < ActionDispatch::IntegrationTest
+  def contact_payload(overrides = {})
+    {
+      contact: {
+        name: "Test User",
+        email: "test@example.com",
+        message: "Hello world",
+        captcha_num1: 1,
+        captcha_num2: 2,
+        captcha_answer: 3
+      }.merge(overrides)
+    }
+  end
+
+  test "creates contact when captcha is valid" do
+    assert_difference("Contact.count", 1) do
+      post api_contacts_path, params: contact_payload
+    end
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal({ "message" => "Thank you for your message!" }, body)
+  end
+
+  test "returns error when captcha answer is incorrect" do
+    assert_no_difference("Contact.count") do
+      post api_contacts_path, params: contact_payload(captcha_answer: 5)
+    end
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert_equal({ "errors" => ["Invalid captcha answer"] }, body)
+  end
+
+  test "returns error when captcha data is missing" do
+    payload = contact_payload.except(:contact)
+
+    assert_no_difference("Contact.count") do
+      post api_contacts_path, params: payload
+    end
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert_equal({ "errors" => ["Invalid captcha answer"] }, body)
+  end
+
+  test "returns error when captcha fields are absent" do
+    assert_no_difference("Contact.count") do
+      post api_contacts_path, params: contact_payload(captcha_num1: nil, captcha_num2: nil, captcha_answer: nil)
+    end
+
+    assert_response :unprocessable_entity
+    body = JSON.parse(response.body)
+    assert_equal({ "errors" => ["Invalid captcha answer"] }, body)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,7 @@
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+require "rails/test_help"
+
+class ActiveSupport::TestCase
+  parallelize(workers: :number_of_processors)
+end


### PR DESCRIPTION
## Summary
- avoid captcha validation errors by safely handling missing contact payloads and defaulting to a structured 422 response
- add controller integration tests for valid, invalid, and missing captcha submissions
- add minimal test helper setup to support the new tests

## Testing
- bin/rails test test/controllers/api/contacts_controller_test.rb *(fails: Ruby 3.2.3 present but Gemfile requires 3.3.0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926dc9e698083229b247533a4a0cf05)