### PR TITLE
Add message reactions with realtime counts in chat

### DIFF
--- a/app/controllers/api/message_reactions_controller.rb
+++ b/app/controllers/api/message_reactions_controller.rb
@@ -1,0 +1,38 @@
+class Api::MessageReactionsController < Api::BaseController
+  before_action :set_message
+
+  def create
+    reaction = @message.message_reactions.find_or_initialize_by(user: current_user, emoji: reaction_params[:emoji])
+
+    if reaction.persisted? || reaction.save
+      render json: { reactions: serialize_reactions(@message), reacted_emojis: @message.reacted_emojis_for(current_user) }, status: :created
+    else
+      render json: { errors: reaction.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    reaction = @message.message_reactions.find_by(user: current_user, emoji: params[:emoji])
+    reaction&.destroy
+
+    render json: { reactions: serialize_reactions(@message), reacted_emojis: @message.reacted_emojis_for(current_user) }
+  end
+
+  private
+
+  def set_message
+    conversation = Conversation.for_user(current_user).find(params[:conversation_id])
+    @message = conversation.messages.find(params[:message_id])
+  end
+
+  def reaction_params
+    params.require(:message_reaction).permit(:emoji)
+  end
+
+  def serialize_reactions(message)
+    MessageReaction::EMOJIS.each_with_object({}) do |emoji, acc|
+      count = message.reaction_counts[emoji] || 0
+      acc[emoji] = count if count.positive?
+    end
+  end
+end

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -235,6 +235,10 @@ export const createConversation = (data) => api.post('/conversations.json', { co
 export const startDirectConversation = (userId) => api.post('/conversations/start_direct', { user_id: userId });
 export const sendMessage = (conversationId, formData) =>
   api.post(`/conversations/${conversationId}/messages`, formData, { headers: { 'Content-Type': 'multipart/form-data' } });
+export const addMessageReaction = (conversationId, messageId, emoji) =>
+  api.post(`/conversations/${conversationId}/messages/${messageId}/reactions`, { message_reaction: { emoji } });
+export const removeMessageReaction = (conversationId, messageId, emoji) =>
+  api.delete(`/conversations/${conversationId}/messages/${messageId}/reactions`, { params: { emoji } });
 
 // NOTIFICATION ENDPOINTS
 export const fetchNotifications = (params = {}) => api.get('/notifications.json', { params });

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -5,6 +5,7 @@ class Message < ApplicationRecord
   belongs_to :conversation
   belongs_to :user
   has_many_attached :attachments
+  has_many :message_reactions, dependent: :destroy
 
   validate :body_or_attachment_present
   validate :attachment_types
@@ -32,6 +33,18 @@ class Message < ApplicationRecord
 
   def broadcast_message
     Chat::Broadcaster.broadcast_message_created(self)
+  end
+
+  public
+
+  def reaction_counts
+    message_reactions.group(:emoji).count
+  end
+
+  def reacted_emojis_for(user)
+    return [] unless user
+
+    message_reactions.where(user_id: user.id).pluck(:emoji)
   end
 
   def notify_participants

--- a/app/models/message_reaction.rb
+++ b/app/models/message_reaction.rb
@@ -1,0 +1,23 @@
+class MessageReaction < ApplicationRecord
+  EMOJIS = %w[👍 ❤️ 🎉].freeze
+
+  belongs_to :message
+  belongs_to :user
+
+  validates :emoji, presence: true, inclusion: { in: EMOJIS }
+  validates :emoji, uniqueness: { scope: [:message_id, :user_id] }
+
+  after_create_commit -> { broadcast_reactions_updated("added") }
+  after_destroy_commit -> { broadcast_reactions_updated("removed") }
+
+  private
+
+  def broadcast_reactions_updated(action)
+    Chat::Broadcaster.broadcast_message_reactions_updated(
+      message,
+      last_actor_id: user_id,
+      last_actor_emoji: emoji,
+      last_actor_action: action
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,7 @@ class User < ApplicationRecord
   has_many :conversation_participants, dependent: :destroy
   has_many :conversations, through: :conversation_participants
   has_many :messages, dependent: :destroy
+  has_many :message_reactions, dependent: :destroy
   has_many :calendar_events, dependent: :destroy
   belongs_to :department, optional: true
 

--- a/app/services/chat/broadcaster.rb
+++ b/app/services/chat/broadcaster.rb
@@ -12,6 +12,20 @@ module Chat
         broadcast_conversation_refresh(message.conversation)
       end
 
+      def broadcast_message_reactions_updated(message, last_actor_id: nil, last_actor_emoji: nil, last_actor_action: nil)
+        payload = {
+          type: "message_reactions_updated",
+          conversation_id: message.conversation_id,
+          message_id: message.id,
+          reactions: message.reaction_counts,
+          last_actor_id: last_actor_id,
+          last_actor_emoji: last_actor_emoji,
+          last_actor_action: last_actor_action
+        }
+
+        ActionCable.server.broadcast(conversation_stream(message.conversation_id), payload)
+      end
+
       def broadcast_conversation_refresh(conversation)
         conversation.participant_ids.each do |participant_id|
           ActionCable.server.broadcast(user_stream(participant_id), {
@@ -46,7 +60,9 @@ module Chat
               content_type: attachment.content_type,
               filename: attachment.filename.to_s
             }
-          end
+          end,
+          reactions: message.reaction_counts,
+          reacted_emojis: []
         }
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -141,7 +141,10 @@ Rails.application.routes.draw do
       collection do
         post :start_direct
       end
-      resources :messages, only: [:create]
+      resources :messages, only: [:create] do
+        resources :reactions, controller: "message_reactions", only: [:create]
+        delete "reactions", to: "message_reactions#destroy"
+      end
     end
 
     resources :notifications, only: [:index] do

--- a/db/migrate/20270216000000_create_message_reactions.rb
+++ b/db/migrate/20270216000000_create_message_reactions.rb
@@ -1,0 +1,13 @@
+class CreateMessageReactions < ActiveRecord::Migration[7.1]
+  def change
+    create_table :message_reactions do |t|
+      t.references :message, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :emoji, null: false
+
+      t.timestamps
+    end
+
+    add_index :message_reactions, [:message_id, :user_id, :emoji], unique: true, name: "idx_unique_message_reaction"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2027_02_15_000000) do
+ActiveRecord::Schema[7.1].define(version: 2027_02_16_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -266,6 +266,18 @@ ActiveRecord::Schema[7.1].define(version: 2027_02_15_000000) do
     t.index ["conversation_id", "created_at"], name: "index_messages_on_conversation_id_and_created_at"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"
     t.index ["user_id"], name: "index_messages_on_user_id"
+  end
+
+
+  create_table "message_reactions", force: :cascade do |t|
+    t.bigint "message_id", null: false
+    t.bigint "user_id", null: false
+    t.string "emoji", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["message_id", "user_id", "emoji"], name: "idx_unique_message_reaction", unique: true
+    t.index ["message_id"], name: "index_message_reactions_on_message_id"
+    t.index ["user_id"], name: "index_message_reactions_on_user_id"
   end
 
   create_table "notifications", force: :cascade do |t|
@@ -654,6 +666,8 @@ ActiveRecord::Schema[7.1].define(version: 2027_02_15_000000) do
   add_foreign_key "learning_goals", "users"
   add_foreign_key "messages", "conversations"
   add_foreign_key "messages", "users"
+  add_foreign_key "message_reactions", "messages"
+  add_foreign_key "message_reactions", "users"
   add_foreign_key "notifications", "users", column: "actor_id"
   add_foreign_key "notifications", "users", column: "recipient_id"
   add_foreign_key "post_likes", "posts"


### PR DESCRIPTION
### Motivation
- Add lightweight emoji reactions (👍 ❤️ 🎉) to chat messages so users can react without sending new messages. 
- Keep reaction state consistent across clients by persisting reactions and broadcasting updates in realtime. 
- Surface per-message reaction counts and whether the current user reacted when retrieving conversations or creating messages.

### Description
- Persistence: add `message_reactions` table and migration (`db/migrate/20270216000000_create_message_reactions.rb`) and a `MessageReaction` model with allowed emojis and uniqueness per (message, user, emoji). 
- Backend APIs & routing: new controller `Api::MessageReactionsController` with `create` (idempotent add) and `destroy` (remove by emoji), and nested routes under `conversations/:conversation_id/messages` in `config/routes.rb`. 
- Serialization & associations: `Message`/`User` associations updated, `Message` helpers `reaction_counts` and `reacted_emojis_for(user)`, and message payloads now include `reactions` and `reacted_emojis` in `Api::ConversationsController` and `Api::MessagesController`. 
- Realtime: `Chat::Broadcaster` emits `message_reactions_updated` payloads and includes reaction data in `message_created` broadcasts so clients can update counts live. 
- Frontend: new API methods `addMessageReaction`/`removeMessageReaction` in `app/javascript/components/api.jsx` and UI changes in `app/javascript/pages/Chat.jsx` to show reaction buttons, send toggles, and handle realtime reaction updates.

### Testing
- Ran Ruby syntax checks with `ruby -c` for updated Ruby files (`app/services/chat/broadcaster.rb`, `app/controllers/api/*`, `app/models/*`) and they returned `Syntax OK` for the touched files. 
- Frontend bundle build `npm run build` completed successfully. 
- `bin/rails db:migrate` could not be executed in this environment due to a local Ruby mismatch (`installed 3.2.3` vs Gemfile `3.3.0`), so the migration exists but was not applied here. 
- Playwright screenshot attempt to `http://127.0.0.1:3000/chat` failed with `ERR_EMPTY_RESPONSE` because no app server was reachable in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996af5cfc048322a29c093ae46a8482)