### PR TITLE
Filter scheduler developers by selected project

### DIFF
--- a/app/controllers/api/developers_controller.rb
+++ b/app/controllers/api/developers_controller.rb
@@ -1,6 +1,7 @@
 class Api::DevelopersController < Api::BaseController
   def index
     users = User.order(:first_name, :last_name, :email)
+    users = users.joins(:project_users).where(project_users: { project_id: params[:project_id] }).distinct if params[:project_id].present?
     render json: users.map { |user| serialize_developer(user) }
   end
 

--- a/app/javascript/components/Scheduler/Scheduler.jsx
+++ b/app/javascript/components/Scheduler/Scheduler.jsx
@@ -283,7 +283,7 @@ function Scheduler({ sprintId, projectId, sheetIntegrationEnabled, qaMode = fals
     if (qaMode) params.type = 'qa';
 
     Promise.all([
-      SchedulerAPI.getDevelopers(),
+      SchedulerAPI.getDevelopers(projectId ? { project_id: projectId } : {}),
       SchedulerAPI.getTaskLogs(params),
       SchedulerAPI.getTasks(params)
     ])

--- a/app/javascript/components/api.jsx
+++ b/app/javascript/components/api.jsx
@@ -54,7 +54,7 @@ export const SchedulerAPI = {
   updateSprint: (id, data) => api.put(`/sprints/${id}.json`, { sprint: data }),
 
   // Developers
-  getDevelopers: () => api.get("/developers.json"),
+  getDevelopers: (params = {}) => api.get("/developers.json", { params }),
 
   // Tasks
   getTasks: (params = {}) => api.get("/tasks.json", { params }),


### PR DESCRIPTION
### Motivation
- The scheduler currently shows all users on the board which is noisy; the board should only display users who are members of the selected project so scheduling reflects actual project assignments.

### Description
- Update `Api::DevelopersController#index` to optionally filter users by `project_id` using `joins(:project_users).where(project_users: { project_id: params[:project_id] }).distinct` when `params[:project_id]` is present.
- Change `SchedulerAPI.getDevelopers` to accept an optional `params` argument and forward it to `/developers.json`.
- Update the Scheduler component to request developers with `project_id` when a project is selected so the UI receives only project-associated users.

### Testing
- Ran `bundle exec ruby -c app/controllers/api/developers_controller.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09890700c8322a77282a00c3b4b0f)