### PR TITLE
Fix calendar reminder delivery and add default email reminder option

### DIFF
--- a/app/javascript/pages/Calendar.jsx
+++ b/app/javascript/pages/Calendar.jsx
@@ -117,6 +117,7 @@ const Calendar = () => {
     project_id: "",
     location_or_meet_link: "",
     reminder_minutes: "10",
+    email_reminder_enabled: true,
   });
 
   const load = async () => {
@@ -219,10 +220,19 @@ const Calendar = () => {
       const { data: createdEvent } = await createCalendarEvent(payload);
 
       if (form.reminder_minutes) {
+        const minutesBefore = Number(form.reminder_minutes);
+
         await createEventReminder(createdEvent.id, {
           channel: "in_app",
-          minutes_before: Number(form.reminder_minutes),
+          minutes_before: minutesBefore,
         });
+
+        if (form.email_reminder_enabled) {
+          await createEventReminder(createdEvent.id, {
+            channel: "email",
+            minutes_before: minutesBefore,
+          });
+        }
       }
 
       setForm((prev) => ({
@@ -428,6 +438,16 @@ const Calendar = () => {
                 <option key={option.value || "none"} value={option.value}>{option.label}</option>
               ))}
             </select>
+
+            <label className="flex items-center gap-2 rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800 px-3 py-2 text-sm text-zinc-700 dark:text-zinc-200">
+              <input
+                type="checkbox"
+                checked={form.email_reminder_enabled}
+                onChange={(e) => setForm((f) => ({ ...f, email_reminder_enabled: e.target.checked }))}
+                className="h-4 w-4 rounded border-zinc-300 text-blue-600 focus:ring-blue-500"
+              />
+              Send email notification too
+            </label>
 
             <button
               type="submit"

--- a/app/jobs/event_reminder_job.rb
+++ b/app/jobs/event_reminder_job.rb
@@ -21,7 +21,9 @@ class EventReminderJob < ApplicationJob
         channel: reminder.channel,
         minutes_before: reminder.minutes_before
       }
-    )
+    ) if reminder.channel == 'in_app'
+
+    CalendarEventReminderMailer.reminder(reminder).deliver_later if reminder.channel == 'email'
 
     reminder.update!(state: 'sent', sent_at: Time.current)
   rescue StandardError

--- a/app/mailers/calendar_event_reminder_mailer.rb
+++ b/app/mailers/calendar_event_reminder_mailer.rb
@@ -1,0 +1,14 @@
+class CalendarEventReminderMailer < ApplicationMailer
+  default from: "calendar-reminders@example.com"
+
+  def reminder(event_reminder)
+    @event_reminder = event_reminder
+    @event = event_reminder.calendar_event
+    @user = @event.user
+
+    mail(
+      to: @user.email,
+      subject: "Reminder: #{@event.title} at #{@event.start_at.in_time_zone.strftime('%b %-d, %Y %I:%M %p')}"
+    )
+  end
+end

--- a/app/models/event_reminder.rb
+++ b/app/models/event_reminder.rb
@@ -29,8 +29,12 @@ class EventReminder < ApplicationRecord
   end
 
   def schedule_delivery_job
-    return if send_at.blank? || send_at <= Time.current
+    return if send_at.blank?
 
-    EventReminderJob.set(wait_until: send_at).perform_later(id)
+    if send_at <= Time.current
+      EventReminderJob.perform_later(id)
+    else
+      EventReminderJob.set(wait_until: send_at).perform_later(id)
+    end
   end
 end

--- a/app/views/calendar_event_reminder_mailer/reminder.html.erb
+++ b/app/views/calendar_event_reminder_mailer/reminder.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <h1>Hi <%= @user.first_name.presence || @user.email %>,</h1>
+    <p>This is a reminder for your calendar event.</p>
+    <p><strong>Title:</strong> <%= @event.title %></p>
+    <p><strong>Starts at:</strong> <%= @event.start_at.in_time_zone.strftime('%B %d, %Y at %I:%M %p') %></p>
+    <p><strong>Reminder lead time:</strong> <%= @event_reminder.minutes_before %> minutes before</p>
+    <% if @event.description.present? %>
+      <p><strong>Description:</strong> <%= @event.description %></p>
+    <% end %>
+    <% if @event.location_or_meet_link.present? %>
+      <p><strong>Location / Link:</strong> <%= @event.location_or_meet_link %></p>
+    <% end %>
+    <p>Please open your calendar to review details.</p>
+  </body>
+</html>

--- a/app/views/calendar_event_reminder_mailer/reminder.text.erb
+++ b/app/views/calendar_event_reminder_mailer/reminder.text.erb
@@ -1,0 +1,15 @@
+Hi <%= @user.first_name.presence || @user.email %>,
+
+This is a reminder for your calendar event.
+
+Title: <%= @event.title %>
+Starts at: <%= @event.start_at.in_time_zone.strftime('%B %d, %Y at %I:%M %p') %>
+Reminder lead time: <%= @event_reminder.minutes_before %> minutes before
+<% if @event.description.present? %>
+Description: <%= @event.description %>
+<% end %>
+<% if @event.location_or_meet_link.present? %>
+Location / Link: <%= @event.location_or_meet_link %>
+<% end %>
+
+Please open your calendar to review details.


### PR DESCRIPTION
### Motivation
- Reminders whose computed `send_at` time was already in the past were never delivered because jobs were only scheduled when `send_at > Time.current`, causing missed notifications.
- Provide users an easy, opt-out way to receive email reminders in addition to in-app notifications by adding a default-on checkbox to the Calendar create-event form.

### Description
- Change scheduling in `EventReminder#schedule_delivery_job` to enqueue immediately when `send_at <= Time.current` and otherwise schedule via `set(wait_until: send_at)` to avoid silently skipping past-due reminders.
- Update `EventReminderJob` so `channel == 'in_app'` creates a `Notification` and `channel == 'email'` sends mail via a new mailer, then mark the reminder as `sent` on success.
- Add `CalendarEventReminderMailer` with HTML and plain-text templates containing event title, start time, lead time, and optional description/location.
- Add `email_reminder_enabled` (default `true`) to the Calendar create-event form in `app/javascript/pages/Calendar.jsx` and create both `in_app` and `email` reminders when the checkbox is selected.

### Testing
- Ran Ruby syntax checks with `ruby -c` on the updated files which returned `Syntax OK` for `EventReminder`, `EventReminderJob`, and the new mailer.
- Attempted to run the test suite with `bin/rails test`, but it failed in this environment due to Bundler reporting a Ruby version mismatch (`current 3.2.3` vs Gemfile `3.3.0`).
- Tried an automated Playwright check to load `/calendar` for a visual validation, but the local app was not reachable (`ERR_EMPTY_RESPONSE`) so the page check could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c30dcbfac83228846393dd8922f90)