### PR TITLE
Fix PDF download flow when opening in a new tab

### DIFF
--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -35,17 +35,42 @@ class PdfsController < ApplicationController
   end
 
   def download
-    if session[:pdf_id].present?
-      working_path = Rails.root.join('public', 'uploads', "#{session[:pdf_id]}_working.pdf")
+    working_path = download_path_from_session || download_path_from_param
+    file_name = session[:original_filename].presence || default_download_name(working_path)
 
-      file_name = session[:original_filename].present? ? session[:original_filename] : "pdf_modifier.pdf"
-      if File.exist?(working_path)
-        send_file working_path, type: 'application/pdf', filename: file_name
-      else
-        render json: { success: false, message: 'PDF not found' }
-      end
+    if working_path.present? && File.exist?(working_path)
+      send_file working_path, type: 'application/pdf', filename: file_name
+    elsif session[:pdf_id].present?
+      render json: { success: false, message: 'PDF not found' }
     else
       render json: { success: false, message: 'No active session' }
     end
+  end
+
+  private
+
+  def download_path_from_session
+    return if session[:pdf_id].blank?
+
+    Rails.root.join('public', 'uploads', "#{session[:pdf_id]}_working.pdf").to_s
+  end
+
+  def download_path_from_param
+    return if params[:pdf_path].blank?
+
+    requested_path = params[:pdf_path].to_s.sub(%r{\A/+}, '')
+    full_path = Rails.root.join('public', requested_path).cleanpath
+    public_root = Rails.root.join('public').to_s
+
+    return unless full_path.to_s.start_with?(public_root)
+    return unless File.extname(full_path.to_s).casecmp('.pdf').zero?
+
+    full_path.to_s
+  end
+
+  def default_download_name(path)
+    return "pdf_modifier.pdf" if path.blank?
+
+    File.basename(path)
   end
 end

--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -105,7 +105,11 @@ const PdfPage = () => {
         <div className="flex items-center space-x-4">
           <button onClick={() => { setPdfUrl(null); localStorage.removeItem("pdfUrl"); }} className="text-xs font-bold text-gray-400 hover:text-red-500 transition-colors">Close</button>
           <button 
-            onClick={() => window.open("/download_pdf", "_blank")} 
+            onClick={() => {
+              const cleanPath = (pdfUrl || "").split("?")[0].replace(/^\//, "");
+              const downloadUrl = cleanPath ? `/download_pdf?pdf_path=${encodeURIComponent(cleanPath)}` : "/download_pdf";
+              window.open(downloadUrl, "_blank");
+            }}
             className="flex items-center px-4 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-xs font-bold transition-all shadow-lg shadow-indigo-100 active:scale-95"
           >
             <Download className="h-3.5 w-3.5 mr-2" />


### PR DESCRIPTION
### Motivation
- Opening `/download_pdf` in a new tab could lack the Rails session cookie and return `{ "success": false, "message": "No active session" }` instead of delivering the PDF.

### Description
- Update `PdfsController#download` to first try the session-backed working file and then fall back to a validated `pdf_path` query parameter when the session is not present (changes in `app/controllers/pdfs_controller.rb`).
- Add safe path resolution helpers (`download_path_from_session`, `download_path_from_param`) that ensure resolved files live under `public/` and have a `.pdf` extension, and add `default_download_name` for filename fallback.
- Update the frontend download button to include the current file path as `pdf_path` in the open URL so new-tab downloads work without relying on the session cookie (changes in `app/javascript/components/PdfPage.jsx`).
- Preserve existing error responses (`PDF not found`, `No active session`) and keep session-based behavior as the first priority.

### Testing
- Ran the test suite via `bin/rails test`, which could not run in this environment due to a Ruby version mismatch reported by Bundler (runtime `3.2.3` vs Gemfile `3.3.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0990e67c88322b376fbed465cda00)