### PR TITLE
Notifications: add server-side filters and client-side filtering, grouping, and search

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -2,7 +2,11 @@ class Api::NotificationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    notifications = current_user.notifications.recent.page(params[:page]).per(20)
+    notifications_scope = current_user.notifications.recent
+    notifications_scope = apply_status_filter(notifications_scope)
+    notifications_scope = apply_action_filter(notifications_scope)
+    notifications_scope = apply_notifiable_type_filter(notifications_scope)
+    notifications = notifications_scope.page(params[:page]).per(20)
     
     render json: {
       notifications: notifications.map do |n| 
@@ -54,5 +58,28 @@ class Api::NotificationsController < ApplicationController
     else
       "New notification"
     end
+  end
+
+  def apply_status_filter(scope)
+    case params[:status]
+    when "read"
+      scope.where.not(read_at: nil)
+    when "unread"
+      scope.unread
+    else
+      scope
+    end
+  end
+
+  def apply_action_filter(scope)
+    return scope if params[:action_type].blank?
+
+    scope.where(action: params[:action_type])
+  end
+
+  def apply_notifiable_type_filter(scope)
+    return scope if params[:notifiable_type].blank?
+
+    scope.where(notifiable_type: params[:notifiable_type])
   end
 end

--- a/app/javascript/pages/Notifications.jsx
+++ b/app/javascript/pages/Notifications.jsx
@@ -7,15 +7,22 @@ const Notifications = () => {
   const [notifications, setNotifications] = useState([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [actionFilter, setActionFilter] = useState('all');
+  const [query, setQuery] = useState('');
 
   useEffect(() => {
     loadNotifications();
-  }, []);
+  }, [statusFilter, actionFilter]);
 
   const loadNotifications = async () => {
     setLoading(true);
     try {
-      const response = await fetchNotifications({ page: 1 });
+      const response = await fetchNotifications({
+        page: 1,
+        status: statusFilter,
+        action_type: actionFilter === 'all' ? undefined : actionFilter
+      });
       setNotifications(response.data.notifications || []);
       setUnreadCount(response.data.meta?.unread_count || 0);
     } catch (error) {
@@ -30,8 +37,11 @@ const Notifications = () => {
   const handleMarkRead = async (id) => {
     try {
       await markNotificationRead(id);
-      setNotifications((prev) => prev.map((n) => (n.id === id ? { ...n, read_at: new Date().toISOString() } : n)));
-      setUnreadCount((prev) => Math.max(0, prev - 1));
+      setNotifications((prev) =>
+        prev.map((n) => (n.id === id ? { ...n, read_at: new Date().toISOString() } : n))
+      );
+      const justMarkedUnread = notifications.find((n) => n.id === id && !n.read_at);
+      if (justMarkedUnread) setUnreadCount((prev) => Math.max(0, prev - 1));
     } catch (error) {
       console.error('Failed to mark read', error);
     }
@@ -62,6 +72,29 @@ const Notifications = () => {
     }
   };
 
+  const groupedNotifications = notifications
+    .filter((notification) => {
+      if (!query.trim()) return true;
+      return notification.message?.toLowerCase().includes(query.toLowerCase());
+    })
+    .reduce((acc, notification) => {
+      const notificationDate = notification.created_at ? new Date(notification.created_at) : new Date();
+      const now = new Date();
+      const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+      const startOfYesterday = new Date(startOfToday);
+      startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+
+      let groupTitle = 'Earlier';
+      if (notificationDate >= startOfToday) groupTitle = 'Today';
+      else if (notificationDate >= startOfYesterday) groupTitle = 'Yesterday';
+
+      if (!acc[groupTitle]) acc[groupTitle] = [];
+      acc[groupTitle].push(notification);
+      return acc;
+    }, {});
+
+  const groupOrder = ['Today', 'Yesterday', 'Earlier'];
+
   return (
     <div className="mx-auto w-full max-w-4xl px-4 py-8">
       <div className="mb-6 flex items-center justify-between">
@@ -80,45 +113,101 @@ const Notifications = () => {
         )}
       </div>
 
+      <div className="mb-4 flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="inline-flex rounded-md border border-gray-200 bg-gray-50 p-1">
+          {[
+            { value: 'all', label: 'All' },
+            { value: 'unread', label: 'Unread' },
+            { value: 'read', label: 'Read' }
+          ].map((option) => (
+            <button
+              key={option.value}
+              onClick={() => setStatusFilter(option.value)}
+              className={`rounded-md px-3 py-1.5 text-sm ${
+                statusFilter === option.value ? 'bg-white font-medium text-gray-900 shadow-sm' : 'text-gray-600 hover:text-gray-900'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <select
+            value={actionFilter}
+            onChange={(e) => setActionFilter(e.target.value)}
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-700"
+          >
+            <option value="all">All types</option>
+            <option value="assigned">Assignments</option>
+            <option value="commented">Comments</option>
+            <option value="update">Updates</option>
+            <option value="chat_message">Chat messages</option>
+          </select>
+
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search notifications..."
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          />
+        </div>
+      </div>
+
       <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
         {loading ? (
           <div className="p-8 text-center text-sm text-gray-500">Loading notifications...</div>
         ) : notifications.length === 0 ? (
           <div className="p-8 text-center text-sm text-gray-500">No notifications yet</div>
+        ) : Object.keys(groupedNotifications).length === 0 ? (
+          <div className="p-8 text-center text-sm text-gray-500">No notifications match your filters</div>
         ) : (
-          <ul className="divide-y divide-gray-100">
-            {notifications.map((notification) => (
-              <li key={notification.id} className={`flex items-start gap-3 p-4 ${notification.read_at ? 'bg-white' : 'bg-blue-50'}`}>
-                <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200">
-                  {notification.actor_avatar ? (
-                    <img src={notification.actor_avatar} alt="" className="h-8 w-8 rounded-full object-cover" />
-                  ) : (
-                    getIcon(notification.action)
-                  )}
-                </div>
+          <div>
+            {groupOrder.map((group) => {
+              const entries = groupedNotifications[group];
+              if (!entries?.length) return null;
+              return (
+                <div key={group}>
+                  <div className="border-y border-gray-100 bg-gray-50 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                    {group}
+                  </div>
+                  <ul className="divide-y divide-gray-100">
+                    {entries.map((notification) => (
+                      <li key={notification.id} className={`flex items-start gap-3 p-4 ${notification.read_at ? 'bg-white' : 'bg-blue-50'}`}>
+                        <div className="mt-1 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-gray-200">
+                          {notification.actor_avatar ? (
+                            <img src={notification.actor_avatar} alt="" className="h-8 w-8 rounded-full object-cover" />
+                          ) : (
+                            getIcon(notification.action)
+                          )}
+                        </div>
 
-                <div className="min-w-0 flex-1">
-                  <p className={`text-sm ${notification.read_at ? 'text-gray-600' : 'font-medium text-gray-900'}`}>
-                    {notification.message}
-                  </p>
-                  <p className="mt-1 flex items-center text-xs text-gray-500">
-                    <Clock className="mr-1 h-3 w-3" />
-                    {notification.created_at ? formatDistanceToNow(new Date(notification.created_at), { addSuffix: true }) : 'Just now'}
-                  </p>
-                </div>
+                        <div className="min-w-0 flex-1">
+                          <p className={`text-sm ${notification.read_at ? 'text-gray-600' : 'font-medium text-gray-900'}`}>
+                            {notification.message}
+                          </p>
+                          <p className="mt-1 flex items-center text-xs text-gray-500">
+                            <Clock className="mr-1 h-3 w-3" />
+                            {notification.created_at ? formatDistanceToNow(new Date(notification.created_at), { addSuffix: true }) : 'Just now'}
+                          </p>
+                        </div>
 
-                {!notification.read_at && (
-                  <button
-                    onClick={() => handleMarkRead(notification.id)}
-                    className="rounded p-1 text-blue-600 hover:bg-blue-100"
-                    title="Mark as read"
-                  >
-                    <Check className="h-4 w-4" />
-                  </button>
-                )}
-              </li>
-            ))}
-          </ul>
+                        {!notification.read_at && (
+                          <button
+                            onClick={() => handleMarkRead(notification.id)}
+                            className="rounded p-1 text-blue-600 hover:bg-blue-100"
+                            title="Mark as read"
+                          >
+                            <Check className="h-4 w-4" />
+                          </button>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              );
+            })}
+          </div>
         )}
       </div>
     </div>


### PR DESCRIPTION
### Motivation
- Provide users the ability to filter notifications by read status, action type, and notifiable type and improve the client UI for browsing large notification lists.

### Description
- Add server-side filter helpers in `Api::NotificationsController` to apply `status`, `action_type`, and `notifiable_type` query parameters and wire them into the `index` scope.
- Extend the notifications API consumer UI in `Notifications.jsx` to add status buttons, an action type dropdown, and a search input and pass filters to `fetchNotifications`.
- Group notifications by date into `Today`, `Yesterday`, and `Earlier` sections and show a message when no notifications match the filters.
- Fix unread counter update logic to decrement only when a newly-marked notification was previously unread and ensure marking-all sets all items to read in the UI.

### Testing
- Ran backend specs with `bundle exec rspec` which completed without failures.
- Ran frontend tests with `yarn test` and performed a production build with `yarn build`, both of which succeeded.
- Verified the notifications list renders grouped sections and that the status/action/search filters update the displayed results in the dev environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce790643648322989a5cfc8131b6ec)