### PR TITLE
Make sprint task developer assignments project-member based

### DIFF
--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -862,7 +862,6 @@ const SprintOverview = ({ sprintId, onSprintChange, projectId, sheetIntegrationE
     };
 
     useEffect(() => {
-        SchedulerAPI.getDevelopers().then(res => setDevelopers(res.data));
         if (projectId) {
             fetchProjects().then(({ data }) => {
                 const list = Array.isArray(data) ? data : [];
@@ -870,12 +869,19 @@ const SprintOverview = ({ sprintId, onSprintChange, projectId, sheetIntegrationE
                 const members = (project ? project.users : []).map(u => ({
                     id: u.id,
                     first_name: u.name,
-                    email: u.name,
+                    email: u.email || u.name,
                     profile_picture: u.profile_picture
                 }));
                 setUsers(members);
+                setDevelopers(
+                    members.map(member => ({
+                        id: member.id,
+                        name: member.first_name || member.email
+                    }))
+                );
             });
         } else {
+            SchedulerAPI.getDevelopers().then(res => setDevelopers(res.data));
             getUsers().then(res => setUsers(Array.isArray(res.data) ? res.data : []));
         }
         const query = projectId ? `?project_id=${projectId}` : '';


### PR DESCRIPTION
### Motivation
- The Assigned To Developer dropdown used a global/static developer list and did not reflect the users assigned to a specific project when creating or editing tasks.
- The goal is to make assignment options dynamic and scoped to the selected `projectId` so task assignments are limited to project members.

### Description
- Updated `app/javascript/pages/SprintOverview.jsx` to load project members via `fetchProjects()` when `projectId` is present and derive both `users` and `developers` from `project.users` instead of the global developers endpoint.
- Preserved existing behavior for non-project contexts by continuing to call `SchedulerAPI.getDevelopers()` and `getUsers()` when no `projectId` is provided.
- Fixed label/data mapping to prefer the real user email with `email: u.email || u.name` and map project members into the `developers` array as `{ id, name }` for dropdown options.

### Testing
- Ran `npm run -s eslint -- app/javascript/pages/SprintOverview.jsx`, which failed due to repo not having a configured `eslint` script (exit code 1).
- Ran `npm run eslint -- app/javascript/pages/SprintOverview.jsx`, which reported the repo has no `eslint` npm script.
- Ran `bin/rails test`, which could not execute because the runtime Ruby version is `3.2.3` while the `Gemfile` requires `3.3.0`, so Rails tests could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea04c967408322928d41c6c4df56e9)