### PR TITLE
Add owner 'Login as user' admin impersonation flow

### DIFF
--- a/app/controllers/api/admin_sessions_controller.rb
+++ b/app/controllers/api/admin_sessions_controller.rb
@@ -1,0 +1,56 @@
+class Api::AdminSessionsController < Api::BaseController
+  include Rails.application.routes.url_helpers
+
+  def create
+    return head :forbidden unless current_user&.owner? || current_user&.admin?
+
+    user = User.find_by(id: params[:user_id])
+    return render json: { error: 'User not found' }, status: :not_found unless user
+
+    return render json: { error: 'Account locked' }, status: :unprocessable_entity if user.locked?
+
+    set_jwt_cookie!(user)
+    render json: {
+      message: 'Impersonation login successful',
+      user: user_payload(user),
+      exp: 15.minutes.from_now.to_i
+    }
+  end
+
+  private
+
+  def user_payload(user)
+    profile_picture_url = rails_blob_url(user.profile_picture, only_path: true) if user.profile_picture.attached?
+    cover_photo_url = rails_blob_url(user.cover_photo, only_path: true) if user.cover_photo.attached?
+
+    user.as_json(include: { roles: { only: [:name] } }).merge(
+      profile_picture: profile_picture_url,
+      cover_photo: cover_photo_url,
+      landing_page: user.landing_page,
+      phone_number: user.phone_number,
+      bio: user.bio,
+      social_links: user.social_links || {}
+    )
+  end
+
+  def set_jwt_cookie!(user)
+    access_token = JwtService.encode({ user_id: user.id }, exp: 15.minutes.from_now)
+    refresh_token = JwtService.encode({ user_id: user.id }, exp: 7.days.from_now)
+
+    cookies.signed[:access_token] = {
+      value: access_token,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :strict,
+      expires: 15.minutes.from_now
+    }
+
+    cookies.signed[:refresh_token] = {
+      value: refresh_token,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax,
+      expires: 7.days.from_now
+    }
+  end
+end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -26,6 +26,7 @@ import WorkLog from "../pages/WorkLog";
 import Settings from "../pages/Settings";
 import PageTitle from "./PageTitle";
 import Calendar from "../pages/Calendar";
+import AdminImpersonation from "../pages/AdminImpersonation";
 import PageLoader from "./ui/PageLoader";
 
 const RouteTransitionLoader = ({ children }) => {
@@ -81,6 +82,7 @@ const App = () => {
               <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><SprintDashboard /></ProjectMemberRoute>} />
               <Route path="/users" element={<PrivateRoute ownerOnly><Users /></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
+              <Route path="/admin/login-as-user" element={<PrivateRoute ownerOnly><AdminImpersonation /></PrivateRoute>} />
               <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
             </Routes>
           </RouteTransitionLoader>

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -337,14 +337,25 @@ const Navbar = () => {
                       </NavLink>
 
                       {isOwner && (
-                        <NavLink
-                          to="/users"
-                          onClick={() => setIsProfileOpen(false)}
-                          className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
-                        >
-                          <FiUsers className="h-4 w-4 text-blue-500" />
-                          User Management
-                        </NavLink>
+                        <>
+                          <NavLink
+                            to="/users"
+                            onClick={() => setIsProfileOpen(false)}
+                            className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                          >
+                            <FiUsers className="h-4 w-4 text-blue-500" />
+                            User Management
+                          </NavLink>
+
+                          <NavLink
+                            to="/admin/login-as-user"
+                            onClick={() => setIsProfileOpen(false)}
+                            className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                          >
+                            <FiLogOut className="h-4 w-4 text-blue-500" />
+                            Login as User
+                          </NavLink>
+                        </>
                       )}
 
                       <NavLink

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -95,6 +95,7 @@ export const updateUser = (id, data) =>
     headers: { 'Content-Type': 'multipart/form-data' },
   });
 export const fetchDepartments = () => api.get('/departments.json');
+export const adminImpersonate = (userId) => api.post('/admin/impersonate', { user_id: userId });
 
 // ISSUE TRACKER
 const buildIssuePayload = (raw) => {

--- a/app/javascript/pages/AdminImpersonation.jsx
+++ b/app/javascript/pages/AdminImpersonation.jsx
@@ -1,0 +1,123 @@
+import React, { useContext, useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { LogIn, Search, Shield } from "lucide-react";
+import { toast } from "react-hot-toast";
+import { getUsers, adminImpersonate } from "../components/api";
+import { AuthContext } from "../context/AuthContext";
+
+const AdminImpersonation = () => {
+  const navigate = useNavigate();
+  const { setUser } = useContext(AuthContext);
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [busyUserId, setBusyUserId] = useState(null);
+  const [search, setSearch] = useState("");
+
+  useEffect(() => {
+    const loadUsers = async () => {
+      setLoading(true);
+      try {
+        const { data } = await getUsers();
+        setUsers(Array.isArray(data) ? data : []);
+      } catch (error) {
+        console.error("Failed to fetch users", error);
+        toast.error("Could not load users");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadUsers();
+  }, []);
+
+  const filteredUsers = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return users;
+    return users.filter((user) => {
+      const haystack = `${user.first_name || ""} ${user.last_name || ""} ${user.email || ""}`.toLowerCase();
+      return haystack.includes(term);
+    });
+  }, [search, users]);
+
+  const handleImpersonate = async (userId) => {
+    try {
+      setBusyUserId(userId);
+      const { data } = await adminImpersonate(userId);
+      setUser(data.user);
+      toast.success(`Logged in as ${data.user.first_name} ${data.user.last_name}`);
+      navigate(data.user.landing_page ? `/${data.user.landing_page}` : "/");
+    } catch (error) {
+      console.error("Failed to impersonate user", error);
+      toast.error(error?.response?.data?.error || "Unable to login as user");
+    } finally {
+      setBusyUserId(null);
+    }
+  };
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8">
+      <div className="mb-6 rounded-2xl border border-blue-100 bg-blue-50 p-5">
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-blue-900">
+          <Shield className="h-6 w-6" />
+          Admin Login as User
+        </h1>
+        <p className="mt-2 text-sm text-blue-800">
+          Select a user below to instantly sign in as that account for support or troubleshooting.
+        </p>
+      </div>
+
+      <div className="mb-5 relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+        <input
+          type="text"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          placeholder="Search by name or email"
+          className="w-full rounded-xl border border-gray-200 bg-white pl-10 pr-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+      </div>
+
+      {loading ? (
+        <div className="rounded-xl border border-gray-200 bg-white p-6 text-sm text-gray-500">Loading users…</div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Name</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Email</th>
+                <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-gray-500">Action</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {filteredUsers.map((user) => (
+                <tr key={user.id}>
+                  <td className="px-4 py-3 text-sm text-gray-900">{[user.first_name, user.last_name].filter(Boolean).join(" ") || "—"}</td>
+                  <td className="px-4 py-3 text-sm text-gray-600">{user.email}</td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      type="button"
+                      onClick={() => handleImpersonate(user.id)}
+                      disabled={busyUserId === user.id}
+                      className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-60"
+                    >
+                      <LogIn className="h-4 w-4" />
+                      {busyUserId === user.id ? "Logging in…" : "Login as user"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+              {filteredUsers.length === 0 && (
+                <tr>
+                  <td colSpan={3} className="px-4 py-8 text-center text-sm text-gray-500">No users found.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AdminImpersonation;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Rails.application.routes.draw do
     post 'keka/refresh', to: 'keka#refresh'
 
     resources :users, only: [:index, :show, :update, :destroy]
+    post 'admin/impersonate', to: 'admin_sessions#create'
     resources :posts, only: [:index, :create, :update, :destroy] do
       resources :comments, only: [:index, :create, :destroy]
       member do


### PR DESCRIPTION
### Motivation
- Provide owners/admins a quick way to sign in as any user for support or troubleshooting without needing passwords.

### Description
- Added `POST /api/admin/impersonate` routed to `Api::AdminSessionsController#create` which authorizes owner/admin roles, validates the target user, checks for locked accounts, issues access and refresh JWT cookies, and returns the standard user payload and expiry.
- Implemented a new owner-only React page `AdminImpersonation` at `/admin/login-as-user` that lists and searches users and triggers the impersonation flow when the admin clicks the action button.
- Wired frontend changes: added `adminImpersonate(userId)` API helper, inserted the new route in `App.jsx`, and added a profile-menu link `Login as User` for owners in `Navbar.jsx`.

### Testing
- Ran `npm run -s build` which completed successfully.
- Ran `npm run -s test` (Vitest) and unit tests passed.
- Attempted `bin/rails routes` to validate Rails routing but the local environment reported a Ruby/Gemfile version mismatch, so server-side route validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c777ab7c8322b7e9ffdd936731aa)