### PR TITLE
Fix notifications pagination without pagination gem

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,13 +1,18 @@
 class Api::NotificationsController < Api::BaseController
+  PAGE_SIZE = 20
+
   def index
-    notifications_scope = current_user.notifications.recent
+    notifications_scope = current_user.notifications.includes(:actor).recent
     notifications_scope = apply_status_filter(notifications_scope)
     notifications_scope = apply_action_filter(notifications_scope)
     notifications_scope = apply_notifiable_type_filter(notifications_scope)
-    notifications = notifications_scope.page(params[:page]).per(20)
-    
+
+    current_page = requested_page
+    total_count = notifications_scope.count
+    notifications = notifications_scope.offset((current_page - 1) * PAGE_SIZE).limit(PAGE_SIZE)
+
     render json: {
-      notifications: notifications.map do |n| 
+      notifications: notifications.map do |n|
         {
           id: n.id,
           actor: n.actor.full_name,
@@ -22,8 +27,8 @@ class Api::NotificationsController < Api::BaseController
         }
       end,
       meta: {
-        total_pages: notifications.total_pages,
-        current_page: notifications.current_page,
+        total_pages: total_pages(total_count),
+        current_page: current_page,
         unread_count: current_user.notifications.unread.count
       }
     }
@@ -41,6 +46,15 @@ class Api::NotificationsController < Api::BaseController
   end
 
   private
+
+  def requested_page
+    page = params[:page].to_i
+    page.positive? ? page : 1
+  end
+
+  def total_pages(total_count)
+    (total_count.to_f / PAGE_SIZE).ceil
+  end
 
   def generate_message(notification)
     case notification.action


### PR DESCRIPTION
### Motivation
- The notifications index relied on `.page(...).per(...)` which requires a pagination gem; that dependency was removed in favor of a simple, explicit pagination implementation. 
- Responses should include accurate `total_pages`/`current_page` metadata and avoid N+1 queries when serializing actor data.

### Description
- Replace `notifications_scope.page(params[:page]).per(20)` with explicit `offset`/`limit` pagination using a `PAGE_SIZE = 20` constant. 
- Add `requested_page` to normalize page params and `total_pages(total_count)` to compute pages without a gem. 
- Eager-load actors with `includes(:actor)` and compute `total_count` for metadata, returning `meta.total_pages` and `meta.current_page` based on the new helpers. 

### Testing
- `ruby -c app/controllers/api/notifications_controller.rb` succeeded to validate syntax. 
- `npm test` (Vitest) ran and passed (2 test files, 8 tests). 
- `bin/rails test` could not be executed in this environment because the runtime Ruby is `3.4.4` while the `Gemfile` specifies `3.3.0`, causing a Bundler version mismatch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fca03a4c788322a95f199d4926c6ca)