### PR TITLE
Fix PDF modifier header overlapping top navbar on scroll

### DIFF
--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -93,9 +93,9 @@ const PdfPage = () => {
   }
 
   return (
-    <div className="h-screen w-screen flex flex-col bg-white overflow-hidden font-inter select-none">
+    <div className="h-full w-full flex min-h-0 flex-col bg-white overflow-hidden font-inter select-none">
       {/* 🚀 Header */}
-      <header className="h-14 border-b border-gray-100 flex items-center justify-between px-6 bg-white shrink-0 z-50">
+      <header className="h-14 border-b border-gray-100 flex items-center justify-between px-6 bg-white shrink-0 z-30">
         <div className="flex items-center space-x-4">
           <div className="bg-indigo-600 text-white p-1.5 rounded-lg shadow-lg shadow-indigo-200">
             <Plus className="h-4 w-4" />


### PR DESCRIPTION
### Motivation
- Prevent the PDF workspace and its header from visually overlapping the app's global sticky navbar when scrolling by adjusting layout sizing and stacking order.

### Description
- Update `app/javascript/components/PdfPage.jsx` to replace `h-screen w-screen` with `h-full w-full min-h-0` on the PDF root container and lower the header stacking context from `z-50` to `z-30`.

### Testing
- Ran `git diff --check -- app/javascript/components/PdfPage.jsx` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0a54fc9b0832280211c0ed170c702)