### PR TITLE
Hide Momentum page and revamp Calendar UI/feature set

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { BrowserRouter as Router, Routes, Route, useLocation } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom";
 
 import { AuthProvider } from "../context/AuthContext";
 import PrivateRoute from "../components/PrivateRoute";
@@ -25,7 +25,6 @@ import ResetPassword from "../pages/ResetPassword";
 import WorkLog from "../pages/WorkLog";
 import Settings from "../pages/Settings";
 import PageTitle from "./PageTitle";
-import DailyMomentumHub from "../pages/DailyMomentumHub";
 import Calendar from "../pages/Calendar";
 import PageLoader from "./ui/PageLoader";
 
@@ -67,8 +66,8 @@ const App = () => {
               <Route path="/projects/:projectId/issues" element={<ProjectMemberRoute><IssueTracker standalone /></ProjectMemberRoute>} />
 
               {/* 🔐 Protected */}
-              <Route path="/" element={<PrivateRoute><DailyMomentumHub /></PrivateRoute>} />
-              <Route path="/momentum" element={<PrivateRoute><DailyMomentumHub /></PrivateRoute>} />
+              <Route path="/" element={<PrivateRoute><Calendar /></PrivateRoute>} />
+              <Route path="/momentum" element={<Navigate to="/calendar" replace />} />
               <Route path="/pdf" element={<PrivateRoute><PdfPage /></PrivateRoute>} />
               <Route path="/posts" element={<PrivateRoute><PostPage /></PrivateRoute>} />
               <Route path="/vault" element={<PrivateRoute><Vault /></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -10,7 +10,7 @@ import {
   FiChevronDown, FiMenu, FiX, FiLogOut, FiUser,
   FiUsers, FiBriefcase, FiLayers, FiBook,
   FiMessageSquare, FiSettings, FiZap, FiAward, FiFileText,
-  FiClock, FiTarget, FiCalendar
+  FiClock, FiCalendar
 } from "react-icons/fi";
 import { motion, AnimatePresence, useScroll, useMotionValueEvent } from "framer-motion";
 
@@ -207,7 +207,6 @@ const Navbar = () => {
 
   // Navigation configuration
   const navLinks = [
-    { to: "/", label: "Momentum", icon: FiTarget, visible: !!user },
     { to: "/posts", label: "Updates", icon: FiMessageSquare, visible: !!user },
     { to: "/pdf", label: "PDF Modifier", icon: FiFileText, visible: !!user },
     { to: "/knowledge", label: "Knowledge", icon: FiBook, visible: !!user },

--- a/app/javascript/components/PageTitle.jsx
+++ b/app/javascript/components/PageTitle.jsx
@@ -18,6 +18,7 @@ const PageTitle = () => {
       "/profile": "Profile",
       "/knowledge": "Knowledge Dashboard",
       "/worklog": "Work Log",
+      "/calendar": "Calendar",
       "/projects": "Projects",
       "/teams": "Teams",
       "/users": "Users",
@@ -28,7 +29,7 @@ const PageTitle = () => {
     let title = APP_NAME;
 
     if (pathname === "/") {
-      title = `Daily Momentum Hub | ${APP_NAME}`;
+      title = `Calendar | ${APP_NAME}`;
     } else if (/^\/projects\/[^/]+\/dashboard$/.test(pathname)) {
       title = `Sprint Dashboard | ${APP_NAME}`;
     } else if (titles[pathname]) {

--- a/app/javascript/pages/Calendar.jsx
+++ b/app/javascript/pages/Calendar.jsx
@@ -1,5 +1,17 @@
 import React, { useEffect, useMemo, useState } from "react";
 import {
+  FiBell,
+  FiCalendar,
+  FiClock,
+  FiFilter,
+  FiFlag,
+  FiLayers,
+  FiMapPin,
+  FiRefreshCw,
+  FiSearch,
+  FiSparkles,
+} from "react-icons/fi";
+import {
   createCalendarEvent,
   createEventReminder,
   fetchCalendarEvents,
@@ -26,10 +38,53 @@ const REMINDER_OPTIONS = [
   { value: "1440", label: "1 day before" },
 ];
 
+const RANGE_OPTIONS = [
+  { value: "7", label: "7 days" },
+  { value: "30", label: "30 days" },
+  { value: "90", label: "90 days" },
+];
+
+const QUICK_TEMPLATES = [
+  {
+    label: "Daily Standup",
+    event_type: "meeting",
+    durationMinutes: 15,
+    reminder_minutes: "10",
+    title: "Daily standup",
+  },
+  {
+    label: "Focus Session",
+    event_type: "focus",
+    durationMinutes: 60,
+    reminder_minutes: "",
+    title: "Deep focus block",
+  },
+  {
+    label: "Sprint Review",
+    event_type: "sprint_ceremony",
+    durationMinutes: 60,
+    reminder_minutes: "30",
+    title: "Sprint review",
+  },
+];
+
 const toInputDateTime = (date) => {
   const pad = (n) => String(n).padStart(2, "0");
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 };
+
+const toReadableDate = (isoString) =>
+  new Date(isoString).toLocaleDateString([], {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+
+const toReadableTime = (isoString) =>
+  new Date(isoString).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 
 const Calendar = () => {
   const now = new Date();
@@ -45,6 +100,9 @@ const Calendar = () => {
   const [filters, setFilters] = useState({
     visibility: "",
     projectId: "",
+    eventType: "",
+    search: "",
+    range: "30",
     start: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7).toISOString(),
     end: new Date(now.getFullYear(), now.getMonth(), now.getDate() + 30).toISOString(),
   });
@@ -87,11 +145,24 @@ const Calendar = () => {
   useEffect(() => {
     load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters.visibility, filters.projectId]);
+  }, [filters.visibility, filters.projectId, filters.start, filters.end]);
+
+  const filteredEvents = useMemo(() => {
+    const query = filters.search.trim().toLowerCase();
+    return events.filter((event) => {
+      const matchesType = !filters.eventType || event.event_type === filters.eventType;
+      const matchesSearch =
+        !query ||
+        event.title?.toLowerCase().includes(query) ||
+        event.description?.toLowerCase().includes(query) ||
+        event.location_or_meet_link?.toLowerCase().includes(query);
+      return matchesType && matchesSearch;
+    });
+  }, [events, filters.eventType, filters.search]);
 
   const grouped = useMemo(() => {
     const byDay = {};
-    events.forEach((event) => {
+    filteredEvents.forEach((event) => {
       const key = new Date(event.start_at).toLocaleDateString();
       if (!byDay[key]) byDay[key] = [];
       byDay[key].push(event);
@@ -103,12 +174,36 @@ const Calendar = () => {
         date,
         events: dayEvents.sort((a, b) => new Date(a.start_at) - new Date(b.start_at)),
       }));
-  }, [events]);
+  }, [filteredEvents]);
+
+  const metrics = useMemo(() => {
+    const todayDate = new Date().toDateString();
+    return {
+      total: filteredEvents.length,
+      today: filteredEvents.filter((event) => new Date(event.start_at).toDateString() === todayDate).length,
+      withReminders: filteredEvents.filter((event) => Array.isArray(event.event_reminders) && event.event_reminders.length > 0).length,
+      meetings: filteredEvents.filter((event) => event.event_type === "meeting").length,
+    };
+  }, [filteredEvents]);
+
+  const nextEvent = useMemo(() => {
+    const current = new Date();
+    return filteredEvents
+      .filter((event) => new Date(event.start_at) >= current)
+      .sort((a, b) => new Date(a.start_at) - new Date(b.start_at))[0];
+  }, [filteredEvents]);
 
   const handleCreate = async (e) => {
     e.preventDefault();
     setSaving(true);
     setError("");
+
+    if (new Date(form.end_at) <= new Date(form.start_at)) {
+      setSaving(false);
+      setError("End time must be after start time.");
+      return;
+    }
+
     try {
       const payload = {
         title: form.title,
@@ -145,185 +240,337 @@ const Calendar = () => {
     }
   };
 
+  const applyRange = (days) => {
+    const rangeDays = Number(days);
+    const start = new Date();
+    const end = new Date(start.getFullYear(), start.getMonth(), start.getDate() + rangeDays);
+
+    setFilters((prev) => ({
+      ...prev,
+      range: String(days),
+      start: start.toISOString(),
+      end: end.toISOString(),
+    }));
+  };
+
+  const applyTemplate = (template) => {
+    const start = new Date();
+    start.setMinutes(0);
+    start.setHours(start.getHours() + 1);
+    const end = new Date(start.getTime() + template.durationMinutes * 60000);
+
+    setForm((prev) => ({
+      ...prev,
+      title: template.title,
+      event_type: template.event_type,
+      reminder_minutes: template.reminder_minutes,
+      start_at: toInputDateTime(start),
+      end_at: toInputDateTime(end),
+    }));
+  };
+
+  const statCards = [
+    { label: "Events in view", value: metrics.total, icon: FiCalendar },
+    { label: "Today", value: metrics.today, icon: FiFlag },
+    { label: "Meetings", value: metrics.meetings, icon: FiLayers },
+    { label: "With reminders", value: metrics.withReminders, icon: FiBell },
+  ];
+
   return (
-    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 grid gap-6 lg:grid-cols-3">
-      <section className="lg:col-span-1 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm">
-        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-100">Calendar & Reminders</h1>
-        <p className="text-sm text-zinc-600 dark:text-zinc-400 mt-1">Create personal or project meetings and auto-schedule reminders.</p>
-
-        <form className="mt-5 space-y-3" onSubmit={handleCreate}>
-          <input
-            value={form.title}
-            onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
-            placeholder="Event title"
-            required
-            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-          />
-
-          <textarea
-            value={form.description}
-            onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
-            placeholder="Description (optional)"
-            rows={3}
-            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-          />
-
-          <div className="grid grid-cols-2 gap-2">
-            <input
-              type="datetime-local"
-              value={form.start_at}
-              onChange={(e) => setForm((f) => ({ ...f, start_at: e.target.value }))}
-              required
-              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-            />
-            <input
-              type="datetime-local"
-              value={form.end_at}
-              onChange={(e) => setForm((f) => ({ ...f, end_at: e.target.value }))}
-              required
-              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-            />
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 py-8 space-y-6">
+      <section className="rounded-3xl border border-zinc-200 dark:border-zinc-800 bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-zinc-900 dark:via-zinc-900 dark:to-zinc-800 p-6 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <p className="text-xs font-semibold tracking-[0.25em] uppercase text-blue-600 dark:text-blue-400">Planner</p>
+            <h1 className="mt-1 text-2xl font-bold text-zinc-900 dark:text-zinc-100">Calendar workspace</h1>
+            <p className="text-sm text-zinc-600 dark:text-zinc-300 mt-1">Plan meetings, protect focus time, and keep reminders visible for your team.</p>
           </div>
-
-          <div className="grid grid-cols-2 gap-2">
-            <select
-              value={form.event_type}
-              onChange={(e) => setForm((f) => ({ ...f, event_type: e.target.value }))}
-              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-            >
-              {EVENT_TYPES.map((option) => (
-                <option key={option.value} value={option.value}>{option.label}</option>
-              ))}
-            </select>
-
-            <select
-              value={form.visibility}
-              onChange={(e) => setForm((f) => ({ ...f, visibility: e.target.value }))}
-              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-            >
-              {VISIBILITY_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>{option.label}</option>
-              ))}
-            </select>
-          </div>
-
-          {form.visibility === "project" && (
-            <select
-              value={form.project_id}
-              onChange={(e) => setForm((f) => ({ ...f, project_id: e.target.value }))}
-              required
-              className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-            >
-              <option value="">Select project</option>
-              {projects.map((project) => (
-                <option key={project.id} value={project.id}>{project.name}</option>
-              ))}
-            </select>
-          )}
-
-          <input
-            value={form.location_or_meet_link}
-            onChange={(e) => setForm((f) => ({ ...f, location_or_meet_link: e.target.value }))}
-            placeholder="Meet link / location"
-            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-          />
-
-          <select
-            value={form.reminder_minutes}
-            onChange={(e) => setForm((f) => ({ ...f, reminder_minutes: e.target.value }))}
-            className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-          >
-            {REMINDER_OPTIONS.map((option) => (
-              <option key={option.value || "none"} value={option.value}>{option.label}</option>
-            ))}
-          </select>
 
           <button
-            type="submit"
-            disabled={saving}
-            className="w-full rounded-lg bg-blue-600 hover:bg-blue-700 text-white py-2.5 text-sm font-semibold disabled:opacity-60"
+            type="button"
+            onClick={load}
+            disabled={loading}
+            className="inline-flex items-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white/90 dark:bg-zinc-800/90 px-3 py-2 text-sm font-medium text-zinc-700 dark:text-zinc-200 hover:bg-white"
           >
-            {saving ? "Saving..." : "Create event"}
+            <FiRefreshCw className={loading ? "animate-spin" : ""} />
+            Refresh
           </button>
-        </form>
-      </section>
-
-      <section className="lg:col-span-2 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm">
-        <div className="flex flex-wrap items-center gap-2 justify-between">
-          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Upcoming agenda</h2>
-          <div className="flex items-center gap-2">
-            <select
-              value={filters.visibility}
-              onChange={(e) => setFilters((f) => ({ ...f, visibility: e.target.value }))}
-              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-            >
-              <option value="">All visibility</option>
-              <option value="personal">Personal</option>
-              <option value="project">Project</option>
-            </select>
-
-            <select
-              value={filters.projectId}
-              onChange={(e) => setFilters((f) => ({ ...f, projectId: e.target.value }))}
-              className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
-            >
-              <option value="">All projects</option>
-              {projects.map((project) => (
-                <option key={project.id} value={project.id}>{project.name}</option>
-              ))}
-            </select>
-          </div>
         </div>
 
-        {error ? <p className="mt-4 text-sm text-red-600">{error}</p> : null}
-
-        {loading ? (
-          <p className="mt-4 text-sm text-zinc-500">Loading events...</p>
-        ) : grouped.length === 0 ? (
-          <p className="mt-4 text-sm text-zinc-500">No events in selected range.</p>
-        ) : (
-          <div className="mt-4 space-y-5">
-            {grouped.map((group) => (
-              <div key={group.date}>
-                <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">{group.date}</h3>
-                <div className="mt-2 space-y-2">
-                  {group.events.map((event) => (
-                    <article key={event.id} className="rounded-xl border border-zinc-200 dark:border-zinc-700 p-3 bg-zinc-50/70 dark:bg-zinc-800/50">
-                      <div className="flex justify-between gap-3">
-                        <div>
-                          <p className="font-semibold text-zinc-900 dark:text-zinc-100">{event.title}</p>
-                          <p className="text-xs text-zinc-500 mt-0.5">
-                            {new Date(event.start_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                            {" - "}
-                            {new Date(event.end_at).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
-                            {` • ${event.visibility}`}
-                          </p>
-                        </div>
-                        <span className="text-xs rounded-full px-2 py-1 bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300 h-fit">
-                          {event.event_type.replace("_", " ")}
-                        </span>
-                      </div>
-
-                      {event.description ? <p className="text-sm mt-2 text-zinc-700 dark:text-zinc-300">{event.description}</p> : null}
-                      {event.location_or_meet_link ? (
-                        <a href={event.location_or_meet_link} target="_blank" rel="noreferrer" className="text-xs text-blue-600 mt-2 inline-block underline break-all">
-                          {event.location_or_meet_link}
-                        </a>
-                      ) : null}
-
-                      {event.event_reminders?.length ? (
-                        <p className="text-xs text-zinc-500 mt-2">
-                          Reminders: {event.event_reminders.map((r) => `${r.minutes_before}m (${r.channel})`).join(", ")}
-                        </p>
-                      ) : null}
-                    </article>
-                  ))}
-                </div>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          {statCards.map((card) => (
+            <div key={card.label} className="rounded-2xl border border-zinc-200/80 dark:border-zinc-700 bg-white/85 dark:bg-zinc-900/70 p-4">
+              <p className="text-xs font-medium uppercase tracking-wide text-zinc-500 dark:text-zinc-400">{card.label}</p>
+              <div className="mt-1 flex items-center justify-between">
+                <p className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">{card.value}</p>
+                <card.icon className="text-blue-500" />
               </div>
+            </div>
+          ))}
+        </div>
+
+        {nextEvent ? (
+          <div className="mt-4 rounded-2xl bg-blue-600 text-white px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-blue-100">Next up</p>
+              <p className="font-semibold">{nextEvent.title}</p>
+              <p className="text-sm text-blue-100">{toReadableDate(nextEvent.start_at)} at {toReadableTime(nextEvent.start_at)}</p>
+            </div>
+            <span className="inline-flex items-center gap-1 rounded-full bg-white/20 px-3 py-1 text-xs">
+              <FiClock />
+              {nextEvent.event_type.replace("_", " ")}
+            </span>
+          </div>
+        ) : null}
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <section className="lg:col-span-1 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm">
+          <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Create event</h2>
+          <p className="text-xs text-zinc-500 mt-1">Use templates for quick planning.</p>
+
+          <div className="mt-3 flex flex-wrap gap-2">
+            {QUICK_TEMPLATES.map((template) => (
+              <button
+                key={template.label}
+                type="button"
+                onClick={() => applyTemplate(template)}
+                className="rounded-full border border-zinc-300 dark:border-zinc-700 px-3 py-1.5 text-xs font-medium text-zinc-700 dark:text-zinc-200 hover:border-blue-400 hover:text-blue-600"
+              >
+                {template.label}
+              </button>
             ))}
           </div>
-        )}
-      </section>
+
+          <form className="mt-4 space-y-3" onSubmit={handleCreate}>
+            <input
+              value={form.title}
+              onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
+              placeholder="Event title"
+              required
+              className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            />
+
+            <textarea
+              value={form.description}
+              onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))}
+              placeholder="Description (optional)"
+              rows={3}
+              className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            />
+
+            <div className="grid grid-cols-2 gap-2">
+              <input
+                type="datetime-local"
+                value={form.start_at}
+                onChange={(e) => setForm((f) => ({ ...f, start_at: e.target.value }))}
+                required
+                className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              />
+              <input
+                type="datetime-local"
+                value={form.end_at}
+                onChange={(e) => setForm((f) => ({ ...f, end_at: e.target.value }))}
+                required
+                className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              />
+            </div>
+
+            <div className="grid grid-cols-2 gap-2">
+              <select
+                value={form.event_type}
+                onChange={(e) => setForm((f) => ({ ...f, event_type: e.target.value }))}
+                className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              >
+                {EVENT_TYPES.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+
+              <select
+                value={form.visibility}
+                onChange={(e) => setForm((f) => ({ ...f, visibility: e.target.value }))}
+                className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              >
+                {VISIBILITY_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </div>
+
+            {form.visibility === "project" && (
+              <select
+                value={form.project_id}
+                onChange={(e) => setForm((f) => ({ ...f, project_id: e.target.value }))}
+                required
+                className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              >
+                <option value="">Select project</option>
+                {projects.map((project) => (
+                  <option key={project.id} value={project.id}>{project.name}</option>
+                ))}
+              </select>
+            )}
+
+            <input
+              value={form.location_or_meet_link}
+              onChange={(e) => setForm((f) => ({ ...f, location_or_meet_link: e.target.value }))}
+              placeholder="Meet link / location"
+              className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            />
+
+            <select
+              value={form.reminder_minutes}
+              onChange={(e) => setForm((f) => ({ ...f, reminder_minutes: e.target.value }))}
+              className="w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+            >
+              {REMINDER_OPTIONS.map((option) => (
+                <option key={option.value || "none"} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+
+            <button
+              type="submit"
+              disabled={saving}
+              className="w-full rounded-lg bg-blue-600 hover:bg-blue-700 text-white py-2.5 text-sm font-semibold disabled:opacity-60"
+            >
+              {saving ? "Saving..." : "Create event"}
+            </button>
+          </form>
+        </section>
+
+        <section className="lg:col-span-2 bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 rounded-2xl p-5 shadow-sm">
+          <div className="flex flex-wrap items-center gap-2 justify-between">
+            <h2 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">Agenda</h2>
+            <div className="flex items-center gap-2 text-xs text-zinc-500">
+              <FiSparkles />
+              Smarter filters and timeline view
+            </div>
+          </div>
+
+          <div className="mt-4 space-y-3 rounded-xl border border-zinc-200 dark:border-zinc-800 p-3 bg-zinc-50/70 dark:bg-zinc-800/30">
+            <div className="flex items-center gap-2">
+              <FiSearch className="text-zinc-400" />
+              <input
+                value={filters.search}
+                onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
+                placeholder="Search title, notes, or location"
+                className="w-full bg-transparent outline-none text-sm"
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {RANGE_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => applyRange(option.value)}
+                  className={`rounded-full px-3 py-1.5 text-xs font-medium border ${filters.range === option.value
+                    ? "border-blue-500 bg-blue-500 text-white"
+                    : "border-zinc-300 dark:border-zinc-700 text-zinc-700 dark:text-zinc-200"}`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-2">
+              <select
+                value={filters.visibility}
+                onChange={(e) => setFilters((f) => ({ ...f, visibility: e.target.value }))}
+                className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              >
+                <option value="">All visibility</option>
+                <option value="personal">Personal</option>
+                <option value="project">Project</option>
+              </select>
+
+              <select
+                value={filters.projectId}
+                onChange={(e) => setFilters((f) => ({ ...f, projectId: e.target.value }))}
+                className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              >
+                <option value="">All projects</option>
+                {projects.map((project) => (
+                  <option key={project.id} value={project.id}>{project.name}</option>
+                ))}
+              </select>
+
+              <select
+                value={filters.eventType}
+                onChange={(e) => setFilters((f) => ({ ...f, eventType: e.target.value }))}
+                className="rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm"
+              >
+                <option value="">All event types</option>
+                {EVENT_TYPES.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+
+              <button
+                type="button"
+                onClick={() => setFilters((f) => ({ ...f, visibility: "", projectId: "", eventType: "", search: "" }))}
+                className="inline-flex items-center justify-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-700 px-3 py-2 text-sm text-zinc-700 dark:text-zinc-200"
+              >
+                <FiFilter />
+                Clear
+              </button>
+            </div>
+          </div>
+
+          {error ? <p className="mt-4 text-sm text-red-600">{error}</p> : null}
+
+          {loading ? (
+            <p className="mt-4 text-sm text-zinc-500">Loading events...</p>
+          ) : grouped.length === 0 ? (
+            <div className="mt-6 rounded-xl border border-dashed border-zinc-300 dark:border-zinc-700 p-8 text-center">
+              <FiCalendar className="mx-auto text-zinc-400" size={20} />
+              <p className="mt-2 text-sm text-zinc-500">No events in this view. Try widening the range or create your next event.</p>
+            </div>
+          ) : (
+            <div className="mt-4 space-y-5">
+              {grouped.map((group) => (
+                <div key={group.date}>
+                  <h3 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">{group.date}</h3>
+                  <div className="mt-2 space-y-2">
+                    {group.events.map((event) => (
+                      <article key={event.id} className="rounded-xl border border-zinc-200 dark:border-zinc-700 p-3 bg-zinc-50/70 dark:bg-zinc-800/50">
+                        <div className="flex flex-wrap justify-between gap-3">
+                          <div>
+                            <p className="font-semibold text-zinc-900 dark:text-zinc-100">{event.title}</p>
+                            <p className="text-xs text-zinc-500 mt-1 flex flex-wrap items-center gap-3">
+                              <span className="inline-flex items-center gap-1"><FiClock />{toReadableTime(event.start_at)} - {toReadableTime(event.end_at)}</span>
+                              <span className="inline-flex items-center gap-1"><FiLayers />{event.visibility}</span>
+                              {event.location_or_meet_link ? <span className="inline-flex items-center gap-1"><FiMapPin />Location set</span> : null}
+                            </p>
+                          </div>
+                          <span className="text-xs rounded-full px-2 py-1 bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300 h-fit">
+                            {event.event_type.replace("_", " ")}
+                          </span>
+                        </div>
+
+                        {event.description ? <p className="text-sm mt-2 text-zinc-700 dark:text-zinc-300">{event.description}</p> : null}
+
+                        {event.location_or_meet_link ? (
+                          <a href={event.location_or_meet_link} target="_blank" rel="noreferrer" className="text-xs text-blue-600 mt-2 inline-block underline break-all">
+                            {event.location_or_meet_link}
+                          </a>
+                        ) : null}
+
+                        {event.event_reminders?.length ? (
+                          <p className="text-xs text-zinc-500 mt-2">
+                            Reminders: {event.event_reminders.map((r) => `${r.minutes_before}m (${r.channel})`).join(", ")}
+                          </p>
+                        ) : null}
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
### Motivation
- Make the Calendar the primary planning surface by hiding the older "Momentum" landing flow and surfacing a richer calendar workspace as the authenticated home route. 
- Provide faster event creation and discovery with templates, smarter filtering, and clearer timeline/agenda views. 
- Improve UX reliability by adding basic validation and clearer empty/loading states for the calendar experience.

### Description
- Route changes: set the authenticated root to `Calendar` and redirect legacy `/momentum` to `/calendar` by updating `app/javascript/components/App.jsx` to use `Navigate` and render `Calendar` at `/`.
- Navigation and title updates: remove the Momentum nav item and its icon from `app/javascript/components/Navbar.jsx` and update `app/javascript/components/PageTitle.jsx` so the home title resolves to `Calendar`.
- Calendar redesign: replace the previous `Calendar.jsx` with a richer workspace that adds a planner header (refresh), metric/stat cards, a “next up” highlight, quick templates for common events, search and event-type filters, visibility/project filters, quick range buttons (`7/30/90` days), improved event cards, and create-event validation (end must be after start) in `app/javascript/pages/Calendar.jsx`.

### Testing
- Ran the frontend build with `npm run build`, which completed successfully.
- Ran unit tests with `npm test` (Vitest), where the existing test file `app/javascript/utils/taskUtils.test.js` passed (3 tests passed).
- Attempted to boot the Rails server with `bin/rails server -p 3000`, but it failed due to a local Ruby version mismatch (`3.2.3` installed vs `3.3.0` required), so end-to-end browser verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c272d1c10832280a22cc5424c5c2e)