### PR TITLE
Add Departments module with member management UI and menu entry

### DIFF
--- a/app/controllers/api/departments_controller.rb
+++ b/app/controllers/api/departments_controller.rb
@@ -1,5 +1,101 @@
 class Api::DepartmentsController < Api::BaseController
+  before_action :set_department, only: [:show, :update, :destroy, :members, :update_members]
+  before_action :authorize_admin!, only: [:create, :update, :destroy, :update_members]
+
   def index
-    render json: Department.order(:name).select(:id, :name)
+    departments = Department.includes(:users).order(:name)
+
+    render json: departments.map { |department| serialize_department(department) }
+  end
+
+  def show
+    render json: serialize_department(@department, include_members: true)
+  end
+
+  def create
+    department = Department.new(department_params)
+
+    if department.save
+      render json: serialize_department(department), status: :created
+    else
+      render json: { errors: department.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @department.update(department_params)
+      render json: serialize_department(@department)
+    else
+      render json: { errors: @department.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @department.destroy
+    head :no_content
+  end
+
+  def members
+    render json: {
+      department: serialize_department(@department),
+      users: serialized_users(@department.users.order(:first_name, :last_name, :email))
+    }
+  end
+
+  def update_members
+    user_ids = Array(params[:user_ids]).map(&:to_i).uniq
+
+    User.transaction do
+      @department.users.update_all(department_id: nil)
+      User.where(id: user_ids).update_all(department_id: @department.id)
+    end
+
+    @department.reload
+
+    render json: {
+      department: serialize_department(@department),
+      users: serialized_users(@department.users.order(:first_name, :last_name, :email)),
+      message: "Department members updated successfully."
+    }
+  end
+
+  private
+
+  def set_department
+    @department = Department.find(params[:id])
+  end
+
+  def department_params
+    params.require(:department).permit(:name)
+  end
+
+  def serialize_department(department, include_members: false)
+    payload = {
+      id: department.id,
+      name: department.name,
+      users_count: department.users.size,
+      updated_at: department.updated_at
+    }
+
+    payload[:members] = serialized_users(department.users.order(:first_name, :last_name, :email)) if include_members
+    payload
+  end
+
+  def serialized_users(users)
+    users.map do |user|
+      {
+        id: user.id,
+        first_name: user.first_name,
+        last_name: user.last_name,
+        email: user.email,
+        job_title: user.job_title,
+        department_id: user.department_id,
+        full_name: user.full_name
+      }
+    end
+  end
+
+  def authorize_admin!
+    head :forbidden unless current_user&.admin? || current_user&.owner?
   end
 end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -28,6 +28,7 @@ import Settings from "../pages/Settings";
 import PageTitle from "./PageTitle";
 import Calendar from "../pages/Calendar";
 import AdminImpersonation from "../pages/AdminImpersonation";
+import Departments from "../pages/Departments";
 import PageLoader from "./ui/PageLoader";
 
 const RouteTransitionLoader = ({ children }) => {
@@ -83,6 +84,7 @@ const App = () => {
               <Route path="/teams" element={<PrivateRoute><Teams /></PrivateRoute>} />
               <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><SprintDashboard /></ProjectMemberRoute>} />
               <Route path="/users" element={<PrivateRoute><Users /></PrivateRoute>} />
+              <Route path="/departments" element={<PrivateRoute><Departments /></PrivateRoute>} />
               <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
               <Route path="/admin/login-as-user" element={<PrivateRoute ownerOnly><AdminImpersonation /></PrivateRoute>} />
               <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -8,7 +8,7 @@ import NotificationCenter from "./NotificationCenter";
 // Icons
 import {
   FiChevronDown, FiMenu, FiX, FiLogOut, FiUser,
-  FiUsers, FiBriefcase, FiLayers, FiBook,
+  FiUsers, FiBriefcase, FiLayers, FiBook, FiGrid,
   FiMessageSquare, FiSettings, FiZap, FiAward, FiFileText,
   FiClock, FiCalendar
 } from "react-icons/fi";
@@ -345,6 +345,15 @@ const Navbar = () => {
                         User Management
                       </NavLink>
 
+                      <NavLink
+                        to="/departments"
+                        onClick={() => setIsProfileOpen(false)}
+                        className="flex items-center gap-3 w-full px-3 py-2.5 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-700"
+                      >
+                        <FiGrid className="h-4 w-4 text-blue-500" />
+                        Departments
+                      </NavLink>
+
                       {isOwner && (
                         <NavLink
                           to="/admin/login-as-user"
@@ -553,6 +562,15 @@ const Navbar = () => {
                     >
                       <FiUsers className="h-4 w-4" />
                       User Management
+                    </NavLink>
+
+                    <NavLink
+                      to="/departments"
+                      onClick={() => setIsMobileMenuOpen(false)}
+                      className="flex items-center gap-3 px-5 py-3 text-sm rounded-lg hover:bg-zinc-100 dark:hover:bg-zinc-800"
+                    >
+                      <FiGrid className="h-4 w-4" />
+                      Departments
                     </NavLink>
 
                     <NavLink

--- a/app/javascript/components/PageTitle.jsx
+++ b/app/javascript/components/PageTitle.jsx
@@ -22,6 +22,7 @@ const PageTitle = () => {
       "/projects": "Projects",
       "/teams": "Teams",
       "/users": "Users",
+      "/departments": "Departments",
       "/admin": "Admin",
       "/settings": "Settings",
     };

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -95,6 +95,11 @@ export const updateUser = (id, data) =>
     headers: { 'Content-Type': 'multipart/form-data' },
   });
 export const fetchDepartments = () => api.get('/departments.json');
+export const createDepartment = (data) => api.post('/departments.json', { department: data });
+export const updateDepartment = (id, data) => api.patch(`/departments/${id}.json`, { department: data });
+export const deleteDepartment = (id) => api.delete(`/departments/${id}.json`);
+export const fetchDepartmentMembers = (id) => api.get(`/departments/${id}/members.json`);
+export const updateDepartmentMembers = (id, userIds) => api.patch(`/departments/${id}/update_members.json`, { user_ids: userIds });
 export const adminImpersonate = (userId) => api.post('/admin/impersonate', { user_id: userId });
 
 // ISSUE TRACKER

--- a/app/javascript/pages/Departments.jsx
+++ b/app/javascript/pages/Departments.jsx
@@ -1,0 +1,264 @@
+import React, { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  FiBuilding,
+  FiEdit2,
+  FiPlus,
+  FiSearch,
+  FiTrash2,
+  FiUsers,
+  FiUserPlus,
+  FiX,
+  FiCheck,
+} from "react-icons/fi";
+import {
+  createDepartment,
+  deleteDepartment,
+  fetchDepartments,
+  getUsers,
+  updateDepartment,
+  updateDepartmentMembers,
+} from "../components/api";
+
+const emptyForm = { name: "" };
+
+const Departments = () => {
+  const [departments, setDepartments] = useState([]);
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [form, setForm] = useState(emptyForm);
+  const [editingId, setEditingId] = useState(null);
+  const [saving, setSaving] = useState(false);
+
+  const [memberModal, setMemberModal] = useState({ open: false, department: null });
+  const [selectedUserIds, setSelectedUserIds] = useState([]);
+  const [savingMembers, setSavingMembers] = useState(false);
+
+  const loadData = async () => {
+    setLoading(true);
+    try {
+      const [deptRes, usersRes] = await Promise.all([fetchDepartments(), getUsers()]);
+      setDepartments(Array.isArray(deptRes.data) ? deptRes.data : []);
+      setUsers(Array.isArray(usersRes.data) ? usersRes.data : []);
+    } catch (error) {
+      toast.error(error?.response?.data?.error || "Failed to load departments.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadData();
+  }, []);
+
+  const filteredDepartments = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    if (!term) return departments;
+    return departments.filter((department) => department.name.toLowerCase().includes(term));
+  }, [departments, search]);
+
+  const unassignedUsersCount = useMemo(
+    () => users.filter((user) => !user.department_id).length,
+    [users]
+  );
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!form.name.trim()) return toast.error("Department name is required.");
+
+    setSaving(true);
+    try {
+      if (editingId) {
+        await updateDepartment(editingId, { name: form.name.trim() });
+        toast.success("Department updated.");
+      } else {
+        await createDepartment({ name: form.name.trim() });
+        toast.success("Department created.");
+      }
+      setForm(emptyForm);
+      setEditingId(null);
+      loadData();
+    } catch (error) {
+      toast.error(error?.response?.data?.errors?.[0] || "Unable to save department.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const onEdit = (department) => {
+    setEditingId(department.id);
+    setForm({ name: department.name });
+  };
+
+  const onDelete = async (department) => {
+    if (!window.confirm(`Delete ${department.name}? Users will become unassigned.`)) return;
+    try {
+      await deleteDepartment(department.id);
+      toast.success("Department deleted.");
+      if (editingId === department.id) {
+        setEditingId(null);
+        setForm(emptyForm);
+      }
+      loadData();
+    } catch (error) {
+      toast.error(error?.response?.data?.errors?.[0] || "Unable to delete department.");
+    }
+  };
+
+  const openMembersModal = (department) => {
+    setMemberModal({ open: true, department });
+    setSelectedUserIds(users.filter((u) => u.department_id === department.id).map((u) => u.id));
+  };
+
+  const closeMembersModal = () => {
+    setMemberModal({ open: false, department: null });
+    setSelectedUserIds([]);
+  };
+
+  const toggleUser = (userId) => {
+    setSelectedUserIds((prev) =>
+      prev.includes(userId) ? prev.filter((id) => id !== userId) : [...prev, userId]
+    );
+  };
+
+  const saveMembers = async () => {
+    if (!memberModal.department) return;
+    setSavingMembers(true);
+    try {
+      await updateDepartmentMembers(memberModal.department.id, selectedUserIds);
+      toast.success("Department members saved.");
+      closeMembersModal();
+      loadData();
+    } catch (error) {
+      toast.error(error?.response?.data?.errors?.[0] || "Unable to update members.");
+    } finally {
+      setSavingMembers(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 px-4 py-8 sm:px-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <div className="rounded-2xl bg-gradient-to-r from-indigo-600 to-blue-600 p-6 text-white shadow">
+          <h1 className="text-2xl font-bold">Department Management</h1>
+          <p className="mt-1 text-sm text-blue-100">Create teams by department and bulk-assign users in one place.</p>
+          <div className="mt-4 flex flex-wrap gap-3 text-sm">
+            <span className="rounded-full bg-white/20 px-3 py-1">{departments.length} Departments</span>
+            <span className="rounded-full bg-white/20 px-3 py-1">{users.length} Total Users</span>
+            <span className="rounded-full bg-white/20 px-3 py-1">{unassignedUsersCount} Unassigned</span>
+          </div>
+        </div>
+
+        <div className="grid gap-6 lg:grid-cols-3">
+          <form onSubmit={handleSubmit} className="rounded-2xl bg-white p-5 shadow-sm border border-gray-100 space-y-4">
+            <h2 className="text-lg font-semibold flex items-center gap-2 text-gray-800">
+              <FiBuilding /> {editingId ? "Edit Department" : "Create Department"}
+            </h2>
+            <div>
+              <label className="text-xs font-semibold uppercase text-gray-500">Department Name</label>
+              <input
+                value={form.name}
+                onChange={(e) => setForm({ name: e.target.value })}
+                placeholder="e.g., Engineering"
+                className="mt-1 w-full rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-indigo-500"
+              />
+            </div>
+            <div className="flex gap-2">
+              <button disabled={saving} className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60">
+                <FiPlus /> {saving ? "Saving..." : editingId ? "Update" : "Create"}
+              </button>
+              {editingId && (
+                <button type="button" onClick={() => { setEditingId(null); setForm(emptyForm); }} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-100">
+                  Cancel
+                </button>
+              )}
+            </div>
+          </form>
+
+          <div className="rounded-2xl bg-white p-5 shadow-sm border border-gray-100 lg:col-span-2">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold text-gray-800">Department Directory</h2>
+              <div className="relative w-full max-w-xs">
+                <FiSearch className="absolute left-3 top-2.5 text-gray-400" />
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search department"
+                  className="w-full rounded-lg border border-gray-200 py-2 pl-9 pr-3 text-sm outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {loading ? (
+                <p className="text-sm text-gray-500">Loading departments...</p>
+              ) : filteredDepartments.length === 0 ? (
+                <p className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-sm text-gray-500">No departments found.</p>
+              ) : (
+                filteredDepartments.map((department) => (
+                  <div key={department.id} className="rounded-xl border border-gray-200 bg-gray-50 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <p className="font-semibold text-gray-800">{department.name}</p>
+                        <p className="text-xs text-gray-500 flex items-center gap-1 mt-1"><FiUsers /> {department.users_count || 0} members</p>
+                      </div>
+                      <div className="flex gap-2">
+                        <button onClick={() => openMembersModal(department)} className="inline-flex items-center gap-1 rounded-lg bg-blue-100 px-3 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-200">
+                          <FiUserPlus /> Members
+                        </button>
+                        <button onClick={() => onEdit(department)} className="inline-flex items-center gap-1 rounded-lg bg-amber-100 px-3 py-1.5 text-xs font-medium text-amber-700 hover:bg-amber-200">
+                          <FiEdit2 /> Edit
+                        </button>
+                        <button onClick={() => onDelete(department)} className="inline-flex items-center gap-1 rounded-lg bg-red-100 px-3 py-1.5 text-xs font-medium text-red-700 hover:bg-red-200">
+                          <FiTrash2 /> Delete
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {memberModal.open && memberModal.department && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-2xl rounded-2xl bg-white p-5 shadow-xl">
+            <div className="mb-4 flex items-center justify-between">
+              <h3 className="text-lg font-semibold">Manage Members · {memberModal.department.name}</h3>
+              <button onClick={closeMembersModal} className="rounded-md p-1.5 text-gray-500 hover:bg-gray-100"><FiX /></button>
+            </div>
+
+            <div className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
+              {users.map((user) => {
+                const checked = selectedUserIds.includes(user.id);
+                return (
+                  <label key={user.id} className={`flex cursor-pointer items-center justify-between rounded-lg border p-3 ${checked ? "border-indigo-300 bg-indigo-50" : "border-gray-200"}`}>
+                    <div>
+                      <p className="text-sm font-medium text-gray-800">{user.first_name} {user.last_name}</p>
+                      <p className="text-xs text-gray-500">{user.email}</p>
+                    </div>
+                    <button type="button" onClick={() => toggleUser(user.id)} className={`inline-flex h-7 w-7 items-center justify-center rounded-md ${checked ? "bg-indigo-600 text-white" : "bg-gray-100 text-gray-500"}`}>
+                      <FiCheck className="text-sm" />
+                    </button>
+                  </label>
+                );
+              })}
+            </div>
+
+            <div className="mt-4 flex justify-end gap-2">
+              <button onClick={closeMembersModal} className="rounded-lg border border-gray-200 px-4 py-2 text-sm text-gray-600 hover:bg-gray-100">Cancel</button>
+              <button disabled={savingMembers} onClick={saveMembers} className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 disabled:opacity-60">
+                {savingMembers ? "Saving..." : "Save Members"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Departments;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,12 @@ Rails.application.routes.draw do
 
     resources :items, only: [:index, :create, :update, :destroy]
     resources :issues, only: [:index, :create, :update, :destroy]
-    resources :departments, only: [:index]
+    resources :departments do
+      member do
+        get :members
+        patch :update_members
+      end
+    end
 
     resources :knowledge_bookmarks, only: [:index, :create, :update, :destroy] do
       member do


### PR DESCRIPTION
### Motivation
- Provide a dedicated Departments module so admins can create/edit/delete departments and bulk-assign users into departments from the UI. 
- Surface Departments in the profile/menu next to existing items (Admin Panel, My Profile, User Management, Settings) for easy access. 
- Reuse existing backend user/department relations and expose safe endpoints to support the new UI.

### Description
- Added a new API controller `Api::DepartmentsController` implementing index/show/create/update/destroy, a `members` endpoint, and an authoritative `update_members` action that bulk-reassigns users to a department; mutating actions are guarded to `admin` or `owner` via `authorize_admin!`. (`app/controllers/api/departments_controller.rb`).
- Extended routes to support full department REST actions plus member management routes (`get :members`, `patch :update_members`). (`config/routes.rb`).
- Added frontend API helpers: `createDepartment`, `updateDepartment`, `deleteDepartment`, `fetchDepartmentMembers`, and `updateDepartmentMembers` so the React UI can manage departments end-to-end. (`app/javascript/components/api.jsx`).
- Implemented a new React `Departments` page with create/edit/delete, searchable list with member counts, top-level stats, and a member-management modal for bulk assigning users. (`app/javascript/pages/Departments.jsx`).
- Wired the page into app routing at `/departments`, added it to `PageTitle` mapping, and added a new **Departments** entry in the profile dropdown and mobile menu (desktop + mobile). (`app/javascript/components/App.jsx`, `app/javascript/components/PageTitle.jsx`, `app/javascript/components/Navbar.jsx`).
- `update_members` is intentionally implemented as a replace operation for clarity: existing users in the department are first unassigned, then selected users are assigned.

### Testing
- Ran frontend build with `npm run build`, which completed successfully. ✅
- Attempted to list Rails routes with `bin/rails routes | rg departments` but the run was blocked by a local Ruby version mismatch (repo requires `3.3.0`, runtime is `3.2.3`), so Rails route output could not be validated here. ⚠️
- Attempted a Playwright page screenshot of `/departments` to validate the UI, but the browser process crashed in this environment (SIGSEGV) so no screenshot was produced. ⚠️

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69940aca5ea4832288e62d8e821c2ee1)