### PR TITLE
Fix JSX parse error in Departments.jsx

### DIFF
--- a/app/javascript/pages/Departments.jsx
+++ b/app/javascript/pages/Departments.jsx
@@ -263,8 +263,6 @@ const Departments = () => {
             </div>
           </div>
         </div>
-      </div>
-
       {memberModal.open && memberModal.department && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
           <div className="w-full max-w-3xl rounded-2xl bg-white p-5 shadow-xl">


### PR DESCRIPTION
### Motivation
- A stray closing `</div>` prematurely closed the component layout in `app/javascript/pages/Departments.jsx`, causing a JSX parse error and breaking the Vite/esbuild transform when rendering the `memberModal` conditional block.

### Description
- Removed the extra closing `</div>` so the `memberModal.open && memberModal.department && (...)` conditional is correctly nested inside the component's return tree in `app/javascript/pages/Departments.jsx`.

### Testing
- Ran `npm run build` successfully and confirmed the esbuild/Vite transform completes without the previous syntax error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994454ab6f8832281da9684b5a8fc8b)