### PR TITLE
Improve chat page UI and hide floating launcher on chat routes

### DIFF
--- a/app/javascript/components/ChatLauncher.jsx
+++ b/app/javascript/components/ChatLauncher.jsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { MessageCircle } from "lucide-react";
 import { fetchConversations } from "./api";
 import { subscribeToUserChat } from "../lib/chatCable";
 
 const ChatLauncher = () => {
+  const location = useLocation();
   const [conversations, setConversations] = useState([]);
 
   useEffect(() => {
@@ -29,9 +30,12 @@ const ChatLauncher = () => {
   }, []);
 
   const unreadCount = useMemo(() => conversations.reduce((count, conversation) => count + (conversation.unread_count || 0), 0), [conversations]);
+  const isChatRoute = location.pathname.startsWith("/chat");
+
+  if (isChatRoute) return null;
 
   return (
-    <Link to="/chat" className="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-lg hover:bg-blue-700">
+    <Link to="/chat" className="fixed bottom-6 right-6 z-40 inline-flex items-center gap-2 rounded-full bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-900/25 hover:bg-blue-700">
       <MessageCircle size={18} />
       Chat
       {unreadCount > 0 && <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-bold text-red-700">{unreadCount}</span>}

--- a/app/javascript/pages/Chat.jsx
+++ b/app/javascript/pages/Chat.jsx
@@ -551,16 +551,21 @@ const Chat = () => {
   }, [conversations, sideSearchQuery, user]);
 
   return (
-    <div className="flex h-[calc(100vh-64px)] w-full bg-gradient-to-br from-slate-50 via-white to-indigo-50/40 dark:from-zinc-900 dark:via-zinc-900 dark:to-zinc-950 overflow-hidden">
+    <div className="flex h-[calc(100vh-64px)] w-full bg-gradient-to-br from-slate-100 via-white to-indigo-100/40 dark:from-zinc-950 dark:via-zinc-900 dark:to-zinc-950 overflow-hidden">
 
       {/* --- Sidebar --- */}
-      <aside className={`flex flex-col w-full md:w-80 border-r border-slate-200/80 dark:border-zinc-800 bg-white/90 dark:bg-zinc-900/70 backdrop-blur ${conversationId ? 'hidden md:flex' : 'flex'}`}>
+      <aside className={`flex flex-col w-full md:w-80 lg:w-96 border-r border-slate-200/80 dark:border-zinc-800 bg-white/90 dark:bg-zinc-900/70 backdrop-blur-xl ${conversationId ? 'hidden md:flex' : 'flex'}`}>
         {/* Header */}
-        <div className="p-4 border-b border-slate-200 dark:border-zinc-800 flex items-center justify-between">
+        <div className="p-4 border-b border-slate-200 dark:border-zinc-800 flex items-center justify-between bg-gradient-to-r from-white to-slate-50 dark:from-zinc-900 dark:to-zinc-900/70">
+          <div>
             <h1 className="text-xl font-bold text-slate-800 dark:text-white">Messages</h1>
+            <p className="text-xs text-slate-500 dark:text-slate-400 mt-1">
+              {conversations.direct.length + conversations.group.length} conversations
+            </p>
+          </div>
             <button
               onClick={() => { setIsNewChatModalOpen(true); setNewChatStep('select'); setSelectedUserIds([]); }}
-              className="p-2 bg-[var(--theme-color)] text-white rounded-lg shadow-sm hover:brightness-110 transition"
+              className="p-2.5 bg-[var(--theme-color)] text-white rounded-xl shadow-sm hover:brightness-110 transition"
               title="Start a new conversation"
             >
               <FiEdit className="w-5 h-5" />
@@ -597,7 +602,10 @@ const Chat = () => {
               {/* Direct Messages */}
               {filteredConversations.direct.length > 0 && (
                 <div>
-                  <h2 className="px-2 text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Direct Messages</h2>
+                  <h2 className="px-2 text-xs font-bold text-slate-400 uppercase tracking-wider mb-2 flex items-center justify-between">
+                    <span>Direct Messages</span>
+                    <span className="text-[10px] font-semibold text-slate-400">{filteredConversations.direct.length}</span>
+                  </h2>
                   <div className="space-y-1">
                     {filteredConversations.direct.map(c => (
                       <ConversationItem key={c.id} conversation={c} isActive={Number(conversationId) === c.id} user={user} />
@@ -646,7 +654,7 @@ const Chat = () => {
         ) : (
           <>
             {/* Header */}
-            <header className="h-16 px-6 border-b border-slate-200/70 dark:border-zinc-800 flex items-center justify-between shrink-0 bg-white/85 dark:bg-zinc-900/80 backdrop-blur-sm z-10 sticky top-0">
+            <header className="h-16 px-6 border-b border-slate-200/70 dark:border-zinc-800 flex items-center justify-between shrink-0 bg-white/90 dark:bg-zinc-900/90 backdrop-blur-sm z-10 sticky top-0">
               <div className="flex items-center gap-3">
                 <Link to="/chat" className="md:hidden p-2 -ml-2 text-slate-500 hover:bg-slate-100 rounded-full">
                   <FiArrowLeft />
@@ -693,7 +701,7 @@ const Chat = () => {
 
                 {/* Messages */}
                 <div
-                  className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6 bg-white/50 dark:bg-zinc-900/40 scroll-smooth relative"
+                  className="flex-1 overflow-y-auto p-4 md:p-6 space-y-6 bg-white/40 dark:bg-zinc-900/40 scroll-smooth relative"
                   style={{
                     backgroundImage: `radial-gradient(circle at 2px 2px, rgba(0,0,0,0.05) 1px, transparent 0)`,
                     backgroundSize: '24px 24px'
@@ -748,7 +756,7 @@ const Chat = () => {
                 </div>
 
                 {/* Input Area */}
-                <div className="p-4 bg-white/90 dark:bg-zinc-900 border-t border-slate-200/70 dark:border-zinc-800 shrink-0 backdrop-blur-sm">
+                <div className="p-4 bg-white/95 dark:bg-zinc-900 border-t border-slate-200/70 dark:border-zinc-800 shrink-0 backdrop-blur-sm">
                   {attachments.length > 0 && (
                     <div className="flex gap-2 mb-3 overflow-x-auto pb-2">
                       {attachments.map((file, i) => (
@@ -765,7 +773,7 @@ const Chat = () => {
                     </div>
                   )}
 
-                  <form onSubmit={handleSendMessage} className="flex gap-3 items-end">
+                  <form onSubmit={handleSendMessage} className="flex gap-3 items-end rounded-2xl border border-slate-200 dark:border-zinc-700 bg-white dark:bg-zinc-900 p-2 shadow-sm">
                     <input
                       type="file"
                       multiple
@@ -776,7 +784,7 @@ const Chat = () => {
                     <button
                       type="button"
                       onClick={() => fileInputRef.current?.click()}
-                      className="p-3 text-slate-400 hover:text-[var(--theme-color)] hover:bg-slate-50 rounded-xl transition"
+                      className="p-3 text-slate-400 hover:text-[var(--theme-color)] hover:bg-slate-100 dark:hover:bg-zinc-800 rounded-xl transition"
                     >
                       <FiPaperclip className="w-5 h-5" />
                     </button>
@@ -801,7 +809,7 @@ const Chat = () => {
                       }}
                       placeholder="Write a message..."
                       rows={1}
-                      className="flex-1 bg-slate-100 dark:bg-zinc-800 border-0 rounded-xl px-4 py-3 max-h-32 focus:ring-2 focus:ring-[var(--theme-color)]/20 outline-none resize-none overflow-hidden"
+                      className="flex-1 bg-slate-50 dark:bg-zinc-800 border-0 rounded-xl px-4 py-3 max-h-32 focus:ring-2 focus:ring-[var(--theme-color)]/20 outline-none resize-none overflow-hidden"
                       style={{ minHeight: '44px' }}
                     />
 


### PR DESCRIPTION
### Motivation
- Polish the chat experience to reduce visual clutter and prevent the floating chat launcher from overlapping the chat page.
- Make the sidebar more informative and the composer area more focused for a cleaner, modern layout.

### Description
- Hide the global floating chat launcher when the current route starts with `/chat` by adding `useLocation` and returning `null` for that route in `app/javascript/components/ChatLauncher.jsx`.
- Increase sidebar width on large screens, add a subtle header gradient, and surface a conversation count in the sidebar header in `app/javascript/pages/Chat.jsx`.
- Improve message area and composer styling by adjusting background gradients, backdrop blur, input/container borders, padding and shadows to create a more premium, focused input area in `app/javascript/pages/Chat.jsx`.
- Minor button and shadow tweaks to the launcher and action buttons to improve visual hierarchy in both `ChatLauncher.jsx` and `Chat.jsx`.

### Testing
- Attempted `npm run -s lint`, which exited non-zero in this environment and could not be validated here.
- Ran `npm test` which failed because the `vitest` binary is not available in this environment.
- Ran `npm run build` which failed because the `esbuild` binary is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7ba84db108322a482b49ec46d3d41)