### PR TITLE
Limit PDF draggable overlay to placement tools

### DIFF
--- a/app/javascript/components/PdfViewer.jsx
+++ b/app/javascript/components/PdfViewer.jsx
@@ -11,6 +11,8 @@ const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool }) => {
   const [scale, setScale] = useState(1.0);
   const [pageWidth, setPageWidth] = useState(null);
   const [pageHeight, setPageHeight] = useState(null);
+  const placementTools = new Set(["addText", "addSignature", "addStamp"]);
+  const shouldShowOverlay = placementTools.has(activeTool);
 
   function onDocumentLoadSuccess({ numPages }) {
     setNumPages(numPages);
@@ -68,7 +70,7 @@ const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool }) => {
             />
 
             {/* Overlay for Drag and Drop */}
-            {activeTool && (
+            {shouldShowOverlay && (
               <DraggableOverlay
                 activeTool={activeTool}
                 onConfirmPosition={(pos) => onConfirmPosition({ ...pos, pageNumber })}


### PR DESCRIPTION
### Motivation
- The draggable placement overlay was being rendered for actions that don't require spatial placement, causing unnecessary UI elements to appear in the PDF viewer.

### Description
- Updated `app/javascript/components/PdfViewer.jsx` to only render `DraggableOverlay` when `activeTool` is one of the placement tools by introducing `placementTools = new Set(["addText","addSignature","addStamp"])` and using `shouldShowOverlay` to gate rendering.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698331739cf08322bc82dbfd406a0263)