### PR TITLE
Make Users page visible to all authenticated users, add pagination and profile links

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -82,7 +82,7 @@ const App = () => {
               <Route path="/projects" element={<PrivateRoute><Projects /></PrivateRoute>} />
               <Route path="/teams" element={<PrivateRoute><Teams /></PrivateRoute>} />
               <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><SprintDashboard /></ProjectMemberRoute>} />
-              <Route path="/users" element={<PrivateRoute ownerOnly><Users /></PrivateRoute>} />
+              <Route path="/users" element={<PrivateRoute><Users /></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
               <Route path="/admin/login-as-user" element={<PrivateRoute ownerOnly><AdminImpersonation /></PrivateRoute>} />
               <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -336,26 +336,24 @@ const Navbar = () => {
                         My Profile
                       </NavLink>
 
-                      {isOwner && (
-                        <>
-                          <NavLink
-                            to="/users"
-                            onClick={() => setIsProfileOpen(false)}
-                            className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
-                          >
-                            <FiUsers className="h-4 w-4 text-blue-500" />
-                            User Management
-                          </NavLink>
+                      <NavLink
+                        to="/users"
+                        onClick={() => setIsProfileOpen(false)}
+                        className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                      >
+                        <FiUsers className="h-4 w-4 text-blue-500" />
+                        User Management
+                      </NavLink>
 
-                          <NavLink
-                            to="/admin/login-as-user"
-                            onClick={() => setIsProfileOpen(false)}
-                            className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
-                          >
-                            <FiLogOut className="h-4 w-4 text-blue-500" />
-                            Login as User
-                          </NavLink>
-                        </>
+                      {isOwner && (
+                        <NavLink
+                          to="/admin/login-as-user"
+                          onClick={() => setIsProfileOpen(false)}
+                          className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                        >
+                          <FiLogOut className="h-4 w-4 text-blue-500" />
+                          Login as User
+                        </NavLink>
                       )}
 
                       <NavLink
@@ -547,6 +545,15 @@ const Navbar = () => {
                         </p>
                       </div>
                     </div>
+
+                    <NavLink
+                      to="/users"
+                      onClick={() => setIsMobileMenuOpen(false)}
+                      className="flex items-center gap-3 px-5 py-3 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                    >
+                      <FiUsers className="h-4 w-4" />
+                      User Management
+                    </NavLink>
 
                     <NavLink
                       to="/settings"


### PR DESCRIPTION
### Motivation
- Allow regular authenticated users to browse the user directory while keeping management actions restricted to owners. 
- Improve usability of the Users page when there are many accounts by adding client-side pagination and clear navigation to individual profiles. 

### Description
- Removed the owner-only guard on the `/users` route so the page is accessible to all authenticated users by updating `app/javascript/components/App.jsx`. 
- Added a persistent "User Management" entry to the desktop profile dropdown and the mobile menu so authenticated users can reach `/users` from the navbar by changing `app/javascript/components/Navbar.jsx`. 
- Enhanced `app/javascript/pages/Users.jsx` by importing `AuthContext` and `Link`, adding `canManageUsers` (owner check), and hiding edit/delete/photo-edit controls for non-owners. 
- Implemented client-side pagination (8 users per page) with `paginatedUsers`, automatic page reset on search changes, page bounds correction, numbered page buttons, and Previous/Next controls, and added a "View profile" link on each card that navigates to `/profile/:userId`. 

### Testing
- Ran the JavaScript test suite with `npm test` (Vitest) and all tests passed. 
- Attempted to run `bin/dev` to validate the running app, but the environment failed to install `foreman` due to a `403 Forbidden` gem fetch error, so live UI startup / screenshot capture was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992e6dabbc08322895749d147c84df3)