### PR TITLE
Fix unauthorized API response format handling

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -19,8 +19,6 @@ class Api::BaseController < ApplicationController
   private
 
   def handle_unauthorized
-    respond_to do |format|
-      format.json { render json: { error: "Unauthorized" }, status: :unauthorized }
-    end
+    render json: { error: "Unauthorized" }, status: :unauthorized
   end
 end


### PR DESCRIPTION
### Motivation
- `handle_unauthorized` used `respond_to` format negotiation which could raise `ActionController::UnknownFormat` and yield a `406 Not Acceptable` for non-JSON requests, so the API should always return a consistent JSON `401` payload.

### Description
- Replace the `respond_to` block in `Api::BaseController#handle_unauthorized` with a direct `render json: { error: "Unauthorized" }, status: :unauthorized` to always return a JSON 401 response.

### Testing
- Ran `bundle exec ruby -c app/controllers/api/base_controller.rb` and `bundle exec ruby -c app/controllers/api/comments_controller.rb`, both succeeded with `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ec8c61748322a834361bc2a4034b)