### PR TITLE
Persist per-action notification preferences and respect them when creating notifications

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -162,7 +162,8 @@ class Api::AuthController < Api::BaseController
       :cover_photo,
       :color_theme,
       :dark_mode,
-      :landing_page
+      :landing_page,
+      :notification_preferences
     )
     permitted.delete(:profile_picture) if permitted[:profile_picture] == "null"
     permitted.delete(:cover_photo) if permitted[:cover_photo] == "null"

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -54,7 +54,8 @@ class Api::UsersController < Api::BaseController
       :color_theme,
       :dark_mode,
       :landing_page,
-      :department_id
+      :department_id,
+      :notification_preferences
     )
   end
 

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -6,7 +6,18 @@ class Notification < ApplicationRecord
   scope :unread, -> { where(read_at: nil) }
   scope :recent, -> { order(created_at: :desc) }
 
+  before_create :respect_recipient_preferences
+
   def mark_as_read!
     update!(read_at: Time.current)
+  end
+
+  private
+
+  def respect_recipient_preferences
+    return if recipient.blank?
+    return if recipient.notification_preference_enabled?(action)
+
+    throw(:abort)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,12 @@ class User < ApplicationRecord
     'available_soon' => 'Available in 2 weeks',
     'fully_booked' => 'Fully Booked'
   }.freeze
+  NOTIFICATION_PREFERENCES_DEFAULTS = {
+    "commented" => true,
+    "assigned" => true,
+    "update" => true,
+    "digest" => false
+  }.freeze
 
   has_one_attached :profile_picture
   has_one_attached :cover_photo
@@ -84,6 +90,14 @@ class User < ApplicationRecord
 
   def availability_label
     AVAILABILITY_LABELS[availability_status] || availability_status.to_s.humanize
+  end
+
+  def notification_preferences_with_defaults
+    NOTIFICATION_PREFERENCES_DEFAULTS.merge((notification_preferences || {}).stringify_keys)
+  end
+
+  def notification_preference_enabled?(action)
+    notification_preferences_with_defaults.fetch(action.to_s, true)
   end
 
   private

--- a/db/migrate/20260204120501_add_notification_preferences_to_users.rb
+++ b/db/migrate/20260204120501_add_notification_preferences_to_users.rb
@@ -1,0 +1,10 @@
+class AddNotificationPreferencesToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :notification_preferences, :jsonb, null: false, default: {
+      commented: true,
+      assigned: true,
+      update: true,
+      digest: false
+    }
+  end
+end


### PR DESCRIPTION
### Motivation
- Make the Settings -> Notifications UI functional so users can set per-action notification preferences and save them.
- Persist user notification preferences on the `users` table with sensible defaults so preferences survive restarts and logins.
- Prevent notifications from being created/sent when a recipient has disabled that specific notification action.

### Description
- Frontend: wired the Notifications tab in `app/javascript/pages/Settings.jsx` to load `user.notification_preferences`, expose toggles for `commented`, `assigned`, `update`, and `digest`, and added a dedicated `Save Notifications` action that posts `auth.notification_preferences` to the backend.
- DB: added migration `db/migrate/20260204120501_add_notification_preferences_to_users.rb` which introduces a `notification_preferences` `jsonb` column on `users` with defaults `{ commented: true, assigned: true, update: true, digest: false }`.
- Model: added `NOTIFICATION_PREFERENCES_DEFAULTS` and helper methods `notification_preferences_with_defaults` and `notification_preference_enabled?` to `app/models/user.rb` to merge saved preferences with defaults.
- Delivery guard and controllers: added a `before_create` hook `respect_recipient_preferences` to `app/models/notification.rb` to abort creating notifications if the recipient disabled that action, and permitted `:notification_preferences` in `user_params` for `app/controllers/api/auth_controller.rb` and `app/controllers/api/users_controller.rb` so the frontend can save preferences.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983356770148322ac429f9f069c8e6c)