### PR TITLE
Permit nested notification_preferences updates

### DIFF
--- a/app/controllers/api/auth_controller.rb
+++ b/app/controllers/api/auth_controller.rb
@@ -163,7 +163,7 @@ class Api::AuthController < Api::BaseController
       :color_theme,
       :dark_mode,
       :landing_page,
-      :notification_preferences
+      notification_preferences: {}
     )
     permitted.delete(:profile_picture) if permitted[:profile_picture] == "null"
     permitted.delete(:cover_photo) if permitted[:cover_photo] == "null"

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -55,7 +55,7 @@ class Api::UsersController < Api::BaseController
       :dark_mode,
       :landing_page,
       :department_id,
-      :notification_preferences
+      notification_preferences: {}
     )
   end
 


### PR DESCRIPTION
### Motivation
- Allow nested `notification_preferences` parameters in profile update endpoints to prevent "Unpermitted parameter" warnings and enable updating structured notification settings.

### Description
- Update strong params in `Api::AuthController#user_params` and `Api::UsersController#user_params` to permit `notification_preferences: {}` so the nested hash is accepted.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833a56c9d08322b4a96aadb789637c)