### PR TITLE
Show notification load errors in notifications views

### DIFF
--- a/app/javascript/components/NotificationCenter.jsx
+++ b/app/javascript/components/NotificationCenter.jsx
@@ -10,6 +10,7 @@ const NotificationCenter = () => {
   const [unreadCount, setUnreadCount] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState(null);
 
   useEffect(() => {
     loadNotifications();
@@ -31,15 +32,15 @@ const NotificationCenter = () => {
   }, []);
 
   const loadNotifications = async () => {
+    setLoadError(null);
     try {
       const response = await fetchNotifications({ page: 1 });
       setNotifications(response.data.notifications);
       setUnreadCount(response.data.meta.unread_count);
     } catch (error) {
       // Silently ignore 401 errors (user not authenticated) to avoid console spam
-      if (error?.response?.status !== 401) {
-        console.error("Failed to load notifications", error);
-      }
+      console.error("Failed to load notifications", error);
+      setLoadError("Unable to load notifications right now.");
     }
   };
 
@@ -123,7 +124,9 @@ const NotificationCenter = () => {
                   </div>
 
                   <div className="space-y-4 max-h-96 overflow-y-auto pr-2 custom-scrollbar">
-                    {notifications.length === 0 ? (
+                    {loadError ? (
+                      <p className="text-center text-red-600 py-8 text-sm">{loadError}</p>
+                    ) : notifications.length === 0 ? (
                       <p className="text-center text-gray-500 py-8 text-sm">No notifications yet</p>
                     ) : (
                       notifications.map((notification) => (

--- a/app/javascript/pages/Notifications.jsx
+++ b/app/javascript/pages/Notifications.jsx
@@ -10,6 +10,7 @@ const Notifications = () => {
   const [statusFilter, setStatusFilter] = useState('all');
   const [actionFilter, setActionFilter] = useState('all');
   const [query, setQuery] = useState('');
+  const [loadError, setLoadError] = useState(null);
 
   useEffect(() => {
     loadNotifications();
@@ -17,6 +18,7 @@ const Notifications = () => {
 
   const loadNotifications = async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const response = await fetchNotifications({
         page: 1,
@@ -26,9 +28,8 @@ const Notifications = () => {
       setNotifications(response.data.notifications || []);
       setUnreadCount(response.data.meta?.unread_count || 0);
     } catch (error) {
-      if (error?.response?.status !== 401) {
-        console.error('Failed to load notifications', error);
-      }
+      console.error('Failed to load notifications', error);
+      setLoadError('Unable to load notifications right now. Please refresh and try again.');
     } finally {
       setLoading(false);
     }
@@ -157,6 +158,8 @@ const Notifications = () => {
       <div className="rounded-lg border border-gray-200 bg-white shadow-sm">
         {loading ? (
           <div className="p-8 text-center text-sm text-gray-500">Loading notifications...</div>
+        ) : loadError ? (
+          <div className="p-8 text-center text-sm text-red-600">{loadError}</div>
         ) : notifications.length === 0 ? (
           <div className="p-8 text-center text-sm text-gray-500">No notifications yet</div>
         ) : Object.keys(groupedNotifications).length === 0 ? (


### PR DESCRIPTION
### Motivation
- Users could see a misleading "No notifications yet" when the fetch actually failed; surface API/load failures so the UI differentiates an error from a true empty state.

### Description
- Add a `loadError` state to `app/javascript/pages/Notifications.jsx` and `app/javascript/components/NotificationCenter.jsx`.
- Clear stale errors before each fetch by calling `setLoadError(null)` at the start of `loadNotifications`.
- On fetch failure set a human-friendly message and render that message in the notifications UI instead of always showing the empty-state text.

### Testing
- Ran `git diff --check` to validate there are no whitespace/patch issues.
- Attempted `yarn eslint app/javascript/pages/Notifications.jsx app/javascript/components/NotificationCenter.jsx` which failed in this environment due to missing/unsynced lockfile package state (lint could not complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7b8023ff88322b3e4e485dcbdfae8)