### PR TITLE
Implement calendar events and reminders backend foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The project serves as a learning playground and starting point for applications 
 - `app/javascript` – React application compiled by Vite.
 - `app/controllers` – API endpoints consumed by the front end.
 - `app/services` – integration helpers such as Google Sheets readers and JWT helpers.
+- `docs/calendar_reminder_plan.md` – proposed roadmap for calendar, reminder, and meeting scheduling features.
 
 ## Tests
 

--- a/app/controllers/api/calendar_events_controller.rb
+++ b/app/controllers/api/calendar_events_controller.rb
@@ -1,0 +1,76 @@
+class Api::CalendarEventsController < Api::BaseController
+  before_action :set_calendar_event, only: [:update, :destroy]
+
+  def index
+    events = scoped_events.includes(:event_reminders).order(:start_at)
+
+    if params[:start].present? && params[:end].present?
+      begin
+        start_time = Time.zone.parse(params[:start])
+        end_time = Time.zone.parse(params[:end])
+        events = events.within_range(start_time, end_time) if start_time.present? && end_time.present?
+      rescue ArgumentError
+        return render json: { error: 'Invalid start or end datetime filter' }, status: :unprocessable_entity
+      end
+    end
+
+    events = events.where(project_id: params[:project_id]) if params[:project_id].present?
+    events = events.where(visibility: params[:visibility]) if params[:visibility].present?
+
+    render json: events.map(&:as_api_json)
+  end
+
+  def create
+    event = current_user.calendar_events.new(calendar_event_params)
+
+    if event.save
+      render json: event.as_api_json, status: :created
+    else
+      render json: { errors: event.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @calendar_event.update(calendar_event_params)
+      render json: @calendar_event.as_api_json
+    else
+      render json: { errors: @calendar_event.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @calendar_event.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_calendar_event
+    @calendar_event = scoped_events.find(params[:id])
+  end
+
+  def scoped_events
+    project_ids = current_user.projects.select(:id)
+
+    CalendarEvent.where(user_id: current_user.id)
+                 .or(CalendarEvent.where(visibility: 'project', project_id: project_ids))
+                 .distinct
+  end
+
+  def calendar_event_params
+    params.require(:calendar_event).permit(
+      :title,
+      :description,
+      :start_at,
+      :end_at,
+      :all_day,
+      :event_type,
+      :visibility,
+      :status,
+      :project_id,
+      :task_id,
+      :sprint_id,
+      :location_or_meet_link
+    )
+  end
+end

--- a/app/controllers/api/event_reminders_controller.rb
+++ b/app/controllers/api/event_reminders_controller.rb
@@ -1,0 +1,51 @@
+class Api::EventRemindersController < Api::BaseController
+  before_action :set_calendar_event, only: [:create]
+  before_action :set_event_reminder, only: [:update, :destroy]
+
+  def create
+    reminder = @calendar_event.event_reminders.new(event_reminder_params)
+
+    if reminder.save
+      render json: reminder.as_json(only: [:id, :calendar_event_id, :channel, :minutes_before, :send_at, :sent_at, :state]), status: :created
+    else
+      render json: { errors: reminder.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @event_reminder.update(event_reminder_params)
+      render json: @event_reminder.as_json(only: [:id, :calendar_event_id, :channel, :minutes_before, :send_at, :sent_at, :state])
+    else
+      render json: { errors: @event_reminder.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @event_reminder.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_calendar_event
+    @calendar_event = accessible_events.find(params[:calendar_event_id])
+  end
+
+  def set_event_reminder
+    @event_reminder = EventReminder.joins(:calendar_event)
+                                   .where(calendar_event: accessible_events)
+                                   .find(params[:id])
+  end
+
+  def accessible_events
+    project_ids = current_user.projects.select(:id)
+
+    CalendarEvent.where(user_id: current_user.id)
+                 .or(CalendarEvent.where(visibility: 'project', project_id: project_ids))
+                 .distinct
+  end
+
+  def event_reminder_params
+    params.require(:event_reminder).permit(:channel, :minutes_before)
+  end
+end

--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -1,0 +1,31 @@
+class EventReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform(event_reminder_id)
+    reminder = EventReminder.includes(calendar_event: :user).find_by(id: event_reminder_id)
+    return unless reminder&.pending?
+
+    event = reminder.calendar_event
+    recipient = event.user
+
+    Notification.create(
+      recipient: recipient,
+      actor: recipient,
+      action: 'update',
+      notifiable: event,
+      metadata: {
+        type: 'calendar_reminder',
+        calendar_event_id: event.id,
+        event_title: event.title,
+        event_start_at: event.start_at,
+        channel: reminder.channel,
+        minutes_before: reminder.minutes_before
+      }
+    )
+
+    reminder.update!(state: 'sent', sent_at: Time.current)
+  rescue StandardError
+    reminder&.update(state: 'failed') if reminder&.pending?
+    raise
+  end
+end

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -1,0 +1,56 @@
+class CalendarEvent < ApplicationRecord
+  EVENT_TYPES = %w[meeting deadline reminder focus sprint_ceremony].freeze
+
+  belongs_to :user
+  belongs_to :project, optional: true
+  belongs_to :task, optional: true
+  belongs_to :sprint, optional: true
+
+  has_many :event_reminders, dependent: :destroy
+
+  enum visibility: {
+    personal: 'personal',
+    project: 'project'
+  }, _default: 'personal'
+
+  enum status: {
+    scheduled: 'scheduled',
+    cancelled: 'cancelled',
+    completed: 'completed'
+  }, _default: 'scheduled'
+
+  validates :title, :start_at, :end_at, :event_type, :visibility, :status, presence: true
+  validates :event_type, inclusion: { in: EVENT_TYPES }
+  validate :end_after_start
+  validate :project_required_for_project_visibility
+
+  scope :within_range, ->(start_time, end_time) {
+    where('start_at < ? AND end_at > ?', end_time, start_time)
+  }
+
+  def as_api_json
+    as_json(
+      only: [:id, :title, :description, :start_at, :end_at, :all_day, :event_type, :visibility, :status, :location_or_meet_link, :project_id, :task_id, :sprint_id, :user_id, :created_at, :updated_at],
+      include: {
+        event_reminders: {
+          only: [:id, :channel, :minutes_before, :send_at, :sent_at, :state]
+        }
+      }
+    )
+  end
+
+  private
+
+  def end_after_start
+    return if start_at.blank? || end_at.blank?
+    return if end_at >= start_at
+
+    errors.add(:end_at, 'must be on or after start_at')
+  end
+
+  def project_required_for_project_visibility
+    return unless visibility == 'project' && project_id.blank?
+
+    errors.add(:project_id, 'is required for project events')
+  end
+end

--- a/app/models/event_reminder.rb
+++ b/app/models/event_reminder.rb
@@ -1,0 +1,36 @@
+class EventReminder < ApplicationRecord
+  CHANNELS = %w[in_app email].freeze
+
+  belongs_to :calendar_event
+
+  enum state: {
+    pending: 'pending',
+    sent: 'sent',
+    failed: 'failed'
+  }, _default: 'pending'
+
+  validates :channel, :minutes_before, :send_at, :state, presence: true
+  validates :channel, inclusion: { in: CHANNELS }
+  validates :minutes_before, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  before_validation :calculate_send_at, if: :needs_send_at_recalculation?
+  after_commit :schedule_delivery_job, on: [:create, :update], if: :pending?
+
+  private
+
+  def needs_send_at_recalculation?
+    send_at.blank? || will_save_change_to_minutes_before? || will_save_change_to_calendar_event_id?
+  end
+
+  def calculate_send_at
+    return if calendar_event.blank? || calendar_event.start_at.blank?
+
+    self.send_at = calendar_event.start_at - minutes_before.to_i.minutes
+  end
+
+  def schedule_delivery_job
+    return if send_at.blank? || send_at <= Time.current
+
+    EventReminderJob.set(wait_until: send_at).perform_later(id)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,7 @@ class Project < ApplicationRecord
   has_many :developers, -> { distinct }, through: :tasks, source: :developer
   has_many :project_environments, dependent: :destroy, inverse_of: :project
   has_many :project_vault_items, dependent: :destroy, inverse_of: :project
+  has_many :calendar_events, dependent: :nullify
 
   enum status: {
     upcoming: 'upcoming',

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -3,4 +3,5 @@ class Sprint < ApplicationRecord
 
   belongs_to :project, inverse_of: :sprints
   has_many :tasks, dependent: :nullify, inverse_of: :sprint
+  has_many :calendar_events, dependent: :nullify
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,6 +7,7 @@ class Task < ApplicationRecord
   belongs_to :assigned_user, class_name: 'User', foreign_key: :assigned_to_user, optional: true, inverse_of: :tasks
 
   has_many :task_logs, dependent: :destroy, inverse_of: :task
+  has_many :calendar_events, dependent: :nullify
 
   # This tells ActiveRecord NOT to use the 'type' column for Single Table Inheritance.
   self.inheritance_column = 'non_existent_type_column'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,7 @@ class User < ApplicationRecord
   has_many :given_skill_endorsements, class_name: 'SkillEndorsement', foreign_key: :endorser_id, dependent: :destroy, inverse_of: :endorser
   has_many :received_skill_endorsements, through: :user_skills, source: :skill_endorsements
   has_many :notifications, foreign_key: :recipient_id, dependent: :destroy
+  has_many :calendar_events, dependent: :destroy
   belongs_to :department, optional: true
 
   enum availability_status: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,12 @@ Rails.application.routes.draw do
       end
     end
 
+
+    resources :calendar_events, only: [:index, :create, :update, :destroy] do
+      resources :event_reminders, only: [:create]
+    end
+    resources :event_reminders, only: [:update, :destroy]
+
     resources :notifications, only: [:index] do
       collection do
         post :mark_all_read

--- a/db/migrate/20270210000000_create_calendar_events.rb
+++ b/db/migrate/20270210000000_create_calendar_events.rb
@@ -1,0 +1,25 @@
+class CreateCalendarEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :calendar_events do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :project, foreign_key: true
+      t.references :task, foreign_key: true
+      t.references :sprint, foreign_key: true
+      t.string :title, null: false
+      t.text :description
+      t.datetime :start_at, null: false
+      t.datetime :end_at, null: false
+      t.boolean :all_day, null: false, default: false
+      t.string :event_type, null: false, default: 'meeting'
+      t.string :visibility, null: false, default: 'personal'
+      t.string :status, null: false, default: 'scheduled'
+      t.string :location_or_meet_link
+
+      t.timestamps
+    end
+
+    add_index :calendar_events, [:user_id, :start_at]
+    add_index :calendar_events, [:visibility, :start_at]
+    add_index :calendar_events, :event_type
+  end
+end

--- a/db/migrate/20270210000001_create_event_reminders.rb
+++ b/db/migrate/20270210000001_create_event_reminders.rb
@@ -1,0 +1,17 @@
+class CreateEventReminders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :event_reminders do |t|
+      t.references :calendar_event, null: false, foreign_key: true
+      t.string :channel, null: false, default: 'in_app'
+      t.integer :minutes_before, null: false, default: 10
+      t.datetime :send_at, null: false
+      t.datetime :sent_at
+      t.string :state, null: false, default: 'pending'
+
+      t.timestamps
+    end
+
+    add_index :event_reminders, [:state, :send_at]
+    add_index :event_reminders, [:calendar_event_id, :minutes_before, :channel], unique: true, name: 'idx_unique_event_reminder_window'
+  end
+end

--- a/docs/calendar_reminder_plan.md
+++ b/docs/calendar_reminder_plan.md
@@ -1,0 +1,195 @@
+# Calendar, Reminder, and Meeting Scheduling Plan
+
+This document proposes **project-specific** and **user-specific** calendar features for this Rails + Vite app, with implementation guidance based on the current architecture.
+
+## 1) What already exists (reuse first)
+
+The app already has:
+
+- Task and sprint workflows (`/api/tasks`, `/api/sprints`) and scheduler-related UI components.
+- Notifications (`/api/notifications`) and background jobs/mailers.
+- Project membership (`projects`, `project_users`) and user-level preferences fields.
+
+So calendar can be built as an extension of existing objects instead of a separate isolated system.
+
+## 2) Calendar models to implement
+
+### A. Project Calendar (team-facing)
+Use this for things shared by a project/team:
+
+- Sprint ceremonies (planning, review, retro)
+- Release deadlines
+- Client/demo meetings
+- Shared milestones
+
+**Ownership**
+- `project_id` required
+- visible to all project members
+
+### B. Personal Calendar (employee-facing)
+Use this for individual work planning:
+
+- Focus blocks
+- 1:1s
+- Interview slots
+- Reminder-only items (no meeting)
+
+**Ownership**
+- `user_id` required
+- optionally linked to `project_id` or `task_id`
+
+### C. Unified Event Table (recommended)
+Instead of separate tables for project/personal calendars, create one table with scope flags:
+
+- `calendar_events`
+  - `title`, `description`
+  - `start_at`, `end_at`, `all_day`
+  - `event_type` (meeting, deadline, reminder, focus, sprint_ceremony)
+  - `visibility` (personal, project)
+  - `user_id` (owner)
+  - `project_id` (optional for personal, required for project visibility)
+  - `task_id` / `sprint_id` (optional links)
+  - `location_or_meet_link`
+  - `status` (scheduled, cancelled, completed)
+  - `recurrence_rule` (later phase)
+
+This keeps reporting and UI simpler while still supporting both calendars.
+
+## 3) Reminder system design
+
+### Reminder data model
+Add `event_reminders`:
+
+- `calendar_event_id`
+- `channel` (in_app, email, slack)
+- `minutes_before` (e.g., 10, 30, 1440)
+- `send_at` (precomputed)
+- `sent_at`
+- `state` (pending, sent, failed)
+
+### Delivery flow
+1. Event created/updated.
+2. Reminder timestamps recalculated.
+3. Background job enqueues deliveries.
+4. Create in-app notification (existing notifications pipeline).
+5. Optional email via mailer.
+
+Start with **in-app + email**, add Slack later.
+
+## 4) API endpoints to add (under `/api`)
+
+- `GET /calendar_events`
+  - filters: `start`, `end`, `project_id`, `visibility`, `mine_only`
+- `POST /calendar_events`
+- `PATCH /calendar_events/:id`
+- `DELETE /calendar_events/:id`
+- `POST /calendar_events/:id/reminders`
+- `PATCH /event_reminders/:id`
+- `DELETE /event_reminders/:id`
+
+Optional optimization:
+- `GET /calendar_feed`
+  - returns merged payload: events + lightweight linked task/project metadata
+
+## 5) Front-end UX options (Vite React)
+
+### Option 1 (Fast MVP)
+- Add a new `Calendar` page.
+- Month/Week toggle.
+- Event dots/cards.
+- Create/edit modal.
+- Reminder selector (10 min, 30 min, 1 day).
+
+### Option 2 (Operational view)
+- Calendar + right-side "Today" agenda panel.
+- Drag/drop event rescheduling.
+- "My Day" quick planner.
+
+### Option 3 (Manager/Team view)
+- Team calendar heatmap and conflict markers.
+- Filters by project/member/event type.
+- Meeting load analytics.
+
+Recommended rollout: **Option 1 -> Option 2 -> Option 3**.
+
+## 6) Project-specific vs user-specific display strategy
+
+Default screen should show merged data with clear coloring:
+
+- Blue = personal
+- Green = project events
+- Red = deadlines
+
+Top filters:
+- My Events
+- My Projects
+- Team Events
+- Deadlines only
+
+For managers, add "member lanes" in week view to detect overload.
+
+## 7) Suggested employee-focused features
+
+High-impact features to reduce employee effort:
+
+1. **Task -> calendar in one click**
+   - from task card, create event prefilled with title and due date.
+2. **Smart reminders**
+   - default reminder based on event type (e.g., meetings 15m, deadlines 1d).
+3. **Conflict detection**
+   - warn when creating overlapping meetings.
+4. **Daily digest**
+   - morning summary of today’s meetings, deadlines, and overdue tasks.
+5. **No-meeting focus blocks**
+   - recurring deep-work slots that block scheduling.
+6. **Attendance/acknowledge actions**
+   - "Going/Not Going" for optional project meetings.
+
+## 8) Implementation phases
+
+### Phase 1 (1-2 sprints)
+- DB tables: `calendar_events`, `event_reminders`
+- CRUD APIs
+- Basic calendar UI with month/week + create/edit
+- In-app reminder delivery
+
+### Phase 2
+- Email reminders
+- Recurring events
+- Conflict detection
+- Task/sprint linkage buttons
+
+### Phase 3
+- Team workload analytics
+- Slack integration
+- ICS import/export + Google Calendar sync
+
+## 9) Where to implement in this codebase
+
+Backend:
+- `app/models/calendar_event.rb`, `app/models/event_reminder.rb`
+- `app/controllers/api/calendar_events_controller.rb`
+- `app/controllers/api/event_reminders_controller.rb`
+- `app/jobs/event_reminder_job.rb`
+- `app/mailers/calendar_mailer.rb`
+- `config/routes.rb`
+- `db/migrate/*create_calendar_events.rb`
+- `db/migrate/*create_event_reminders.rb`
+
+Frontend:
+- `app/javascript/pages/Calendar.jsx`
+- `app/javascript/components/Calendar/*`
+- Add route entry in app router/navigation
+- Reuse existing notification center for in-app alert rendering
+
+## 10) Minimal MVP feature set (best first implementation)
+
+If you want to start quickly without overbuilding, implement exactly this:
+
+- Personal + project events in one calendar screen
+- One-time reminders (10m/30m/1d)
+- Meeting events with links + attendees (simple text for MVP)
+- Deadline events linked to task/project
+- Daily agenda widget on dashboard
+
+This will already make employee planning much easier and gives a clean base for advanced automation later.


### PR DESCRIPTION
### Motivation
- Add a backend foundation to support personal and project calendar events and timed reminders so the frontend calendar UI and reminder features can be implemented next. 
- Reuse the existing notifications/background-job infrastructure to deliver in-app reminders and keep behavior consistent with other app events. 

### Description
- Add DB migrations `CreateCalendarEvents` and `CreateEventReminders` to create `calendar_events` and `event_reminders` tables with indexes and a uniqueness index for reminder windows. 
- Implement `CalendarEvent` and `EventReminder` models with validations, enums, `within_range` scope, `as_api_json` serialization, automatic `send_at` calculation, and scheduling via `EventReminderJob`. 
- Add authenticated API controllers `Api::CalendarEventsController` (index/create/update/destroy with date/project/visibility filters and scoped access) and `Api::EventRemindersController` (create/update/destroy) and wire routes for nested reminder creation and top-level reminder updates/deletes. 
- Wire associations from `User`, `Project`, `Task`, and `Sprint` to `calendar_events` and add `EventReminderJob` which creates in-app `Notification` entries and marks reminders `sent`/`failed`. 
- Add `docs/calendar_reminder_plan.md` with the planning/rollout notes to guide frontend and future integrations. 

### Testing
- Ran syntax checks `ruby -c` on `app/models/calendar_event.rb`, `app/models/event_reminder.rb`, `app/controllers/api/calendar_events_controller.rb`, `app/controllers/api/event_reminders_controller.rb`, and `app/jobs/event_reminder_job.rb`, and all returned `Syntax OK`. 
- Verified `ruby -c config/routes.rb` returned `Syntax OK` and inspected route insertion for `calendar_events` and `event_reminders`. 
- Attempted to run `bin/rails db:migrate` but it failed in this environment due to a Ruby runtime mismatch (runtime `3.2.3` vs Gemfile `3.3.0`), so migrations were added but could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b178987e483229b5a789d928cc5cd)