### PR TITLE
Sync task dates using code logs only

### DIFF
--- a/app/models/task_log.rb
+++ b/app/models/task_log.rb
@@ -9,17 +9,46 @@ class TaskLog < ApplicationRecord
   validates :task, :developer, :log_date, :hours_logged, presence: true
   validates :hours_logged, numericality: true
 
-  after_save :sync_task_dates, if: -> { type == 'Code' }
+  before_destroy :store_task_date_sync_context
+  after_commit :sync_task_dates, on: [:create, :update, :destroy]
 
   private
 
   def sync_task_dates
-    return unless task
+    task_ids = []
+    if destroyed?
+      return unless @destroyed_type == 'Code'
 
-    code_logs = task.task_logs.where(type: 'Code')
-    task.update(
-      start_date: code_logs.minimum(:log_date),
-      end_date: code_logs.maximum(:log_date)
-    )
+      task_ids << @destroyed_task_id
+    else
+      return unless code_log_change?
+
+      task_ids << task_id
+      if (previous_task_id = previous_changes.dig('task_id', 0))
+        task_ids << previous_task_id
+      end
+    end
+
+    task_ids.compact.uniq.each do |task_id|
+      task = Task.find_by(id: task_id)
+      next unless task
+
+      code_logs = task.task_logs.where(type: 'Code')
+      task.update(
+        start_date: code_logs.minimum(:log_date),
+        end_date: code_logs.maximum(:log_date)
+      )
+    end
+  end
+
+  def code_log_change?
+    return true if type == 'Code'
+
+    previous_changes['type']&.include?('Code')
+  end
+
+  def store_task_date_sync_context
+    @destroyed_task_id = task_id
+    @destroyed_type = type
   end
 end


### PR DESCRIPTION
### Motivation
- Ensure task `start_date`/`end_date` are calculated only from code-related task logs (type `Code`).
- Recalculate dates when code logs are created, updated, moved between tasks, or deleted so sprint/overview display remains accurate.
- Avoid updating task dates for non-code log changes to prevent incorrect date drift.

### Description
- Replaced the old `after_save` callback with `after_commit :sync_task_dates, on: [:create, :update, :destroy]` and added `before_destroy :store_task_date_sync_context` in `TaskLog` to capture deletion context. 
- Reworked `sync_task_dates` to collect affected `task_id`s (including previous `task_id` on reassignment and the stored id for deletions) and recalculate `start_date`/`end_date` by taking the `minimum`/`maximum` of `log_date` from `task.task_logs.where(type: 'Code')` for each affected task. 
- Added `code_log_change?` helper to skip recalculation unless the change involves a `Code` log, and `store_task_date_sync_context` to preserve deleted log context for use after commit. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698333d192ec832289fd14a237cb520b)