### PR TITLE
Fix ProjectUser notification actor lookup

### DIFF
--- a/app/models/project_user.rb
+++ b/app/models/project_user.rb
@@ -36,11 +36,12 @@ class ProjectUser < ApplicationRecord
   private
 
   def notify_user
-    return unless created_by && created_by != user_id
+    actor_id = Current.user&.id
+    return unless actor_id && actor_id != user_id
 
     Notification.create(
       recipient: user,
-      actor_id: created_by,
+      actor_id: actor_id,
       action: 'assigned',
       notifiable: self,
       metadata: { project_name: project.name, role: role }


### PR DESCRIPTION
### Motivation
- Creating a `ProjectUser` raised a `NameError` because `notify_user` referenced a non-existent `created_by` accessor on `ProjectUser`, preventing notification creation.

### Description
- Replace `created_by` usage in `ProjectUser#notify_user` with `actor_id = Current.user&.id`, preserve the self-notification guard by checking `actor_id != user_id`, and pass `actor_id` to `Notification.create`.

### Testing
- Attempted to run `bin/rails test test/models/project_user_test.rb` but tests were blocked due to a Ruby version mismatch (runtime `3.2.3` vs Gemfile `3.3.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea089d50388322ad87b0c6711f9b92)