### PR TITLE
Fix PDF viewer refresh after modifier actions

### DIFF
--- a/app/javascript/components/FormComponent.jsx
+++ b/app/javascript/components/FormComponent.jsx
@@ -43,10 +43,12 @@ const FormComponent = ({ setActiveForm, setPdfUpdated, setPdfUrl, formFields = [
       if (data.pdf_url && setPdfUrl) {
         setPdfUrl(data.pdf_url);
         localStorage.setItem("pdfUrl", data.pdf_url);
-      } else {
-        // Otherwise just trigger a reload of the current URL (e.g. if name didn't change but content did)
-        setPdfUpdated((prev) => prev + 1);
       }
+
+      // Always bust the viewer cache after a successful mutation.
+      // Some backend actions overwrite the same file path, so relying only on
+      // a URL change can miss refreshes (e.g. add/remove/duplicate page).
+      setPdfUpdated((prev) => prev + 1);
 
       setActiveForm(null);
     } catch (error) {


### PR DESCRIPTION
### Motivation
- Actions that edit the PDF sometimes overwrite the same file path so the viewer did not refresh when `pdf_url` stayed the same, causing a stale view until manual reload.

### Description
- Update `app/javascript/components/FormComponent.jsx` to always increment `setPdfUpdated` after a successful form submission while preserving the existing `pdfUrl`/`localStorage` update when the backend returns a new path.

### Testing
- Ran `npm test` which executed the Vitest suite and passed (`1 file, 3 tests` passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b85a8b808322987b4e46821e122b)