### PR TITLE
Fix DraggableOverlay undefined position and bounds handling

### DIFF
--- a/app/javascript/components/DraggableOverlay.jsx
+++ b/app/javascript/components/DraggableOverlay.jsx
@@ -17,6 +17,8 @@ const DraggableOverlay = ({
   pageHeight
 }) => {
   const nodeRef = React.useRef(null);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [bounds, setBounds] = useState("parent");
 
   useEffect(() => {
     if (pageWidth && pageHeight) {
@@ -26,6 +28,8 @@ const DraggableOverlay = ({
         right: pageWidth - 100, // Approximate width of the element
         bottom: pageHeight - 50 // Approximate height
       });
+    } else {
+      setBounds("parent");
     }
   }, [pageWidth, pageHeight]);
 
@@ -51,7 +55,7 @@ const DraggableOverlay = ({
         nodeRef={nodeRef}
         position={position}
         onStop={handleStop}
-        bounds="parent"
+        bounds={bounds}
         handle=".handle"
       >
         <div ref={nodeRef} className="pointer-events-auto absolute flex flex-col items-center group">


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError` thrown when interacting with the PDF overlay by ensuring `position` is defined and using page dimensions to constrain dragging bounds.

### Description
- Initialize local state with `const [position, setPosition] = useState({ x: 0, y: 0 })` and `const [bounds, setBounds] = useState("parent")` in `app/javascript/components/DraggableOverlay.jsx`, compute `bounds` from `pageWidth`/`pageHeight` in `useEffect`, and pass `bounds` into the `Draggable` component.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983302a36e4832284dd168faca1496e)