### PR TITLE
Add Calendar UI and frontend API wiring for calendar & reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The project serves as a learning playground and starting point for applications 
 - `app/javascript` – React application compiled by Vite.
 - `app/controllers` – API endpoints consumed by the front end.
 - `app/services` – integration helpers such as Google Sheets readers and JWT helpers.
+- `docs/calendar_reminder_plan.md` – proposed roadmap for calendar, reminder, and meeting scheduling features.
 
 ## Tests
 

--- a/app/controllers/api/calendar_events_controller.rb
+++ b/app/controllers/api/calendar_events_controller.rb
@@ -1,0 +1,76 @@
+class Api::CalendarEventsController < Api::BaseController
+  before_action :set_calendar_event, only: [:update, :destroy]
+
+  def index
+    events = scoped_events.includes(:event_reminders).order(:start_at)
+
+    if params[:start].present? && params[:end].present?
+      begin
+        start_time = Time.zone.parse(params[:start])
+        end_time = Time.zone.parse(params[:end])
+        events = events.within_range(start_time, end_time) if start_time.present? && end_time.present?
+      rescue ArgumentError
+        return render json: { error: 'Invalid start or end datetime filter' }, status: :unprocessable_entity
+      end
+    end
+
+    events = events.where(project_id: params[:project_id]) if params[:project_id].present?
+    events = events.where(visibility: params[:visibility]) if params[:visibility].present?
+
+    render json: events.map(&:as_api_json)
+  end
+
+  def create
+    event = current_user.calendar_events.new(calendar_event_params)
+
+    if event.save
+      render json: event.as_api_json, status: :created
+    else
+      render json: { errors: event.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @calendar_event.update(calendar_event_params)
+      render json: @calendar_event.as_api_json
+    else
+      render json: { errors: @calendar_event.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @calendar_event.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_calendar_event
+    @calendar_event = scoped_events.find(params[:id])
+  end
+
+  def scoped_events
+    project_ids = current_user.projects.select(:id)
+
+    CalendarEvent.where(user_id: current_user.id)
+                 .or(CalendarEvent.where(visibility: 'project', project_id: project_ids))
+                 .distinct
+  end
+
+  def calendar_event_params
+    params.require(:calendar_event).permit(
+      :title,
+      :description,
+      :start_at,
+      :end_at,
+      :all_day,
+      :event_type,
+      :visibility,
+      :status,
+      :project_id,
+      :task_id,
+      :sprint_id,
+      :location_or_meet_link
+    )
+  end
+end

--- a/app/controllers/api/event_reminders_controller.rb
+++ b/app/controllers/api/event_reminders_controller.rb
@@ -1,0 +1,51 @@
+class Api::EventRemindersController < Api::BaseController
+  before_action :set_calendar_event, only: [:create]
+  before_action :set_event_reminder, only: [:update, :destroy]
+
+  def create
+    reminder = @calendar_event.event_reminders.new(event_reminder_params)
+
+    if reminder.save
+      render json: reminder.as_json(only: [:id, :calendar_event_id, :channel, :minutes_before, :send_at, :sent_at, :state]), status: :created
+    else
+      render json: { errors: reminder.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @event_reminder.update(event_reminder_params)
+      render json: @event_reminder.as_json(only: [:id, :calendar_event_id, :channel, :minutes_before, :send_at, :sent_at, :state])
+    else
+      render json: { errors: @event_reminder.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @event_reminder.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_calendar_event
+    @calendar_event = accessible_events.find(params[:calendar_event_id])
+  end
+
+  def set_event_reminder
+    @event_reminder = EventReminder.joins(:calendar_event)
+                                   .where(calendar_event: accessible_events)
+                                   .find(params[:id])
+  end
+
+  def accessible_events
+    project_ids = current_user.projects.select(:id)
+
+    CalendarEvent.where(user_id: current_user.id)
+                 .or(CalendarEvent.where(visibility: 'project', project_id: project_ids))
+                 .distinct
+  end
+
+  def event_reminder_params
+    params.require(:event_reminder).permit(:channel, :minutes_before)
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -26,6 +26,7 @@ import WorkLog from "../pages/WorkLog";
 import Settings from "../pages/Settings";
 import PageTitle from "./PageTitle";
 import DailyMomentumHub from "../pages/DailyMomentumHub";
+import Calendar from "../pages/Calendar";
 import PageLoader from "./ui/PageLoader";
 
 const RouteTransitionLoader = ({ children }) => {
@@ -74,6 +75,7 @@ const App = () => {
               <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
               <Route path="/knowledge" element={<PrivateRoute><KnowledgeDashboard /></PrivateRoute>} />
               <Route path="/worklog" element={<PrivateRoute><WorkLog /></PrivateRoute>} />
+              <Route path="/calendar" element={<PrivateRoute><Calendar /></PrivateRoute>} />
               <Route path="/projects" element={<PrivateRoute><Projects /></PrivateRoute>} />
               <Route path="/teams" element={<PrivateRoute><Teams /></PrivateRoute>} />
               <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><SprintDashboard /></ProjectMemberRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -10,7 +10,7 @@ import {
   FiChevronDown, FiMenu, FiX, FiLogOut, FiUser,
   FiUsers, FiBriefcase, FiLayers, FiBook,
   FiMessageSquare, FiSettings, FiZap, FiAward, FiFileText,
-  FiClock, FiTarget
+  FiClock, FiTarget, FiCalendar
 } from "react-icons/fi";
 import { motion, AnimatePresence, useScroll, useMotionValueEvent } from "framer-motion";
 
@@ -213,6 +213,7 @@ const Navbar = () => {
     { to: "/knowledge", label: "Knowledge", icon: FiBook, visible: !!user },
     { to: "/vault", label: "Vault", icon: FiMenu, visible: !!user },
     { to: "/worklog", label: "Work Log", icon: FiClock, visible: !!user },
+    { to: "/calendar", label: "Calendar", icon: FiCalendar, visible: !!user },
     {
       to: "/teams",
       label: "Teams",

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -224,4 +224,14 @@ export const fetchNotifications = (params = {}) => api.get('/notifications.json'
 export const markNotificationRead = (id) => api.post(`/notifications/${id}/mark_read`);
 export const markAllNotificationsRead = () => api.post('/notifications/mark_all_read');
 
+
+// CALENDAR ENDPOINTS
+export const fetchCalendarEvents = (params = {}) => api.get('/calendar_events', { params });
+export const createCalendarEvent = (data) => api.post('/calendar_events', { calendar_event: data });
+export const updateCalendarEvent = (id, data) => api.patch(`/calendar_events/${id}`, { calendar_event: data });
+export const deleteCalendarEvent = (id) => api.delete(`/calendar_events/${id}`);
+export const createEventReminder = (calendarEventId, data) => api.post(`/calendar_events/${calendarEventId}/event_reminders`, { event_reminder: data });
+export const updateEventReminder = (id, data) => api.patch(`/event_reminders/${id}`, { event_reminder: data });
+export const deleteEventReminder = (id) => api.delete(`/event_reminders/${id}`);
+
 export default api;

--- a/app/javascript/pages/Calendar.jsx
+++ b/app/javascript/pages/Calendar.jsx
@@ -1,0 +1,331 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  createCalendarEvent,
+  createEventReminder,
+  fetchCalendarEvents,
+  fetchProjects,
+} from "../components/api";
+
+const EVENT_TYPES = [
+  { value: "meeting", label: "Meeting" },
+  { value: "deadline", label: "Deadline" },
+  { value: "reminder", label: "Reminder" },
+  { value: "focus", label: "Focus Block" },
+  { value: "sprint_ceremony", label: "Sprint Ceremony" },
+];
+
+const VISIBILITY_OPTIONS = [
+  { value: "personal", label: "Personal" },
+  { value: "project", label: "Project" },
+];
+
+const REMINDER_OPTIONS = [
+  { value: "", label: "No reminder" },
+  { value: "10", label: "10 min before" },
+  { value: "30", label: "30 min before" },
+  { value: "1440", label: "1 day before" },
+];
+
+const toInputDateTime = (date) => {
+  const pad = (n) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
+const Calendar = () => {
+  const now = new Date();
+  const defaultStart = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 10, 0);
+  const defaultEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 11, 0);
+
+  const [events, setEvents] = useState([]);
+  const [projects, setProjects] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const [filters, setFilters] = useState({
+    visibility: "",
+    projectId: "",
+    start: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7).toISOString(),
+    end: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 30).toISOString(),
+  });
+
+  const [form, setForm] = useState({
+    title: "",
+    description: "",
+    start_at: toInputDateTime(defaultStart),
+    end_at: toInputDateTime(defaultEnd),
+    event_type: "meeting",
+    visibility: "personal",
+    project_id: "",
+    location_or_meet_link: "",
+    reminder_minutes: "10",
+  });
+
+  const load = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const [eventsRes, projectsRes] = await Promise.all([
+        fetchCalendarEvents({
+          start: filters.start,
+          end: filters.end,
+          visibility: filters.visibility || undefined,
+          project_id: filters.projectId || undefined,
+        }),
+        fetchProjects(),
+      ]);
+
+      setEvents(Array.isArray(eventsRes?.data) ? eventsRes.data : []);
+      setProjects(Array.isArray(projectsRes?.data) ? projectsRes.data : []);
+    } catch (e) {
+      setError(e?.response?.data?.error || "Failed to load calendar data.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filters.visibility, filters.projectId]);
+
+  const grouped = useMemo(() => {
+    const byDay = {};
+    events.forEach((event) => {
+      const key = new Date(event.start_at).toLocaleDateString();
+      if (!byDay[key]) byDay[key] = [];
+      byDay[key].push(event);
+    });
+
+    return Object.entries(byDay)
+      .sort((a, b) => new Date(a[1][0].start_at) - new Date(b[1][0].start_at))
+      .map(([date, dayEvents]) => ({
+        date,
+        events: dayEvents.sort((a, b) => new Date(a.start_at) - new Date(b.start_at)),
+      }));
+  }, [events]);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      const payload = {
+        title: form.title,
+        description: form.description || undefined,
+        start_at: new Date(form.start_at).toISOString(),
+        end_at: new Date(form.end_at).toISOString(),
+        event_type: form.event_type,
+        visibility: form.visibility,
+        project_id: form.visibility === "project" ? Number(form.project_id) : undefined,
+        location_or_meet_link: form.location_or_meet_link || undefined,
+      };
+
+      const { data: createdEvent } = await createCalendarEvent(payload);
+
+      if (form.reminder_minutes) {
+        await createEventReminder(createdEvent.id, {
+          channel: "in_app",
+          minutes_before: Number(form.reminder_minutes),
+        });
+      }
+
+      setForm((prev) => ({
+        ...prev,
+        title: "",
+        description: "",
+        location_or_meet_link: "",
+      }));
+      await load();
+    } catch (err) {
+      const apiErrors = err?.response?.data?.errors;
+      setError(Array.isArray(apiErrors) ? apiErrors.join(", ") : "Failed to create calendar event.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 grid gap-6 lg:grid-cols-3">
+      <section className="lg:col-span-1 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm">
+        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">Calendar & Reminders</h1>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 mt-1">Create personal or project meetings and auto-schedule reminders.</p>
+
+        <form className="mt-5 space-y-3" onSubmit={handleCreate}>
+          <input
+            value={form.title}
+            onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+            placeholder="Event title"
+            required
+            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+          />
+
+          <textarea
+            value={form.description}
+            onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+            placeholder="Description (optional)"
+            rows={3}
+            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+          />
+
+          <div className="grid grid-cols-2 gap-2">
+            <input
+              type="datetime-local"
+              value={form.start_at}
+              onChange={(e) => setForm((f) => ({ ...f, start_at: e.target.value }))}
+              required
+              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            />
+            <input
+              type="datetime-local"
+              value={form.end_at}
+              onChange={(e) => setForm((f) => ({ ...f, end_at: e.target.value }))}
+              required
+              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <select
+              value={form.event_type}
+              onChange={(e) => setForm((f) => ({ ...f, event_type: e.target.value }))}
+              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            >
+              {EVENT_TYPES.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+
+            <select
+              value={form.visibility}
+              onChange={(e) => setForm((f) => ({ ...f, visibility: e.target.value }))}
+              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            >
+              {VISIBILITY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {form.visibility === "project" && (
+            <select
+              value={form.project_id}
+              onChange={(e) => setForm((f) => ({ ...f, project_id: e.target.value }))}
+              required
+              className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            >
+              <option value="">Select project</option>
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>{project.name}</option>
+              ))}
+            </select>
+          )}
+
+          <input
+            value={form.location_or_meet_link}
+            onChange={(e) => setForm((f) => ({ ...f, location_or_meet_link: e.target.value }))}
+            placeholder="Meet link / location"
+            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+          />
+
+          <select
+            value={form.reminder_minutes}
+            onChange={(e) => setForm((f) => ({ ...f, reminder_minutes: e.target.value }))}
+            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+          >
+            {REMINDER_OPTIONS.map((option) => (
+              <option key={option.value || "none"} value={option.value}>{option.label}</option>
+            ))}
+          </select>
+
+          <button
+            type="submit"
+            disabled={saving}
+            className="w-full rounded-lg bg-blue-600 hover:bg-blue-700 text-white py-2.5 text-sm font-semibold disabled:opacity-60"
+          >
+            {saving ? "Saving..." : "Create event"}
+          </button>
+        </form>
+      </section>
+
+      <section className="lg:col-span-2 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm">
+        <div className="flex flex-wrap items-center gap-2 justify-between">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Upcoming agenda</h2>
+          <div className="flex items-center gap-2">
+            <select
+              value={filters.visibility}
+              onChange={(e) => setFilters((f) => ({ ...f, visibility: e.target.value }))}
+              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            >
+              <option value="">All visibility</option>
+              <option value="personal">Personal</option>
+              <option value="project">Project</option>
+            </select>
+
+            <select
+              value={filters.projectId}
+              onChange={(e) => setFilters((f) => ({ ...f, projectId: e.target.value }))}
+              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            >
+              <option value="">All projects</option>
+              {projects.map((project) => (
+                <option key={project.id} value={project.id}>{project.name}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        {error ? <p className="mt-4 text-sm text-red-600">{error}</p> : null}
+
+        {loading ? (
+          <p className="mt-4 text-sm text-zinc-500">Loading events...</p>
+        ) : grouped.length === 0 ? (
+          <p className="mt-4 text-sm text-zinc-500">No events in selected range.</p>
+        ) : (
+          <div className="mt-4 space-y-5">
+            {grouped.map((group) => (
+              <div key={group.date}>
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">{group.date}</h3>
+                <div className="mt-2 space-y-2">
+                  {group.events.map((event) => (
+                    <article key={event.id} className="rounded-xl border border-zinc-200 dark:border-zinc-700 p-3 bg-zinc-50/70 dark:bg-zinc-800/50">
+                      <div className="flex justify-between gap-3">
+                        <div>
+                          <p className="font-semibold text-zinc-900 dark:text-zinc-100">{event.title}</p>
+                          <p className="text-xs text-zinc-500 mt-0.5">
+                            {new Date(event.start_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                            {" - "}
+                            {new Date(event.end_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                            {` • ${event.visibility}`}
+                          </p>
+                        </div>
+                        <span className="text-xs rounded-full px-2 py-1 bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300 h-fit">
+                          {event.event_type.replace("_", " ")}
+                        </span>
+                      </div>
+
+                      {event.description ? <p className="text-sm mt-2 text-zinc-700 dark:text-zinc-300">{event.description}</p> : null}
+                      {event.location_or_meet_link ? (
+                        <a href={event.location_or_meet_link} target="_blank" rel="noreferrer" className="text-xs text-blue-600 mt-2 inline-block underline break-all">
+                          {event.location_or_meet_link}
+                        </a>
+                      ) : null}
+
+                      {event.event_reminders?.length ? (
+                        <p className="text-xs text-zinc-500 mt-2">
+                          Reminders: {event.event_reminders.map((r) => `${r.minutes_before}m (${r.channel})`).join(", ")}
+                        </p>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+};
+
+export default Calendar;

--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -1,0 +1,31 @@
+class EventReminderJob < ApplicationJob
+  queue_as :default
+
+  def perform(event_reminder_id)
+    reminder = EventReminder.includes(calendar_event: :user).find_by(id: event_reminder_id)
+    return unless reminder&.pending?
+
+    event = reminder.calendar_event
+    recipient = event.user
+
+    Notification.create(
+      recipient: recipient,
+      actor: recipient,
+      action: 'update',
+      notifiable: event,
+      metadata: {
+        type: 'calendar_reminder',
+        calendar_event_id: event.id,
+        event_title: event.title,
+        event_start_at: event.start_at,
+        channel: reminder.channel,
+        minutes_before: reminder.minutes_before
+      }
+    )
+
+    reminder.update!(state: 'sent', sent_at: Time.current)
+  rescue StandardError
+    reminder&.update(state: 'failed') if reminder&.pending?
+    raise
+  end
+end

--- a/app/models/calendar_event.rb
+++ b/app/models/calendar_event.rb
@@ -1,0 +1,56 @@
+class CalendarEvent < ApplicationRecord
+  EVENT_TYPES = %w[meeting deadline reminder focus sprint_ceremony].freeze
+
+  belongs_to :user
+  belongs_to :project, optional: true
+  belongs_to :task, optional: true
+  belongs_to :sprint, optional: true
+
+  has_many :event_reminders, dependent: :destroy
+
+  enum visibility: {
+    personal: 'personal',
+    project: 'project'
+  }, _default: 'personal'
+
+  enum status: {
+    scheduled: 'scheduled',
+    cancelled: 'cancelled',
+    completed: 'completed'
+  }, _default: 'scheduled'
+
+  validates :title, :start_at, :end_at, :event_type, :visibility, :status, presence: true
+  validates :event_type, inclusion: { in: EVENT_TYPES }
+  validate :end_after_start
+  validate :project_required_for_project_visibility
+
+  scope :within_range, ->(start_time, end_time) {
+    where('start_at < ? AND end_at > ?', end_time, start_time)
+  }
+
+  def as_api_json
+    as_json(
+      only: [:id, :title, :description, :start_at, :end_at, :all_day, :event_type, :visibility, :status, :location_or_meet_link, :project_id, :task_id, :sprint_id, :user_id, :created_at, :updated_at],
+      include: {
+        event_reminders: {
+          only: [:id, :channel, :minutes_before, :send_at, :sent_at, :state]
+        }
+      }
+    )
+  end
+
+  private
+
+  def end_after_start
+    return if start_at.blank? || end_at.blank?
+    return if end_at >= start_at
+
+    errors.add(:end_at, 'must be on or after start_at')
+  end
+
+  def project_required_for_project_visibility
+    return unless visibility == 'project' && project_id.blank?
+
+    errors.add(:project_id, 'is required for project events')
+  end
+end

--- a/app/models/event_reminder.rb
+++ b/app/models/event_reminder.rb
@@ -1,0 +1,36 @@
+class EventReminder < ApplicationRecord
+  CHANNELS = %w[in_app email].freeze
+
+  belongs_to :calendar_event
+
+  enum state: {
+    pending: 'pending',
+    sent: 'sent',
+    failed: 'failed'
+  }, _default: 'pending'
+
+  validates :channel, :minutes_before, :send_at, :state, presence: true
+  validates :channel, inclusion: { in: CHANNELS }
+  validates :minutes_before, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  before_validation :calculate_send_at, if: :needs_send_at_recalculation?
+  after_commit :schedule_delivery_job, on: [:create, :update], if: :pending?
+
+  private
+
+  def needs_send_at_recalculation?
+    send_at.blank? || will_save_change_to_minutes_before? || will_save_change_to_calendar_event_id?
+  end
+
+  def calculate_send_at
+    return if calendar_event.blank? || calendar_event.start_at.blank?
+
+    self.send_at = calendar_event.start_at - minutes_before.to_i.minutes
+  end
+
+  def schedule_delivery_job
+    return if send_at.blank? || send_at <= Time.current
+
+    EventReminderJob.set(wait_until: send_at).perform_later(id)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,6 +8,7 @@ class Project < ApplicationRecord
   has_many :developers, -> { distinct }, through: :tasks, source: :developer
   has_many :project_environments, dependent: :destroy, inverse_of: :project
   has_many :project_vault_items, dependent: :destroy, inverse_of: :project
+  has_many :calendar_events, dependent: :nullify
 
   enum status: {
     upcoming: 'upcoming',

--- a/app/models/sprint.rb
+++ b/app/models/sprint.rb
@@ -3,4 +3,5 @@ class Sprint < ApplicationRecord
 
   belongs_to :project, inverse_of: :sprints
   has_many :tasks, dependent: :nullify, inverse_of: :sprint
+  has_many :calendar_events, dependent: :nullify
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,6 +7,7 @@ class Task < ApplicationRecord
   belongs_to :assigned_user, class_name: 'User', foreign_key: :assigned_to_user, optional: true, inverse_of: :tasks
 
   has_many :task_logs, dependent: :destroy, inverse_of: :task
+  has_many :calendar_events, dependent: :nullify
 
   # This tells ActiveRecord NOT to use the 'type' column for Single Table Inheritance.
   self.inheritance_column = 'non_existent_type_column'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,7 @@ class User < ApplicationRecord
   has_many :given_skill_endorsements, class_name: 'SkillEndorsement', foreign_key: :endorser_id, dependent: :destroy, inverse_of: :endorser
   has_many :received_skill_endorsements, through: :user_skills, source: :skill_endorsements
   has_many :notifications, foreign_key: :recipient_id, dependent: :destroy
+  has_many :calendar_events, dependent: :destroy
   belongs_to :department, optional: true
 
   enum availability_status: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,12 @@ Rails.application.routes.draw do
       end
     end
 
+
+    resources :calendar_events, only: [:index, :create, :update, :destroy] do
+      resources :event_reminders, only: [:create]
+    end
+    resources :event_reminders, only: [:update, :destroy]
+
     resources :notifications, only: [:index] do
       collection do
         post :mark_all_read

--- a/db/migrate/20270210000000_create_calendar_events.rb
+++ b/db/migrate/20270210000000_create_calendar_events.rb
@@ -1,0 +1,25 @@
+class CreateCalendarEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :calendar_events do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :project, foreign_key: true
+      t.references :task, foreign_key: true
+      t.references :sprint, foreign_key: true
+      t.string :title, null: false
+      t.text :description
+      t.datetime :start_at, null: false
+      t.datetime :end_at, null: false
+      t.boolean :all_day, null: false, default: false
+      t.string :event_type, null: false, default: 'meeting'
+      t.string :visibility, null: false, default: 'personal'
+      t.string :status, null: false, default: 'scheduled'
+      t.string :location_or_meet_link
+
+      t.timestamps
+    end
+
+    add_index :calendar_events, [:user_id, :start_at]
+    add_index :calendar_events, [:visibility, :start_at]
+    add_index :calendar_events, :event_type
+  end
+end

--- a/db/migrate/20270210000001_create_event_reminders.rb
+++ b/db/migrate/20270210000001_create_event_reminders.rb
@@ -1,0 +1,17 @@
+class CreateEventReminders < ActiveRecord::Migration[7.1]
+  def change
+    create_table :event_reminders do |t|
+      t.references :calendar_event, null: false, foreign_key: true
+      t.string :channel, null: false, default: 'in_app'
+      t.integer :minutes_before, null: false, default: 10
+      t.datetime :send_at, null: false
+      t.datetime :sent_at
+      t.string :state, null: false, default: 'pending'
+
+      t.timestamps
+    end
+
+    add_index :event_reminders, [:state, :send_at]
+    add_index :event_reminders, [:calendar_event_id, :minutes_before, :channel], unique: true, name: 'idx_unique_event_reminder_window'
+  end
+end

--- a/docs/calendar_reminder_plan.md
+++ b/docs/calendar_reminder_plan.md
@@ -1,0 +1,195 @@
+# Calendar, Reminder, and Meeting Scheduling Plan
+
+This document proposes **project-specific** and **user-specific** calendar features for this Rails + Vite app, with implementation guidance based on the current architecture.
+
+## 1) What already exists (reuse first)
+
+The app already has:
+
+- Task and sprint workflows (`/api/tasks`, `/api/sprints`) and scheduler-related UI components.
+- Notifications (`/api/notifications`) and background jobs/mailers.
+- Project membership (`projects`, `project_users`) and user-level preferences fields.
+
+So calendar can be built as an extension of existing objects instead of a separate isolated system.
+
+## 2) Calendar models to implement
+
+### A. Project Calendar (team-facing)
+Use this for things shared by a project/team:
+
+- Sprint ceremonies (planning, review, retro)
+- Release deadlines
+- Client/demo meetings
+- Shared milestones
+
+**Ownership**
+- `project_id` required
+- visible to all project members
+
+### B. Personal Calendar (employee-facing)
+Use this for individual work planning:
+
+- Focus blocks
+- 1:1s
+- Interview slots
+- Reminder-only items (no meeting)
+
+**Ownership**
+- `user_id` required
+- optionally linked to `project_id` or `task_id`
+
+### C. Unified Event Table (recommended)
+Instead of separate tables for project/personal calendars, create one table with scope flags:
+
+- `calendar_events`
+  - `title`, `description`
+  - `start_at`, `end_at`, `all_day`
+  - `event_type` (meeting, deadline, reminder, focus, sprint_ceremony)
+  - `visibility` (personal, project)
+  - `user_id` (owner)
+  - `project_id` (optional for personal, required for project visibility)
+  - `task_id` / `sprint_id` (optional links)
+  - `location_or_meet_link`
+  - `status` (scheduled, cancelled, completed)
+  - `recurrence_rule` (later phase)
+
+This keeps reporting and UI simpler while still supporting both calendars.
+
+## 3) Reminder system design
+
+### Reminder data model
+Add `event_reminders`:
+
+- `calendar_event_id`
+- `channel` (in_app, email, slack)
+- `minutes_before` (e.g., 10, 30, 1440)
+- `send_at` (precomputed)
+- `sent_at`
+- `state` (pending, sent, failed)
+
+### Delivery flow
+1. Event created/updated.
+2. Reminder timestamps recalculated.
+3. Background job enqueues deliveries.
+4. Create in-app notification (existing notifications pipeline).
+5. Optional email via mailer.
+
+Start with **in-app + email**, add Slack later.
+
+## 4) API endpoints to add (under `/api`)
+
+- `GET /calendar_events`
+  - filters: `start`, `end`, `project_id`, `visibility`, `mine_only`
+- `POST /calendar_events`
+- `PATCH /calendar_events/:id`
+- `DELETE /calendar_events/:id`
+- `POST /calendar_events/:id/reminders`
+- `PATCH /event_reminders/:id`
+- `DELETE /event_reminders/:id`
+
+Optional optimization:
+- `GET /calendar_feed`
+  - returns merged payload: events + lightweight linked task/project metadata
+
+## 5) Front-end UX options (Vite React)
+
+### Option 1 (Fast MVP)
+- Add a new `Calendar` page.
+- Month/Week toggle.
+- Event dots/cards.
+- Create/edit modal.
+- Reminder selector (10 min, 30 min, 1 day).
+
+### Option 2 (Operational view)
+- Calendar + right-side "Today" agenda panel.
+- Drag/drop event rescheduling.
+- "My Day" quick planner.
+
+### Option 3 (Manager/Team view)
+- Team calendar heatmap and conflict markers.
+- Filters by project/member/event type.
+- Meeting load analytics.
+
+Recommended rollout: **Option 1 -> Option 2 -> Option 3**.
+
+## 6) Project-specific vs user-specific display strategy
+
+Default screen should show merged data with clear coloring:
+
+- Blue = personal
+- Green = project events
+- Red = deadlines
+
+Top filters:
+- My Events
+- My Projects
+- Team Events
+- Deadlines only
+
+For managers, add "member lanes" in week view to detect overload.
+
+## 7) Suggested employee-focused features
+
+High-impact features to reduce employee effort:
+
+1. **Task -> calendar in one click**
+   - from task card, create event prefilled with title and due date.
+2. **Smart reminders**
+   - default reminder based on event type (e.g., meetings 15m, deadlines 1d).
+3. **Conflict detection**
+   - warn when creating overlapping meetings.
+4. **Daily digest**
+   - morning summary of today’s meetings, deadlines, and overdue tasks.
+5. **No-meeting focus blocks**
+   - recurring deep-work slots that block scheduling.
+6. **Attendance/acknowledge actions**
+   - "Going/Not Going" for optional project meetings.
+
+## 8) Implementation phases
+
+### Phase 1 (1-2 sprints)
+- DB tables: `calendar_events`, `event_reminders`
+- CRUD APIs
+- Basic calendar UI with month/week + create/edit
+- In-app reminder delivery
+
+### Phase 2
+- Email reminders
+- Recurring events
+- Conflict detection
+- Task/sprint linkage buttons
+
+### Phase 3
+- Team workload analytics
+- Slack integration
+- ICS import/export + Google Calendar sync
+
+## 9) Where to implement in this codebase
+
+Backend:
+- `app/models/calendar_event.rb`, `app/models/event_reminder.rb`
+- `app/controllers/api/calendar_events_controller.rb`
+- `app/controllers/api/event_reminders_controller.rb`
+- `app/jobs/event_reminder_job.rb`
+- `app/mailers/calendar_mailer.rb`
+- `config/routes.rb`
+- `db/migrate/*create_calendar_events.rb`
+- `db/migrate/*create_event_reminders.rb`
+
+Frontend:
+- `app/javascript/pages/Calendar.jsx`
+- `app/javascript/components/Calendar/*`
+- Add route entry in app router/navigation
+- Reuse existing notification center for in-app alert rendering
+
+## 10) Minimal MVP feature set (best first implementation)
+
+If you want to start quickly without overbuilding, implement exactly this:
+
+- Personal + project events in one calendar screen
+- One-time reminders (10m/30m/1d)
+- Meeting events with links + attendees (simple text for MVP)
+- Deadline events linked to task/project
+- Daily agenda widget on dashboard
+
+This will already make employee planning much easier and gives a clean base for advanced automation later.


### PR DESCRIPTION
### Motivation
- Provide a usable frontend for the calendar/reminder backend so users can create events and reminders and see an agenda view. 
- Surface calendar functionality in the main app navigation and integrate it with existing projects/tasks so the backend foundation becomes immediately usable. 

### Description
- Add a new authenticated page `app/javascript/pages/Calendar.jsx` that implements an event creation form, optional reminder setup, agenda grouped by day, and filters for visibility/project. 
- Wire the page into routing and navigation by adding the `/calendar` route in `app/javascript/components/App.jsx` and a **Calendar** item in `app/javascript/components/Navbar.jsx`. 
- Extend the frontend API client (`app/javascript/components/api.jsx`) with calendar and reminder endpoints (`fetchCalendarEvents`, `createCalendarEvent`, `createEventReminder`, `updateEventReminder`, `deleteEventReminder`) used by the UI. 
- Include the previously added backend pieces: `CalendarEvent` and `EventReminder` models, `Api::CalendarEventsController` and `Api::EventRemindersController`, migrations to create `calendar_events` and `event_reminders`, `EventReminderJob`, route entries, and model associations on `User`, `Project`, `Task`, and `Sprint`; plus the planning doc `docs/calendar_reminder_plan.md`. 

### Testing
- Ran the JS build with `npm run build` and it completed successfully. 
- Ran the frontend unit tests with `npm test` (Vitest) and all tests passed. 
- Attempted a Playwright screenshot of `http://127.0.0.1:3000/calendar` but the app was not reachable in this environment (`ERR_EMPTY_RESPONSE`). 
- From the backend rollout, `ruby -c` syntax checks were run for the new Ruby files and returned `Syntax OK`, while running `bin/rails db:migrate` could not be executed in this environment due to a Ruby runtime mismatch (migration files were added but not applied here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b178987e483229b5a789d928cc5cd)