### PR TITLE
Add direct & group chat with attachments, notifications, and UI entry points

### DIFF
--- a/app/controllers/api/conversations_controller.rb
+++ b/app/controllers/api/conversations_controller.rb
@@ -1,0 +1,96 @@
+class Api::ConversationsController < Api::BaseController
+  before_action :set_conversation, only: [:show]
+
+  def index
+    conversations = Conversation.for_user(current_user)
+      .includes(:participants, :messages)
+      .order(updated_at: :desc)
+
+    render json: conversations.map { |conversation| serialize_conversation(conversation) }
+  end
+
+  def show
+    participant = @conversation.conversation_participants.find_by(user_id: current_user.id)
+    participant&.update(last_read_at: Time.current)
+
+    render json: serialize_conversation(@conversation, include_messages: true)
+  end
+
+  def create
+    conversation = Conversation.new(conversation_params.merge(creator: current_user))
+
+    participant_ids = Array(params[:participant_ids]).map(&:to_i).uniq
+    participant_ids << current_user.id
+
+    if conversation.save
+      participant_ids.each do |user_id|
+        conversation.conversation_participants.create!(user_id: user_id)
+      end
+      render json: serialize_conversation(conversation), status: :created
+    else
+      render json: { errors: conversation.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def start_direct
+    other_user = User.find(params[:user_id])
+    conversation = find_or_create_direct_conversation(other_user)
+
+    render json: serialize_conversation(conversation)
+  end
+
+  private
+
+  def set_conversation
+    @conversation = Conversation.for_user(current_user).find(params[:id])
+  end
+
+  def conversation_params
+    params.require(:conversation).permit(:title, :conversation_type)
+  end
+
+  def find_or_create_direct_conversation(other_user)
+    candidate = Conversation.direct
+      .joins(:conversation_participants)
+      .where(conversation_participants: { user_id: [current_user.id, other_user.id] })
+      .group("conversations.id")
+      .having("COUNT(DISTINCT conversation_participants.user_id) = 2")
+      .first
+
+    return candidate if candidate
+
+    conversation = Conversation.create!(conversation_type: :direct, creator: current_user)
+    conversation.conversation_participants.create!(user: current_user)
+    conversation.conversation_participants.create!(user: other_user)
+    conversation
+  end
+
+  def serialize_conversation(conversation, include_messages: false)
+    membership = conversation.conversation_participants.find { |cp| cp.user_id == current_user.id } || conversation.conversation_participants.find_by(user_id: current_user.id)
+    unread_count = conversation.messages.where("messages.created_at > ?", membership&.last_read_at || Time.at(0)).where.not(user_id: current_user.id).count
+    payload = {
+      id: conversation.id,
+      title: conversation.display_name(current_user),
+      conversation_type: conversation.conversation_type,
+      participants: conversation.participants.map { |user| { id: user.id, name: user.full_name, profile_picture: (rails_blob_url(user.profile_picture, only_path: true) if user.profile_picture.attached?) } },
+      unread_count: unread_count,
+      last_message_at: conversation.messages.maximum(:created_at),
+      updated_at: conversation.updated_at
+    }
+
+    if include_messages
+      payload[:messages] = conversation.messages.order(created_at: :asc).map do |message|
+        {
+          id: message.id,
+          body: message.body,
+          user_id: message.user_id,
+          user_name: message.user.full_name,
+          created_at: message.created_at,
+          attachments: message.attachments.map { |attachment| { id: attachment.id, url: rails_blob_url(attachment, only_path: true), content_type: attachment.content_type, filename: attachment.filename.to_s } }
+        }
+      end
+    end
+
+    payload
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,33 @@
+class Api::MessagesController < Api::BaseController
+  before_action :set_conversation
+
+  def create
+    message = @conversation.messages.new(message_params)
+    message.user = current_user
+
+    if message.save
+      @conversation.touch
+      @conversation.conversation_participants.where(user_id: current_user.id).update_all(last_read_at: Time.current)
+      render json: {
+        id: message.id,
+        body: message.body,
+        user_id: message.user_id,
+        user_name: message.user.full_name,
+        created_at: message.created_at,
+        attachments: message.attachments.map { |attachment| { id: attachment.id, url: rails_blob_url(attachment, only_path: true), content_type: attachment.content_type, filename: attachment.filename.to_s } }
+      }, status: :created
+    else
+      render json: { errors: message.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_conversation
+    @conversation = Conversation.for_user(current_user).find(params[:conversation_id])
+  end
+
+  def message_params
+    params.require(:message).permit(:body, attachments: [])
+  end
+end

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -48,6 +48,9 @@ class Api::NotificationsController < ApplicationController
       "#{notification.actor.full_name} commented on your post"
     when 'update'
       "#{notification.actor.full_name} updated a task"
+    when 'chat_message'
+      conversation_name = notification.metadata&.dig('conversation_name') || 'a conversation'
+      "#{notification.actor.full_name} sent a message in #{conversation_name}"
     else
       "New notification"
     end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -30,6 +30,8 @@ import Calendar from "../pages/Calendar";
 import AdminImpersonation from "../pages/AdminImpersonation";
 import Departments from "../pages/Departments";
 import PageLoader from "./ui/PageLoader";
+import Chat from "../pages/Chat";
+import ChatLauncher from "./ChatLauncher";
 
 const RouteTransitionLoader = ({ children }) => {
   const location = useLocation();
@@ -88,9 +90,12 @@ const App = () => {
               <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
               <Route path="/admin/login-as-user" element={<PrivateRoute ownerOnly><AdminImpersonation /></PrivateRoute>} />
               <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
+              <Route path="/chat" element={<PrivateRoute><Chat /></PrivateRoute>} />
+              <Route path="/chat/:conversationId" element={<PrivateRoute><Chat /></PrivateRoute>} />
             </Routes>
           </RouteTransitionLoader>
 
+          <ChatLauncher />
           {/* ✅ Footer */}
           <Footer />
 

--- a/app/javascript/components/ChatLauncher.jsx
+++ b/app/javascript/components/ChatLauncher.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { MessageCircle } from "lucide-react";
+import { fetchConversations } from "./api";
+
+const ChatLauncher = () => {
+  const [conversations, setConversations] = useState([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const { data } = await fetchConversations();
+        setConversations(Array.isArray(data) ? data : []);
+      } catch (error) {
+        // ignore for logged out state
+      }
+    };
+
+    load();
+    const interval = setInterval(load, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const unreadCount = useMemo(() => conversations.reduce((count, conversation) => count + (conversation.unread_count || 0), 0), [conversations]);
+
+  return (
+    <Link to="/chat" className="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-lg hover:bg-blue-700">
+      <MessageCircle size={18} />
+      Chat
+      {unreadCount > 0 && <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-bold text-red-700">{unreadCount}</span>}
+    </Link>
+  );
+};
+
+export default ChatLauncher;

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -212,6 +212,7 @@ const Navbar = () => {
     { to: "/knowledge", label: "Knowledge", icon: FiBook, visible: !!user },
     { to: "/vault", label: "Vault", icon: FiMenu, visible: !!user },
     { to: "/worklog", label: "Work Log", icon: FiClock, visible: !!user },
+    { to: "/chat", label: "Chat", icon: FiMessageSquare, visible: !!user },
     { to: "/calendar", label: "Calendar", icon: FiCalendar, visible: !!user },
     {
       to: "/teams",

--- a/app/javascript/components/NotificationCenter.jsx
+++ b/app/javascript/components/NotificationCenter.jsx
@@ -57,6 +57,7 @@ const NotificationCenter = () => {
   const getIcon = (action) => {
     switch (action) {
       case 'commented': return <MessageSquare className="w-4 h-4 text-blue-500" />;
+      case 'chat_message': return <MessageSquare className="w-4 h-4 text-indigo-500" />;
       case 'assigned': return <Briefcase className="w-4 h-4 text-green-500" />;
       case 'update': return <FileText className="w-4 h-4 text-orange-500" />;
       default: return <Bell className="w-4 h-4 text-gray-500" />;

--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useMemo, useContext } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { fetchUserInfo, fetchUserProfile, fetchPosts, SchedulerAPI, fetchTeams, saveKekaCredentials, refreshKekaProfile } from "../components/api";
+import { fetchUserInfo, fetchUserProfile, fetchPosts, SchedulerAPI, fetchTeams, saveKekaCredentials, refreshKekaProfile, startDirectConversation } from "../components/api";
 import { getStatusClasses } from '/utils/taskUtils';
 import { Squares2X2Icon, FolderIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { AuthContext } from '../context/AuthContext';
@@ -482,6 +482,18 @@ const Profile = () => {
     return sections;
   }, [otherTasks]);
 
+
+  const handleStartDirectChat = async () => {
+    if (!userId) return;
+
+    try {
+      const { data } = await startDirectConversation(userId);
+      navigate(`/chat/${data.id}`);
+    } catch (error) {
+      console.error("Unable to start direct chat", error);
+    }
+  };
+
   const getProjectName = (projectId) => {
     const project = projects.find((p) => p.id === projectId);
     return project ? project.name : `Project ${projectId}`;
@@ -630,6 +642,15 @@ const Profile = () => {
                     <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
                   </svg>
                   Edit Profile
+                </button>
+              )}
+
+              {!editMode && viewingOtherProfile && (
+                <button
+                  onClick={handleStartDirectChat}
+                  className="flex items-center gap-2 px-6 py-3 bg-blue-600 text-white font-semibold rounded-full hover:bg-blue-700 transition"
+                >
+                  Text
                 </button>
               )}
             </div>

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -226,6 +226,15 @@ export const sendContact = (data) => api.post('/contacts', { contact: data });
 
 export const fetchSheetData = (params) => api.get('/sheet', { params });
 
+
+// CHAT ENDPOINTS
+export const fetchConversations = () => api.get('/conversations.json');
+export const fetchConversation = (id) => api.get(`/conversations/${id}.json`);
+export const createConversation = (data) => api.post('/conversations.json', { conversation: data, participant_ids: data.participant_ids || [] });
+export const startDirectConversation = (userId) => api.post('/conversations/start_direct', { user_id: userId });
+export const sendMessage = (conversationId, formData) =>
+  api.post(`/conversations/${conversationId}/messages`, formData, { headers: { 'Content-Type': 'multipart/form-data' } });
+
 // NOTIFICATION ENDPOINTS
 export const fetchNotifications = (params = {}) => api.get('/notifications.json', { params });
 export const markNotificationRead = (id) => api.post(`/notifications/${id}/mark_read`);

--- a/app/javascript/pages/Chat.jsx
+++ b/app/javascript/pages/Chat.jsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { createConversation, fetchConversation, fetchConversations, getUsers, sendMessage } from "../components/api";
+
+const Chat = () => {
+  const { conversationId } = useParams();
+  const navigate = useNavigate();
+  const [conversations, setConversations] = useState([]);
+  const [activeConversation, setActiveConversation] = useState(null);
+  const [users, setUsers] = useState([]);
+  const [groupTitle, setGroupTitle] = useState("");
+  const [selectedUserIds, setSelectedUserIds] = useState([]);
+  const [messageBody, setMessageBody] = useState("");
+  const [attachments, setAttachments] = useState([]);
+
+  const groupedConversations = useMemo(() => ({
+    direct: conversations.filter((conversation) => conversation.conversation_type === "direct"),
+    group: conversations.filter((conversation) => conversation.conversation_type === "group")
+  }), [conversations]);
+
+  const loadConversations = async () => {
+    const { data } = await fetchConversations();
+    setConversations(Array.isArray(data) ? data : []);
+  };
+
+  const loadConversation = async (id) => {
+    if (!id) return;
+    const { data } = await fetchConversation(id);
+    setActiveConversation(data);
+  };
+
+  useEffect(() => {
+    loadConversations();
+    getUsers().then(({ data }) => setUsers(Array.isArray(data) ? data : []));
+
+    const interval = setInterval(() => {
+      loadConversations();
+      if (conversationId) loadConversation(conversationId);
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [conversationId]);
+
+  useEffect(() => {
+    if (conversationId) {
+      loadConversation(conversationId);
+    }
+  }, [conversationId]);
+
+  const handleCreateGroup = async (event) => {
+    event.preventDefault();
+    if (!groupTitle || selectedUserIds.length === 0) return;
+
+    const { data } = await createConversation({
+      title: groupTitle,
+      conversation_type: "group",
+      participant_ids: selectedUserIds
+    });
+
+    setGroupTitle("");
+    setSelectedUserIds([]);
+    await loadConversations();
+    navigate(`/chat/${data.id}`);
+  };
+
+  const handleSendMessage = async (event) => {
+    event.preventDefault();
+    if (!conversationId) return;
+
+    const formData = new FormData();
+    formData.append("message[body]", messageBody);
+    attachments.forEach((file) => formData.append("message[attachments][]", file));
+
+    await sendMessage(conversationId, formData);
+    setMessageBody("");
+    setAttachments([]);
+    await loadConversation(conversationId);
+    await loadConversations();
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-7xl p-4 md:p-6">
+      <div className="grid gap-4 md:grid-cols-3">
+        <aside className="rounded-xl border border-gray-200 bg-white p-4">
+          <h2 className="mb-3 text-lg font-semibold">Chats</h2>
+
+          <p className="mb-1 text-xs font-semibold uppercase text-gray-500">Direct</p>
+          <div className="mb-4 space-y-2">
+            {groupedConversations.direct.map((conversation) => (
+              <Link key={conversation.id} to={`/chat/${conversation.id}`} className="block rounded-lg border border-gray-200 px-3 py-2 text-sm hover:bg-gray-50">
+                <div className="flex items-center justify-between">
+                  <span>{conversation.title}</span>
+                  {conversation.unread_count > 0 && <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700">{conversation.unread_count}</span>}
+                </div>
+              </Link>
+            ))}
+          </div>
+
+          <p className="mb-1 text-xs font-semibold uppercase text-gray-500">Groups</p>
+          <div className="space-y-2">
+            {groupedConversations.group.map((conversation) => (
+              <Link key={conversation.id} to={`/chat/${conversation.id}`} className="block rounded-lg border border-gray-200 px-3 py-2 text-sm hover:bg-gray-50">
+                <div className="flex items-center justify-between">
+                  <span>{conversation.title}</span>
+                  {conversation.unread_count > 0 && <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-700">{conversation.unread_count}</span>}
+                </div>
+              </Link>
+            ))}
+          </div>
+
+          <form onSubmit={handleCreateGroup} className="mt-5 space-y-2 border-t pt-4">
+            <p className="text-sm font-semibold">Create Group</p>
+            <input value={groupTitle} onChange={(e) => setGroupTitle(e.target.value)} placeholder="Group name" className="w-full rounded border px-2 py-1 text-sm" />
+            <select multiple value={selectedUserIds.map(String)} onChange={(e) => setSelectedUserIds(Array.from(e.target.selectedOptions).map((o) => Number(o.value)))} className="h-28 w-full rounded border px-2 py-1 text-sm">
+              {users.map((user) => <option key={user.id} value={user.id}>{user.first_name} {user.last_name}</option>)}
+            </select>
+            <button className="w-full rounded bg-blue-600 px-3 py-2 text-sm font-medium text-white">Create</button>
+          </form>
+        </aside>
+
+        <section className="md:col-span-2 rounded-xl border border-gray-200 bg-white p-4">
+          {!activeConversation && <p className="text-sm text-gray-500">Open a conversation to start chatting.</p>}
+          {activeConversation && (
+            <>
+              <h2 className="mb-3 text-lg font-semibold">{activeConversation.title}</h2>
+              <div className="mb-4 h-[420px] overflow-y-auto rounded-lg border border-gray-100 bg-gray-50 p-3">
+                {activeConversation.messages?.map((message) => (
+                  <div key={message.id} className="mb-3 rounded-lg bg-white p-3 shadow-sm">
+                    <p className="text-xs font-semibold text-gray-500">{message.user_name}</p>
+                    {message.body && <p className="text-sm text-gray-800">{message.body}</p>}
+                    <div className="mt-2 space-y-1">
+                      {message.attachments?.map((attachment) => (
+                        <a key={attachment.id} href={attachment.url} target="_blank" rel="noreferrer" className="block text-xs text-blue-600 underline">{attachment.filename}</a>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              <form onSubmit={handleSendMessage} className="space-y-2">
+                <textarea value={messageBody} onChange={(e) => setMessageBody(e.target.value)} placeholder="Type your message" className="w-full rounded border px-3 py-2 text-sm" rows={3} />
+                <input type="file" accept="image/*,video/*" multiple onChange={(e) => setAttachments(Array.from(e.target.files || []))} className="block w-full text-xs" />
+                <button className="rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white">Send</button>
+              </form>
+            </>
+          )}
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default Chat;

--- a/app/javascript/pages/Users.jsx
+++ b/app/javascript/pages/Users.jsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { AuthContext } from "../context/AuthContext";
 import { 
   Search, Edit2, Trash2, X, Check, Upload, PencilLine,
-  Mail, Calendar, Users as UsersIcon 
+  Mail, Calendar, Users as UsersIcon, MessageSquare 
 } from "lucide-react";
 import {
   getUsers,
@@ -13,10 +13,12 @@ import {
   fetchProjects,
   fetchRoles,
   fetchDepartments,
+  startDirectConversation,
 } from "../components/api";
 
 const Users = () => {
   const { user: currentUser } = React.useContext(AuthContext);
+  const navigate = useNavigate();
   // --- State Management ---
   const [users, setUsers] = useState([]);
   const [search, setSearch] = useState("");
@@ -197,6 +199,16 @@ const Users = () => {
       closePhotoModal();
     } catch (error) {
       console.error("Photo update failed", error);
+    }
+  };
+
+
+  const handleStartChat = async (userId) => {
+    try {
+      const { data } = await startDirectConversation(userId);
+      navigate(`/chat/${data.id}`);
+    } catch (error) {
+      console.error("Failed to start chat", error);
     }
   };
 
@@ -383,12 +395,19 @@ const Users = () => {
 
         {/* Footer Actions */}
         <div className="bg-gray-50 px-6 py-4 border-t border-gray-100 flex justify-between items-center opacity-80 group-hover:opacity-100 transition-opacity">
-            <Link
-              to={`/profile/${user.id}`}
-              className="text-[var(--theme-color)] hover:text-indigo-700 font-medium text-sm"
-            >
-              View profile
-            </Link>
+            <div className="flex items-center gap-3">
+              <Link
+                to={`/profile/${user.id}`}
+                className="text-[var(--theme-color)] hover:text-indigo-700 font-medium text-sm"
+              >
+                View profile
+              </Link>
+              {currentUser?.id !== user.id && (
+                <button type="button" onClick={() => handleStartChat(user.id)} className="text-sm font-medium text-blue-600 hover:text-blue-800 inline-flex items-center gap-1">
+                  <MessageSquare size={14} /> Text
+                </button>
+              )}
+            </div>
             {canManageUsers ? (
               <div className="flex items-center gap-4">
                 <button 

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,0 +1,20 @@
+class Conversation < ApplicationRecord
+  enum conversation_type: { direct: "direct", group: "group" }
+
+  belongs_to :creator, class_name: "User"
+  has_many :conversation_participants, dependent: :destroy
+  has_many :participants, through: :conversation_participants, source: :user
+  has_many :messages, dependent: :destroy
+
+  validates :conversation_type, presence: true
+  validates :title, presence: true, if: :group?
+
+  scope :for_user, ->(user) { joins(:conversation_participants).where(conversation_participants: { user_id: user.id }).distinct }
+
+  def display_name(for_user)
+    return title if group?
+
+    other_participant = participants.where.not(id: for_user.id).first
+    other_participant&.full_name || "Direct chat"
+  end
+end

--- a/app/models/conversation_participant.rb
+++ b/app/models/conversation_participant.rb
@@ -1,0 +1,6 @@
+class ConversationParticipant < ApplicationRecord
+  belongs_to :conversation
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :conversation_id }
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,48 @@
+class Message < ApplicationRecord
+  IMAGE_TYPES = %w[image/png image/jpeg image/jpg image/gif image/webp].freeze
+  VIDEO_TYPES = %w[video/mp4 video/webm video/quicktime].freeze
+
+  belongs_to :conversation
+  belongs_to :user
+  has_many_attached :attachments
+
+  validate :body_or_attachment_present
+  validate :attachment_types
+
+  after_create_commit :notify_participants
+
+  private
+
+  def body_or_attachment_present
+    return if body.present? || attachments.attached?
+
+    errors.add(:base, "Message must include text or an attachment")
+  end
+
+  def attachment_types
+    return unless attachments.attached?
+
+    attachments.each do |attachment|
+      next if IMAGE_TYPES.include?(attachment.content_type) || VIDEO_TYPES.include?(attachment.content_type)
+
+      errors.add(:attachments, "must be an image or video")
+    end
+  end
+
+  def notify_participants
+    recipient_ids = conversation.participants.where.not(id: user_id).pluck(:id)
+
+    recipient_ids.each do |recipient_id|
+      Notification.create(
+        recipient_id: recipient_id,
+        actor: user,
+        action: "chat_message",
+        notifiable: self,
+        metadata: {
+          conversation_id: conversation_id,
+          conversation_name: conversation.display_name(User.find(recipient_id))
+        }
+      )
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,6 +44,9 @@ class User < ApplicationRecord
   has_many :given_skill_endorsements, class_name: 'SkillEndorsement', foreign_key: :endorser_id, dependent: :destroy, inverse_of: :endorser
   has_many :received_skill_endorsements, through: :user_skills, source: :skill_endorsements
   has_many :notifications, foreign_key: :recipient_id, dependent: :destroy
+  has_many :conversation_participants, dependent: :destroy
+  has_many :conversations, through: :conversation_participants
+  has_many :messages, dependent: :destroy
   has_many :calendar_events, dependent: :destroy
   belongs_to :department, optional: true
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -136,6 +136,13 @@ Rails.application.routes.draw do
     end
     resources :event_reminders, only: [:update, :destroy]
 
+    resources :conversations, only: [:index, :show, :create] do
+      collection do
+        post :start_direct
+      end
+      resources :messages, only: [:create]
+    end
+
     resources :notifications, only: [:index] do
       collection do
         post :mark_all_read

--- a/db/migrate/20270215000000_create_chat_core.rb
+++ b/db/migrate/20270215000000_create_chat_core.rb
@@ -1,0 +1,33 @@
+class CreateChatCore < ActiveRecord::Migration[7.1]
+  def change
+    create_table :conversations do |t|
+      t.string :title
+      t.string :conversation_type, null: false, default: "direct"
+      t.references :creator, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+
+    add_index :conversations, :conversation_type
+
+    create_table :conversation_participants do |t|
+      t.references :conversation, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.datetime :last_read_at
+
+      t.timestamps
+    end
+
+    add_index :conversation_participants, [:conversation_id, :user_id], unique: true, name: "idx_unique_conversation_participant"
+
+    create_table :messages do |t|
+      t.references :conversation, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.text :body
+
+      t.timestamps
+    end
+
+    add_index :messages, [:conversation_id, :created_at]
+  end
+end


### PR DESCRIPTION
### Motivation
- Provide one-on-one and group chat so users can text from profiles and user cards, send photo/video attachments, and receive live in-app notifications and a compact chat launcher.

### Description
- Added DB migration and backend models `Conversation`, `ConversationParticipant`, and `Message` with ActiveStorage attachments, per-user read tracking, and validations for image/video types.
- Implemented API controllers `Api::ConversationsController` and `Api::MessagesController` with endpoints to list/show/create conversations, start/reuse direct chats (`start_direct`), and post messages with multipart attachments, and wired routes under `/api/conversations` and nested `messages`.
- Created messages -> notifications integration that emits `chat_message` notifications for other participants and extended `Api::NotificationsController`/`NotificationCenter` to surface chat notification text and icon.
- Frontend additions and wiring: new `Chat` page (`/chat` and `/chat/:conversationId`) with conversation list, group creation, message composer (attachments), `ChatLauncher` floating button with unread badge, navbar Chat link, and "Text" buttons on user cards and profile to start direct chats; added client API helpers in `app/javascript/components/api.jsx`.

### Testing
- Ran frontend unit tests with `npm test` (Vitest) and they passed successfully.
- Built the frontend with `npm run build` and the bundle completed successfully.
- `bin/rails db:migrate` could not be run in this environment due to a local Ruby version mismatch (installed 3.2.3 vs Gemfile 3.3.0), so migrations were not applied here.
- `bin/dev` could not be started in this environment due to a `foreman` installation/network error, so the full server integration/run was not validated locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69947d60ac4c8322b9c6aca3573f73dd)