### PR TITLE
Fix service edge cases and PDF update validation

### DIFF
--- a/app/controllers/pdf_modifiers_controller.rb
+++ b/app/controllers/pdf_modifiers_controller.rb
@@ -198,6 +198,10 @@ class PdfModifiersController < ApplicationController
     text_boxes = params[:textBoxes]
     # Use params[:pdfUrl] but secure it
     file_path = safe_pdf_path(params[:pdfUrl])
+
+    unless text_boxes.is_a?(Hash)
+      return render json: { error: "Invalid text box data." }, status: :unprocessable_entity
+    end
     
     text_boxes.each do |page_number, boxes|
       boxes.each do |box|
@@ -256,4 +260,3 @@ class PdfModifiersController < ApplicationController
     path.to_s
   end
 end
-

--- a/app/services/google_sheets_reader.rb
+++ b/app/services/google_sheets_reader.rb
@@ -13,7 +13,7 @@ class GoogleSheetsReader
   def read_data
     range = "#{@sheet_name}!A1:Z"
     response = @service.get_spreadsheet_values(@spreadsheet_id, range)
-    response.values
+    response.values || []
   end
 
   private

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -7,7 +7,7 @@ class JwtService
   end
 
   def self.decode(token)
-    decoded = JWT.decode(token, SECRET_KEY)[0]
+    decoded = JWT.decode(token, SECRET_KEY, true, { algorithm: "HS256" })[0]
     decoded.with_indifferent_access
   rescue JWT::ExpiredSignature
     nil # Token expired

--- a/app/services/scheduler_sheet_service.rb
+++ b/app/services/scheduler_sheet_service.rb
@@ -98,7 +98,9 @@ class SchedulerSheetService
     @sheet_id ||= begin
       spreadsheet = @service.get_spreadsheet(@spreadsheet_id)
       sheet = spreadsheet.sheets.find { |s| s.properties.title == @sheet_name }
-      sheet.properties.sheet_id
+      return sheet.properties.sheet_id if sheet
+
+      raise StandardError, "Sheet not found: #{@sheet_name}"
     end
   end
 end

--- a/app/services/task_sheet_service.rb
+++ b/app/services/task_sheet_service.rb
@@ -49,7 +49,7 @@ class TaskSheetService
   end
 
   def import_tasks_from_sheet(sheet_data, sprint_id:, created_by_id:, project_id: nil)
-    sheet_data[1..].each do |row|
+    (sheet_data[1..] || []).each do |row|
       next if row.compact.empty?
 
       task_id = row[1]
@@ -209,8 +209,9 @@ class TaskSheetService
     @sheet_id ||= begin
       spreadsheet = @service.get_spreadsheet(@spreadsheet_id)
       sheet = spreadsheet.sheets.find { |s| s.properties.title == @sheet_name }
-      sheet.properties.sheet_id
+      return sheet.properties.sheet_id if sheet
+
+      raise StandardError, "Sheet not found: #{@sheet_name}"
     end
   end
 end
-


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when Google Sheets reads return nil or when imported sheet data is empty.
- Ensure JWT decoding is explicit and fails safely for invalid tokens.
- Surface clear errors when a referenced sheet name is missing in spreadsheet operations.
- Protect the PDF update endpoint from invalid/malformed payloads to avoid exceptions.

### Description
- Return an empty array from `GoogleSheetsReader#read_data` when `response.values` is nil to avoid callers crashing.
- Require verification and specify the algorithm in `JwtService.decode` by calling `JWT.decode(token, SECRET_KEY, true, { algorithm: "HS256" })` and rescue `JWT::DecodeError`.
- Add nil guards in `SchedulerSheetService#sheet_id` and `TaskSheetService#sheet_id` to `return sheet.properties.sheet_id if sheet` and `raise StandardError, "Sheet not found: #{@sheet_name}"` when missing.
- Make `TaskSheetService#import_tasks_from_sheet` iterate over `(sheet_data[1..] || [])` to avoid errors when `sheet_data` is nil or short.
- Validate `params[:textBoxes]` in `PdfModifiersController#update_pdf` and return a `422 Unprocessable Entity` JSON error if it is not a Hash, preventing iteration over malformed input.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832fa425248322b8b4d27cfde584c9)