### PR TITLE
Add toast feedback to Settings updates

### DIFF
--- a/app/javascript/pages/Settings.jsx
+++ b/app/javascript/pages/Settings.jsx
@@ -3,6 +3,7 @@ import api from "../components/api";
 import { AuthContext } from "../context/AuthContext";
 import { COLOR_MAP } from "/utils/theme";
 import { Switch, Tab } from "@headlessui/react";
+import { Toaster, toast } from "react-hot-toast";
 import {
   User,
   Palette,
@@ -73,8 +74,10 @@ const Settings = () => {
         dark_mode: darkMode,
         landing_page: landingPage,
       }));
+      toast.success("Settings updated.");
     } catch (err) {
       console.error("Failed to update profile", err);
+      toast.error("Unable to update settings. Please try again.");
     } finally {
       setSaving(false);
     }
@@ -92,8 +95,10 @@ const Settings = () => {
         ...prev,
         notification_preferences: notificationPrefs,
       }));
+      toast.success("Notification preferences saved.");
     } catch (err) {
       console.error("Failed to update notification preferences", err);
+      toast.error("Unable to save notifications. Please try again.");
     } finally {
       setSavingNotifications(false);
     }
@@ -108,6 +113,7 @@ const Settings = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
+      <Toaster position="top-right" />
       <div className="max-w-4xl mx-auto">
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-gray-900">Settings</h1>


### PR DESCRIPTION
### Motivation
- Provide immediate user feedback when saving profile settings or notification preferences on the Settings page because there was no toast shown on form updates.
- Surface both success and failure states so users know whether their action completed.

### Description
- Import `Toaster` and `toast` from `react-hot-toast` and mount `<Toaster position="top-right" />` at the top of the Settings page layout.
- Show a success toast `"Settings updated."` after a successful profile update and an error toast `"Unable to update settings. Please try again."` on failure in `handleSave`.
- Show a success toast `"Notification preferences saved."` after saving notification preferences and an error toast `"Unable to save notifications. Please try again."` on failure in `handleSaveNotifications`.
- Modified file: `app/javascript/pages/Settings.jsx`.

### Testing
- Ran an automated Playwright script to capture a screenshot of `/settings`, but the app was not reachable and the run failed with `net::ERR_EMPTY_RESPONSE`, so in-browser validation could not complete.
- No additional automated tests (unit/CI) were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833c691fdc83228057b635d4ad3432)