### PR TITLE
Polish loading UI across app and add dashboard & route loaders

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import React, { useEffect, useState } from "react";
+import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
 
 import { AuthProvider } from "../context/AuthContext";
 import PrivateRoute from "../components/PrivateRoute";
@@ -26,6 +26,25 @@ import WorkLog from "../pages/WorkLog";
 import Settings from "../pages/Settings";
 import PageTitle from "./PageTitle";
 import DailyMomentumHub from "../pages/DailyMomentumHub";
+import PageLoader from "./ui/PageLoader";
+
+const RouteTransitionLoader = ({ children }) => {
+  const location = useLocation();
+  const [isRouteLoading, setIsRouteLoading] = useState(false);
+
+  useEffect(() => {
+    setIsRouteLoading(true);
+    const timer = setTimeout(() => setIsRouteLoading(false), 250);
+    return () => clearTimeout(timer);
+  }, [location.pathname, location.search]);
+
+  return (
+    <>
+      {isRouteLoading ? <PageLoader title="Navigating" message="Getting your page ready…" compact /> : null}
+      {children}
+    </>
+  );
+};
 
 const App = () => {
   return (
@@ -38,6 +57,7 @@ const App = () => {
           <Navbar />
 
           {/* ✅ Page Content */}
+          <RouteTransitionLoader>
             <Routes>
               <Route path="/contact" element={<Contact />} />
               <Route path="/legal" element={<Legal />} />
@@ -60,7 +80,8 @@ const App = () => {
               <Route path="/users" element={<PrivateRoute ownerOnly><Users /></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
               <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
-              </Routes>
+            </Routes>
+          </RouteTransitionLoader>
 
           {/* ✅ Footer */}
           <Footer />

--- a/app/javascript/components/PrivateRoute.jsx
+++ b/app/javascript/components/PrivateRoute.jsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
+import PageLoader from "./ui/PageLoader";
 import AuthPage from "../pages/AuthPage";
 
 const PrivateRoute = ({ children, ownerOnly = false, allowedRoles = [] }) => {
@@ -8,7 +9,7 @@ const PrivateRoute = ({ children, ownerOnly = false, allowedRoles = [] }) => {
   const location = useLocation();
   const mode = location.state?.mode || "login";
 
-  if (initializing) return <div>Loading…</div>;
+  if (initializing) return <PageLoader title="Authenticating" message="Checking your access…" />;
   if (!isAuthenticated) return <AuthPage mode={mode} />;
   if (ownerOnly && !user?.roles?.some((r) => r.name === "owner")) {
     return <div className="p-4">Unauthorized</div>;

--- a/app/javascript/components/ProjectMemberRoute.jsx
+++ b/app/javascript/components/ProjectMemberRoute.jsx
@@ -3,6 +3,7 @@ import { useParams, useLocation } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
 import { fetchProjects } from "./api";
 import AuthPage from "../pages/AuthPage";
+import PageLoader from "./ui/PageLoader";
 
 const ProjectMemberRoute = ({ children }) => {
   const { projectId } = useParams();
@@ -27,7 +28,7 @@ const ProjectMemberRoute = ({ children }) => {
     };
   }, [projectId, isAuthenticated, user]);
 
-  if (initializing || isMember === null) return <div>Loading…</div>;
+  if (initializing || isMember === null) return <PageLoader title="Project access" message="Verifying project permissions…" />;
   if (!isAuthenticated) return <AuthPage mode={mode} />;
   if (!isMember) return <div className="p-4">Unauthorized</div>;
   return children;

--- a/app/javascript/components/ui/PageLoader.jsx
+++ b/app/javascript/components/ui/PageLoader.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+const MESSAGES = {
+  default: "Preparing your workspace…",
+  auth: "Checking your session…",
+  project: "Loading project dashboard…",
+};
+
+export default function PageLoader({
+  message = MESSAGES.default,
+  title = "Loading",
+  compact = false,
+}) {
+  return (
+    <div className={`flex items-center justify-center ${compact ? "py-10" : "min-h-[55vh] px-4"}`}>
+      <div className="w-full max-w-md rounded-2xl border border-slate-200 bg-white/95 p-6 shadow-sm">
+        <div className="mb-4 flex items-center gap-3">
+          <span className="h-10 w-10 animate-spin rounded-full border-4 border-slate-200 border-t-[var(--theme-color)]" />
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">{title}</p>
+            <p className="text-base font-medium text-slate-700">{message}</p>
+          </div>
+        </div>
+        <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+          <div className="h-full w-1/2 animate-pulse rounded-full bg-[var(--theme-color)]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { MESSAGES };

--- a/app/javascript/context/AuthContext.jsx
+++ b/app/javascript/context/AuthContext.jsx
@@ -5,6 +5,7 @@ import { auth, googleProvider } from "../firebaseConfig";
 import { signInWithPopup } from "firebase/auth";
 import { toast } from "react-hot-toast";
 import { COLOR_MAP, toRgb, lightenColor, darkenColor } from '/utils/theme';
+import PageLoader from "../components/ui/PageLoader";
 
 export const AuthContext = createContext();
 
@@ -120,7 +121,7 @@ export function AuthProvider({ children }) {
 
   return (
     <AuthContext.Provider value={value}>
-      {initializing ? <div>Loading…</div> : children}
+      {initializing ? <PageLoader title="Authenticating" message="Checking your session…" /> : children}
     </AuthContext.Provider>
   );
 }

--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -10,6 +10,7 @@ import Sheet from './Sheet';
 import ProjectStatistics from './ProjectStatistics';
 import IssueTracker from './IssueTracker';
 import ProjectVault from './ProjectVault';
+import PageLoader from '../components/ui/PageLoader';
 
 const calculateWorkingDays = (start, end) => {
   let count = 0;
@@ -53,6 +54,7 @@ export default function SprintDashboard() {
   const [project, setProject] = useState(null);
   const [isHeaderExpanded, setIsHeaderExpanded] = useState(false);
   const [qaMode, setQaMode] = useState(false);
+  const [isLoadingDashboard, setIsLoadingDashboard] = useState(true);
   const sheetEnabled = !!(project?.sheet_integration_enabled && project?.sheet_id);
 
   useEffect(() => {
@@ -82,6 +84,7 @@ export default function SprintDashboard() {
   useEffect(() => {
     setSprint(null);
     setSprints([]);
+    setIsLoadingDashboard(true);
 
     const query = projectId ? `?project_id=${projectId}` : '';
     fetch(`/api/sprints.json${query}`)
@@ -111,7 +114,13 @@ export default function SprintDashboard() {
         } else {
           setSprintId(null);
         }
-      });
+      })
+      .catch(() => {
+        setSprint(null);
+        setSprintId(null);
+        setSprints([]);
+      })
+      .finally(() => setIsLoadingDashboard(false));
   }, [projectId, selectedDate]);
 
   useEffect(() => {
@@ -120,6 +129,10 @@ export default function SprintDashboard() {
       if (found) setSprint(found);
     }
   }, [sprintId, sprints]);
+
+  if (isLoadingDashboard) {
+    return <PageLoader title="Project dashboard" message="Loading sprint board, tasks, and project data…" />;
+  }
 
   const isCurrentSprint = (s) => {
     if (!s) return false;


### PR DESCRIPTION
### Motivation
- The project page (and other areas) showed a minimal blank or plain `Loading…` text during data/auth checks, producing a poor UX. 
- Provide a consistent, friendly loading experience during session hydration, route transitions, and project dashboard loads. 

### Description
- Added a reusable `PageLoader` component (`app/javascript/components/ui/PageLoader.jsx`) that shows a spinner card, message and a progress bar-like pulse. 
- Replaced plain text loaders with `PageLoader` in `AuthProvider` (`app/javascript/context/AuthContext.jsx`) and route guards (`PrivateRoute.jsx` and `ProjectMemberRoute.jsx`) so authentication and permission checks render a polished UI. 
- Introduced a lightweight `RouteTransitionLoader` in `App.jsx` to show a brief navigation loader on route changes. 
- Improved `SprintDashboard.jsx` by adding `isLoadingDashboard` state, handling fetch errors, and returning `PageLoader` while sprint/project data loads to prevent the blank screen situation. 

### Testing
- Ran unit tests with `npm test` (Vitest): tests passed (`app/javascript/utils/taskUtils.test.js` - all tests green). 
- Attempted to run the local dev server with `bin/dev` but it failed due to a remote gem fetch error while installing `foreman` (403 Forbidden), so a live manual run/screenshot was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698587d106108322847bf4a1e23584ad)