### PR TITLE
Add Google Sheet import to Issue Tracker

### DIFF
--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -1,6 +1,6 @@
 class Api::IssuesController < Api::BaseController
   include Rails.application.routes.url_helpers
-  before_action :require_project_id!, only: [:create, :update, :destroy]
+  before_action :require_project_id!, only: [:create, :update, :destroy, :import_from_sheet]
   before_action :set_issue, only: [:update, :destroy]
 
   def index
@@ -34,6 +34,21 @@ class Api::IssuesController < Api::BaseController
   def destroy
     @issue.destroy
     head :no_content
+  end
+
+  def import_from_sheet
+    project = Project.find(@project_id)
+    return render json: { error: "Sheet integration is disabled for this project" }, status: :unprocessable_entity unless project.sheet_integration_enabled?
+    return render json: { error: "Google Sheet ID missing for this project" }, status: :unprocessable_entity if project.sheet_id.blank?
+
+    summary = IssueSheetImportService.new(
+      project: project,
+      sheet_name: params[:sheet].presence || "Issues"
+    ).call
+
+    render json: summary
+  rescue StandardError => e
+    render json: { error: e.message }, status: :unprocessable_entity
   end
 
   private
@@ -81,4 +96,3 @@ class Api::IssuesController < Api::BaseController
     )
   end
 end
-

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -135,6 +135,8 @@ export const updateIssue = (id, data) => {
   return api.patch(`/issues/${id}.json`, payload, payload instanceof FormData ? { headers: { 'Content-Type': 'multipart/form-data' } } : {});
 };
 export const deleteIssue = (id, projectId) => api.delete(`/issues/${id}.json`, { params: { project_id: projectId } });
+export const importIssuesFromSheet = (projectId, sheet) =>
+  api.post('/issues/import_from_sheet.json', { project_id: projectId, sheet });
 
 // POST ENDPOINTS (existing)
 export const fetchPosts = (id) => api.get(id ? `/posts?user_id=${id}` : "/posts");

--- a/app/javascript/pages/IssueTracker.jsx
+++ b/app/javascript/pages/IssueTracker.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { SchedulerAPI, getIssues, createIssue, updateIssue, deleteIssue } from "../components/api";
+import { SchedulerAPI, getIssues, createIssue, updateIssue, deleteIssue, importIssuesFromSheet } from "../components/api";
 import { Toaster, toast } from "react-hot-toast";
 import { SparklesIcon, ClipboardDocumentListIcon, LinkIcon, ShieldExclamationIcon, ExclamationTriangleIcon, CheckCircleIcon, ListBulletIcon, Squares2X2Icon, VideoCameraIcon, BellIcon, ClockIcon, BoltIcon, FireIcon, TrashIcon, UserGroupIcon, FunnelIcon } from "@heroicons/react/24/outline";
 import { motion, AnimatePresence } from "framer-motion";
@@ -1197,6 +1197,7 @@ const IssueTracker = ({ projectId, sprint, standalone = false }) => {
   const [selectedIssues, setSelectedIssues] = useState([]);
   const [smartFilter, setSmartFilter] = useState("all");
   const [isActivityOpen, setIsActivityOpen] = useState(false);
+  const [isImporting, setIsImporting] = useState(false);
   const [mockActivities, setMockActivities] = useState([
     { user: "Sarah J.", text: "moved ISS-9922 to In Progress", time: "2m ago", type: "update" },
     { user: "System", text: "auto-assigned ISS-1234 to Dev Alpha", time: "15m ago", type: "system" },
@@ -1400,6 +1401,26 @@ const IssueTracker = ({ projectId, sprint, standalone = false }) => {
     }
   };
 
+  const handleImportFromSheet = async () => {
+    if (!projectId || isImporting) return;
+    const suggestedName = sprint?.name || "Issues";
+    const sheetName = window.prompt("Sheet tab name to import from:", suggestedName);
+    if (!sheetName) return;
+
+    setIsImporting(true);
+    try {
+      const { data } = await importIssuesFromSheet(projectId, sheetName);
+      const issuesRes = await getIssues(projectId);
+      setIssues(Array.isArray(issuesRes.data) ? issuesRes.data : []);
+      toast.success(`Imported ${data.created} new and updated ${data.updated} issues from "${sheetName}".`);
+      handleManualAction(`imported issues from sheet ${sheetName}`, "update");
+    } catch (error) {
+      toast.error(error?.response?.data?.error || "Failed to import issues from sheet");
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-slate-50/50 p-6">
       <Toaster position="top-right" />
@@ -1428,6 +1449,14 @@ const IssueTracker = ({ projectId, sprint, standalone = false }) => {
             >
               <SparklesIcon className="h-4 w-4" />
               <span>Log New Issue</span>
+            </button>
+            <button
+              onClick={handleImportFromSheet}
+              disabled={!projectId || isImporting}
+              className="flex items-center gap-2 px-4 py-2.5 bg-emerald-600 hover:bg-emerald-700 disabled:bg-emerald-300 text-white rounded-xl transition-all font-semibold shadow-lg shadow-emerald-500/25 active:scale-95 transform"
+            >
+              <LinkIcon className="h-4 w-4" />
+              <span>{isImporting ? "Importing..." : "Import from Sheet"}</span>
             </button>
 
             <button

--- a/app/services/issue_sheet_import_service.rb
+++ b/app/services/issue_sheet_import_service.rb
@@ -1,0 +1,105 @@
+class IssueSheetImportService
+  HEADER_MAP = {
+    "taskcreated" => :task_id,
+    "issuefoundby" => :found_by,
+    "date" => :found_on,
+    "module" => :module_name,
+    "submodule" => :sub_module,
+    "sectiondetail" => :section_detail,
+    "issuedescription" => :issue_description,
+    "attachment" => :attachment,
+    "mf6app" => :mf6_app,
+    "localqa" => :local_qa,
+    "teamtestdevqa" => :team_test,
+    "commentkajalteam" => :comment,
+    "devcomments" => :dev_comments_dated,
+    "developercomment" => :developer_comment,
+    "qacomment" => :comment_qa
+  }.freeze
+
+  def initialize(project:, sheet_name:)
+    @project = project
+    @sheet_name = sheet_name
+  end
+
+  def call
+    rows = GoogleSheetsReader.new(@sheet_name, @project.sheet_id).read_data
+    return { created: 0, updated: 0, skipped: 0, total: 0 } if rows.blank?
+
+    headers = Array(rows.first).map { |h| normalize_header(h) }
+    created = 0
+    updated = 0
+    skipped = 0
+
+    rows.drop(1).each do |row|
+      attrs = build_attrs(headers, row)
+      if attrs[:issue_description].blank?
+        skipped += 1
+        next
+      end
+
+      issue = find_existing_issue(attrs)
+      issue.assign_attributes(attrs)
+      issue.title = build_title(attrs) if issue.title.blank?
+
+      if issue.new_record?
+        if issue.save
+          created += 1
+        else
+          skipped += 1
+        end
+      elsif issue.changed?
+        if issue.save
+          updated += 1
+        else
+          skipped += 1
+        end
+      else
+        skipped += 1
+      end
+    end
+
+    { created: created, updated: updated, skipped: skipped, total: rows.length - 1 }
+  end
+
+  private
+
+  def build_attrs(headers, row)
+    attrs = {}
+    headers.each_with_index do |header, idx|
+      target = HEADER_MAP[header]
+      next unless target
+
+      value = row[idx].to_s.strip
+      next if value.blank?
+
+      attrs[target] = target == :found_on ? parse_date(value) : value
+    end
+    attrs
+  end
+
+  def find_existing_issue(attrs)
+    Issue.where(project_id: @project.id)
+         .where(issue_description: attrs[:issue_description], module_name: attrs[:module_name], sub_module: attrs[:sub_module])
+         .where(found_on: attrs[:found_on])
+         .first_or_initialize
+  end
+
+  def build_title(attrs)
+    [
+      attrs[:module_name],
+      attrs[:sub_module],
+      attrs[:issue_description]
+    ].compact.join(" - ").truncate(120)
+  end
+
+  def parse_date(value)
+    Date.parse(value)
+  rescue ArgumentError
+    nil
+  end
+
+  def normalize_header(value)
+    value.to_s.downcase.gsub(/[^a-z0-9]/, "")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -109,7 +109,11 @@ Rails.application.routes.draw do
     resources :task_logs, only: [:index, :create, :update, :destroy]
 
     resources :items, only: [:index, :create, :update, :destroy]
-    resources :issues, only: [:index, :create, :update, :destroy]
+    resources :issues, only: [:index, :create, :update, :destroy] do
+      collection do
+        post :import_from_sheet
+      end
+    end
     resources :departments do
       member do
         get :members


### PR DESCRIPTION
### Motivation
- Enable teams to bulk-import and sync issues from a project-linked Google Sheet so QA/Dev reported items in a shared spreadsheet can be ingested into the Issue Tracker.
- Map spreadsheet columns (module, sub-module, found-by/date, description, attachments, QA/Dev comments, etc.) into Issue fields and deduplicate or update existing issues.

### Description
- Added `IssueSheetImportService` which normalizes headers, maps known columns to issue attributes, parses dates, deduplicates by project+description+module+sub-module+found_on, and returns a summary of `created/updated/skipped/total`. (`app/services/issue_sheet_import_service.rb`).
- Exposed a new API action `POST /api/issues/import_from_sheet` that validates project sheet integration settings and invokes the import service with an optional sheet/tab name. (`app/controllers/api/issues_controller.rb` and `config/routes.rb`).
- Added a frontend API helper `importIssuesFromSheet(projectId, sheet)` and wired an "Import from Sheet" button in the Issue Tracker UI which prompts for the sheet tab, triggers the import, reloads issues, shows toast feedback, and records a brief activity. (`app/javascript/components/api.jsx` and `app/javascript/pages/IssueTracker.jsx`).

### Testing
- Ran `ruby -c app/services/issue_sheet_import_service.rb` and it returned `Syntax OK` for the new service file. 
- Ran `ruby -c app/controllers/api/issues_controller.rb` and it returned `Syntax OK` for the controller changes.
- Ran `git diff --check` and no whitespace/errors were reported.
- Attempted to verify `bin/rails routes` but it could not run in this environment due to a Ruby runtime mismatch (`3.2.3` installed vs `3.3.0` in `Gemfile`), so route-list validation was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4ada82b3c8322b14074392f98b153)