### PR TITLE
Allow API auth to fall back to Devise session user

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,21 +2,32 @@ class Api::BaseController < ApplicationController
   protect_from_forgery with: :null_session
   before_action :authenticate_user!
 
-  attr_reader :current_user
-
   def authenticate_user!
-    token = cookies.signed[:access_token]
-    payload = JwtService.decode(token)
-
-    @current_user = User.find_by(id: payload["user_id"]) if payload
+    @current_user = jwt_cookie_user || devise_session_user
     Current.user = @current_user
 
     handle_unauthorized unless @current_user
-  rescue
+  rescue StandardError
     handle_unauthorized
   end
 
+  def current_user
+    @current_user || devise_session_user
+  end
+
   private
+
+  def jwt_cookie_user
+    token = cookies.signed[:access_token]
+    payload = JwtService.decode(token)
+    User.find_by(id: payload["user_id"]) if payload
+  end
+
+  def devise_session_user
+    return nil unless defined?(super)
+
+    super
+  end
 
   def handle_unauthorized
     render json: { error: "Unauthorized" }, status: :unauthorized


### PR DESCRIPTION
### Motivation
- API endpoints were returning `401 Unauthorized` for requests authenticated via Devise session when the signed JWT cookie was not present, causing client flows like `POST /api/posts/:post_id/comments` to fail.

### Description
- Update `Api::BaseController#authenticate_user!` to resolve the user via JWT cookie first and then fall back to Devise session with `jwt_cookie_user || devise_session_user`.
- Add an explicit `current_user` method in the API base controller to consistently return the resolved API user or Devise fallback via `@current_user || devise_session_user`.
- Extract helper methods `jwt_cookie_user` and `devise_session_user` and narrow the rescue clause to `StandardError` for clearer error handling.
- Remove the previous `attr_reader :current_user` approach so controllers use the new resolution logic.

### Testing
- Ran Ruby syntax check with `bundle exec ruby -c app/controllers/api/base_controller.rb`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992ee9689bc8322a767ba4ce63987d3)