### PR TITLE
Fix Conversation enum method collision causing 500s

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,5 +1,5 @@
 class Conversation < ApplicationRecord
-  enum conversation_type: { direct: "direct", group: "group" }
+  enum conversation_type: { direct: "direct", group: "group" }, _prefix: :conversation
 
   belongs_to :creator, class_name: "User"
   has_many :conversation_participants, dependent: :destroy
@@ -10,6 +10,14 @@ class Conversation < ApplicationRecord
   validates :title, presence: true, if: :group?
 
   scope :for_user, ->(user) { joins(:conversation_participants).where(conversation_participants: { user_id: user.id }).distinct }
+
+  def direct?
+    conversation_type == "direct"
+  end
+
+  def group?
+    conversation_type == "group"
+  end
 
   def display_name(for_user)
     return title if group?


### PR DESCRIPTION
### Motivation
- Requests to `/api/conversations.json` were raising an `ArgumentError` because defining the `conversation_type` enum generated a `direct?` predicate that collided with another enum-derived method, causing 500 errors when the model loaded.

### Description
- Add `_prefix: :conversation` to the `conversation_type` enum so Rails generates prefixed enum predicates and avoids name collisions.
- Add explicit `direct?` and `group?` instance methods that return the underlying `conversation_type` string checks to preserve the existing public interface used by validations and controller code.
- No other behavioral changes were introduced; `display_name` and `title` validation keep using `group?`/`direct?` as before.

### Testing
- Attempted to run `bundle exec rails runner 'puts Conversation.inspect'`, which failed due to missing `rails` executable in the current bundler environment; the command did not succeed.
- Attempted to run `bin/rails runner 'puts Conversation.inspect'`, which failed because the local Ruby is `3.2.3` while the `Gemfile` requires `3.3.0`, so model loading could not be validated in this environment.
- No full automated test suite was executed because the runtime environment did not match project requirements, so validation is limited to static inspection of the modified file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994820c46d483228bdcbdb4ae3297e9)