### PR TITLE
Add missing browser page titles for uncovered routes

### DIFF
--- a/app/javascript/components/PageTitle.jsx
+++ b/app/javascript/components/PageTitle.jsx
@@ -3,44 +3,50 @@ import { useLocation } from "react-router-dom";
 
 const APP_NAME = "My Rails + Vite + React App";
 
+const routeTitles = {
+  "/": "Calendar",
+  "/calendar": "Calendar",
+  "/contact": "Contact",
+  "/legal": "Legal",
+  "/pdf": "PDF",
+  "/momentum": "Daily Momentum Hub",
+  "/posts": "Posts",
+  "/vault": "Vault",
+  "/profile": "Profile",
+  "/knowledge": "Knowledge Dashboard",
+  "/worklog": "Work Log",
+  "/projects": "Projects",
+  "/teams": "Teams",
+  "/users": "Users",
+  "/departments": "Departments",
+  "/admin": "Admin",
+  "/admin/login-as-user": "Admin Impersonation",
+  "/settings": "Settings",
+  "/chat": "Chat",
+  "/notifications": "Notifications",
+  "/forgot-password": "Forgot Password",
+  "/reset-password": "Reset Password",
+};
+
+const pageTitleForPath = (pathname) => {
+  if (routeTitles[pathname]) return routeTitles[pathname];
+
+  if (/^\/projects\/[^/]+\/dashboard$/.test(pathname)) return "Sprint Dashboard";
+  if (/^\/projects\/[^/]+\/issues$/.test(pathname)) return "Issue Tracker";
+  if (/^\/departments\/[^/]+$/.test(pathname)) return "Department Details";
+  if (/^\/profile\/[^/]+$/.test(pathname)) return "Profile";
+  if (/^\/chat\/[^/]+$/.test(pathname)) return "Chat";
+
+  return null;
+};
+
 const PageTitle = () => {
   const location = useLocation();
 
   useEffect(() => {
-    const { pathname } = location;
-    const titles = {
-      "/contact": "Contact",
-      "/legal": "Legal",
-      "/pdf": "PDF",
-      "/momentum": "Daily Momentum Hub",
-      "/posts": "Posts",
-      "/vault": "Vault",
-      "/profile": "Profile",
-      "/knowledge": "Knowledge Dashboard",
-      "/worklog": "Work Log",
-      "/calendar": "Calendar",
-      "/projects": "Projects",
-      "/teams": "Teams",
-      "/users": "Users",
-      "/departments": "Departments",
-      "/admin": "Admin",
-      "/settings": "Settings",
-    };
-
-    let title = APP_NAME;
-
-    if (pathname === "/") {
-      title = `Calendar | ${APP_NAME}`;
-    } else if (/^\/projects\/[^/]+\/dashboard$/.test(pathname)) {
-      title = `Sprint Dashboard | ${APP_NAME}`;
-    } else if (titles[pathname]) {
-      title = `${titles[pathname]} | ${APP_NAME}`;
-    } else {
-      title = APP_NAME;
-    }
-
-    document.title = title;
-  }, [location]);
+    const title = pageTitleForPath(location.pathname);
+    document.title = title ? `${title} | ${APP_NAME}` : APP_NAME;
+  }, [location.pathname]);
 
   return null;
 };


### PR DESCRIPTION
### Motivation
- Ensure every page in the SPA has a meaningful browser title instead of falling back to the app default. 
- Centralize title resolution so static and dynamic routes can be extended and maintained easily.

### Description
- Refactored `PageTitle` to use a centralized `routeTitles` map and a `pageTitleForPath` helper to resolve titles for both static and parameterized routes in `app/javascript/components/PageTitle.jsx`.
- Added explicit titles for previously uncovered routes including `forgot-password`, `reset-password`, `admin/login-as-user`, `chat`, and `notifications`.
- Added pattern-based title resolution for dynamic routes such as project dashboards, project issues, department details, profile-by-id, and chat conversation routes using regular expressions.
- Simplified the `useEffect` to set `document.title` based on the resolved page title with the consistent format `<Page> | <App Name>`.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues, which completed successfully. 
- Performed a quick module import check with `node -e "import('./app/javascript/components/PageTitle.jsx')..."` which failed in this environment because Node cannot import `.jsx` modules without the project's transpilation tooling (this is an environment limitation, not a runtime app failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4933f7eac8322abe6b4e1d14463c5)