### PR TITLE
Add favicon link tags and update document title

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>My Rails + Vite + React App</title>
+    <title>Rails Vite App</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= favicon_link_tag 'favicon.ico' %>
+    <%= favicon_link_tag 'apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png' %>
 
     <%= vite_client_tag %>
     <%= vite_javascript_tag 'entrypoints/application.jsx' %>


### PR DESCRIPTION
### Motivation
- Ensure the site displays an icon in browser tabs and provide a cleaner document title for the application.

### Description
- Updated `app/views/layouts/application.html.erb` to change the `<title>` to `Rails Vite App` and added `favicon_link_tag 'favicon.ico'` and `favicon_link_tag 'apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png'` to enable browser and Apple touch icons.

### Testing
- Verified the change was committed and inspected the diff with `git show --stat --oneline HEAD` and `git diff`, and attempted to run `bin/rails runner 'puts "rails-ok"'` which failed in this environment due to a Ruby version mismatch (local Ruby `3.2.3` vs Gemfile-specified `3.3.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b1074bf8883229753ef192897d0ba)