### PR TITLE
Add basic test setup (RSpec + Vitest), sample tests, README updates and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      DB_HOST: localhost
+      RAILS_ENV: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install JavaScript dependencies
+        run: npm ci
+
+      - name: Prepare database
+        run: bin/rails db:prepare
+
+      - name: Run RSpec
+        run: bundle exec rspec
+
+      - name: Run front-end tests
+        run: npm test

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem "bootsnap", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
+  gem "rspec-rails"
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ This application showcases how to build a modern React front end on top of a Rub
    bin/setup
    ```
 
+   The script installs Ruby/JS dependencies, prepares the database, clears logs/tempfiles, and restarts the Rails server.
+
 2. **Configure environment variables**
 
    ```bash
@@ -41,6 +43,8 @@ This application showcases how to build a modern React front end on top of a Rub
    ```bash
    bin/rails db:create db:migrate db:seed
    ```
+
+   The seeds populate baseline data such as roles, teams, projects, work categories/tags, departments, and sample issues.
 
 4. **Start the application**
 
@@ -56,6 +60,40 @@ This application showcases how to build a modern React front end on top of a Rub
    docker-compose up --build
    ```
 
+## Required Environment Variables
+
+The following values are referenced by the application or infrastructure configuration:
+
+- `RAILS_MASTER_KEY` (required): decrypts Rails credentials.
+- `DB_HOST` or `DATABASE_URL` (required): database connectivity.
+- `SMTP_ADDRESS`, `SMTP_PORT`, `SMTP_DOMAIN`, `SMTP_USERNAME`, `SMTP_PASSWORD` (optional): outbound email delivery.
+- `BASE_URL` (optional): base URL for mailer links.
+- `REDIS_URL` (optional): Action Cable Redis connection.
+- `SLACK_WEBHOOK_URL` (optional): issue notification hooks.
+
+For Google Sheets integration, provide `config/google_service_account.json` with a service account key and share the target spreadsheet with that account.
+
+## Docker Quickstart
+
+```bash
+cp .env.example .env
+docker-compose up --build
+docker-compose run --rm web bin/rails db:prepare
+```
+
+Visit `http://localhost:3000` once the containers are running.
+
+## API Overview
+
+Authentication is cookie-based: `/api/signup` and `/api/login` set a signed `access_token` cookie used by authenticated endpoints.
+
+Key endpoints:
+
+- `POST /api/signup`, `POST /api/login`, `DELETE /api/logout`, `POST /api/refresh`
+- `POST /upload_pdf`, `POST /api/update_pdf`, `GET /download_pdf`
+- `GET /api/sheet` (Google Sheets data)
+- RESTful resources under `/api` (e.g., `/api/tasks`, `/api/projects`, `/api/work_logs`)
+
 ## Purpose
 
 The project serves as a learning playground and starting point for applications that need a Rails backend and a React front end bundled through Vite. It demonstrates PDF manipulation, token based authentication and external API integrations.
@@ -68,7 +106,12 @@ The project serves as a learning playground and starting point for applications 
 
 ## Tests
 
-This repository does not include an automated test suite.
+Run the Rails and front-end test suites with:
+
+```bash
+bundle exec rspec
+npm test
+```
 
 ## Deployment
 

--- a/app/javascript/utils/taskUtils.test.js
+++ b/app/javascript/utils/taskUtils.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { getCompletionData, getDueColor, getStatusClasses } from './taskUtils';
+
+describe('taskUtils', () => {
+  it('builds completion data with percentages', () => {
+    const columns = {
+      todo: { name: 'Todo', items: [{ id: 1 }, { id: 2 }] },
+      done: { name: 'Done', items: [{ id: 3 }] },
+    };
+
+    const result = getCompletionData(columns);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ name: 'Todo', value: 2, percent: 67 });
+    expect(result[1]).toMatchObject({ name: 'Done', value: 1, percent: 33 });
+  });
+
+  it('returns due colors based on today', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-01-15T12:00:00Z'));
+
+    expect(getDueColor('2024-01-14')).toBe('text-red-600');
+    expect(getDueColor('2024-01-15')).toBe('text-green-600');
+    expect(getDueColor('2024-01-16')).toBe('text-gray-500');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('maps status to css classes', () => {
+    expect(getStatusClasses('completed')).toBe('bg-green-100 text-green-800');
+    expect(getStatusClasses('in progress')).toBe('bg-yellow-100 text-yellow-800');
+    expect(getStatusClasses('other')).toBe('bg-blue-100 text-blue-800');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "esbuild": "^0.25.0",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.1",
-    "vite-plugin-ruby": "^5.1.0"
+    "vite-plugin-ruby": "^5.1.0",
+    "vitest": "^2.1.8"
   },
   "scripts": {
-    "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets"
+    "build": "esbuild app/javascript/*.* --bundle --sourcemap --format=esm --outdir=app/assets/builds --public-path=/assets",
+    "test": "vitest run"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -35,9 +37,9 @@
     "react-dom": "^18.3.1",
     "react-draggable": "^4.4.6",
     "react-dropzone": "^14.3.8",
+    "react-helmet": "^6.1.0",
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
-    "react-helmet": "^6.1.0",
     "react-pdf": "^9.2.1",
     "react-rnd": "^10.5.2",
     "react-router-dom": "^7.2.0",

--- a/spec/models/work_priority_spec.rb
+++ b/spec/models/work_priority_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe WorkPriority, type: :model do
+  it "is valid with a name" do
+    expect(described_class.new(name: "High")).to be_valid
+  end
+
+  it "is invalid without a name" do
+    priority = described_class.new(name: nil)
+
+    expect(priority).not_to be_valid
+    expect(priority.errors[:name]).to include("can't be blank")
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] ||= "test"
+require_relative "../config/environment"
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+
+require "rspec/rails"
+
+begin
+  ActiveRecord::Migration.maintain_test_schema!
+rescue ActiveRecord::PendingMigrationError => e
+  warn e.to_s.strip
+  exit 1
+end
+
+RSpec.configure do |config|
+  config.fixture_path = Rails.root.join("spec/fixtures")
+  config.use_transactional_fixtures = true
+  config.infer_spec_type_from_file_location!
+  config.filter_rails_from_backtrace!
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+end

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['app/javascript/**/*.test.{js,ts,jsx,tsx}'],
+  },
+});


### PR DESCRIPTION
### Motivation

- Provide a minimal test scaffold for both the Rails backend and front-end JS utilities to make the project testable. 
- Add a CI workflow so automated test runs can be executed on push / pull requests. 
- Improve README with setup, environment variable documentation and test commands to lower onboarding friction.

### Description

- Added RSpec support and basic Rails test files: `Gemfile` (added `rspec-rails`), `.rspec`, `spec/spec_helper.rb`, and `spec/rails_helper.rb`, plus a starter model spec `spec/models/work_priority_spec.rb`.
- Added a Vitest configuration and JS unit test: `vitest.config.mts` and `app/javascript/utils/taskUtils.test.js`, and updated `package.json` to include `vitest` devDependency and a `test` script (`npm test`).
- Added a GitHub Actions CI workflow at `.github/workflows/ci.yml` that sets up Ruby/Node, prepares the DB, runs `bundle exec rspec`, and runs front-end tests (`npm test`).
- Updated `README.md` with setup details, required environment variables, Docker quickstart, API overview, and test commands.

### Testing

- Attempted to install JS dependencies with `npm install`, but the install failed with a `403 Forbidden` when fetching packages so front-end tests were not run.
- Attempted to run `bundle install`, but bundler/gem fetch failed with `403 Forbidden` and the environment reported a Ruby version mismatch, so RSpec was not run locally.
- The CI workflow was added to run `bin/rails db:prepare`, `bundle exec rspec`, and `npm test` on GitHub Actions, but it has not been executed within this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69832fd5594883228f0e62f536101315)