### PR TITLE
Import FiArrowRight to fix DepartmentDetails runtime error

### DIFF
--- a/app/javascript/pages/DepartmentDetails.jsx
+++ b/app/javascript/pages/DepartmentDetails.jsx
@@ -15,7 +15,8 @@ import {
   FiSave,
   FiBriefcase,
   FiCpu,
-  FiUser
+  FiUser,
+  FiArrowRight
 } from "react-icons/fi";
 import {
   fetchDepartment,


### PR DESCRIPTION
### Motivation
- Prevent a runtime `ReferenceError: FiArrowRight is not defined` thrown when rendering the member picker on the Department Details page which blocked member management flows.

### Description
- Add the missing `FiArrowRight` import to `app/javascript/pages/DepartmentDetails.jsx` so the arrow icon used in the member modal renders correctly.

### Testing
- Ran `npm run build` to validate the frontend build, but it failed in this environment because `esbuild` is not available on PATH, so the change could not be compiled here; no other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a4ae52f48322936cc8e43afb3b77)