### PR TITLE
Fix unreadable Department Lead dropdown contrast

### DIFF
--- a/app/javascript/pages/DepartmentDetails.jsx
+++ b/app/javascript/pages/DepartmentDetails.jsx
@@ -360,11 +360,11 @@ const DepartmentDetails = () => {
                 <select
                   value={newManagerId}
                   onChange={(e) => setNewManagerId(e.target.value)}
-                  className="w-full bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-lg p-2.5 text-sm outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
+                  className="w-full bg-slate-50 dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 rounded-lg p-2.5 text-sm text-slate-900 dark:text-white outline-none focus:ring-2 focus:ring-[var(--theme-color)]"
                 >
-                  <option value="">No Lead Assigned</option>
+                  <option value="" className="text-slate-900">No Lead Assigned</option>
                   {users.map(u => (
-                    <option key={u.id} value={u.id}>{u.full_name}</option>
+                    <option key={u.id} value={u.id} className="text-slate-900">{u.full_name}</option>
                   ))}
                 </select>
                 <div className="flex justify-end gap-2">


### PR DESCRIPTION
### Motivation
- Fix the Department Lead edit dropdown which could render option text as white-on-white and be unreadable under certain theme/browser combinations.

### Description
- Update `app/javascript/pages/DepartmentDetails.jsx` to add explicit text color classes to the `<select>` (`text-slate-900 dark:text-white`) and to each `<option>` (`className="text-slate-900"`) so the selected value and options remain visible on light and dark backgrounds.

### Testing
- Ran `npm run lint -- app/javascript/pages/DepartmentDetails.jsx` (failed because there is no `lint` script in `package.json`) and `bin/rails test` (could not run in this environment due to Ruby version mismatch: installed 3.2.3 vs Gemfile requirement 3.3.0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b05d94d08322b73d7533f165dc74)