### PR TITLE
Add mention-based ping notifications for chat messages

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -53,6 +53,9 @@ class Api::NotificationsController < Api::BaseController
     when 'chat_message'
       conversation_name = notification.metadata&.dig('conversation_name') || 'a conversation'
       "#{notification.actor.full_name} sent a message in #{conversation_name}"
+    when 'chat_ping'
+      conversation_name = notification.metadata&.dig('conversation_name') || 'a conversation'
+      "#{notification.actor.full_name} mentioned you in #{conversation_name}"
     else
       "New notification"
     end

--- a/app/javascript/components/NotificationCenter.jsx
+++ b/app/javascript/components/NotificationCenter.jsx
@@ -81,6 +81,7 @@ const NotificationCenter = () => {
     switch (action) {
       case 'commented': return <MessageSquare className="w-4 h-4 text-blue-500" />;
       case 'chat_message': return <MessageSquare className="w-4 h-4 text-indigo-500" />;
+      case 'chat_ping': return <MessageSquare className="w-4 h-4 text-fuchsia-500" />;
       case 'assigned': return <Briefcase className="w-4 h-4 text-green-500" />;
       case 'update': return <FileText className="w-4 h-4 text-orange-500" />;
       default: return <Bell className="w-4 h-4 text-gray-500" />;

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,6 +1,7 @@
 class Message < ApplicationRecord
   IMAGE_TYPES = %w[image/png image/jpeg image/jpg image/gif image/webp].freeze
   VIDEO_TYPES = %w[video/mp4 video/webm video/quicktime].freeze
+  MENTION_REGEX = /@([a-zA-Z0-9._-]+)/.freeze
 
   belongs_to :conversation
   belongs_to :user
@@ -48,19 +49,45 @@ class Message < ApplicationRecord
   end
 
   def notify_participants
-    recipient_ids = conversation.participants.where.not(id: user_id).pluck(:id)
+    recipients = conversation.participants.where.not(id: user_id)
+    mentioned_user_ids = extract_mentioned_user_ids(recipients)
 
-    recipient_ids.each do |recipient_id|
+    recipients.find_each do |recipient|
+      mentioned = mentioned_user_ids.include?(recipient.id)
+
       Notification.create(
-        recipient_id: recipient_id,
+        recipient_id: recipient.id,
         actor: user,
-        action: "chat_message",
+        action: mentioned ? "chat_ping" : "chat_message",
         notifiable: self,
         metadata: {
           conversation_id: conversation_id,
-          conversation_name: conversation.display_name(User.find(recipient_id))
+          conversation_name: conversation.display_name(recipient),
+          mentioned: mentioned
         }
       )
     end
+  end
+
+  def extract_mentioned_user_ids(recipients)
+    return [] if body.blank?
+
+    handles = body.scan(MENTION_REGEX).flatten.map(&:downcase).uniq
+    return [] if handles.empty?
+
+    recipients.select do |participant|
+      mention_handles_for(participant).any? { |handle| handles.include?(handle) }
+    end.map(&:id)
+  end
+
+  def mention_handles_for(participant)
+    [
+      participant.email.to_s.split("@").first,
+      participant.full_name.to_s,
+      [ participant.first_name, participant.last_name ].compact.join(" "),
+      participant.first_name.to_s
+    ].map { |value| value.to_s.downcase.strip.gsub(/\s+/, ".") }
+      .reject(&:blank?)
+      .uniq
   end
 end


### PR DESCRIPTION
### Motivation
- Improve chat usability by notifying users who are explicitly mentioned with `@handle` so pings are distinguishable from regular conversation messages.
- Allow the system to surface mention context in notification text and UI to make pings more visible in notification lists.

### Description
- Added `MENTION_REGEX` and mention-parsing helpers to `Message` to extract handles and match them to conversation participants via `mention_handles_for` and `extract_mentioned_user_ids`.
- Reworked `Message#notify_participants` to send `chat_ping` notifications to mentioned users and `chat_message` notifications to other participants, and to include `conversation_name` and `mentioned` in `metadata`.
- Extended `Api::NotificationsController#generate_message` to render a specific message for `chat_ping` actions ("mentioned you in ...").
- Updated the frontend `NotificationCenter` icon mapping to render a distinct style for `chat_ping` notifications by adding a `chat_ping` case to `getIcon`.

### Testing
- Ran `ruby -c app/models/message.rb` which reported `Syntax OK`.
- Ran `ruby -c app/controllers/api/notifications_controller.rb` which reported `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4a597b8b483228e37b76cca1b4cd1)