### PR TITLE
Expand Settings landing pages and notification preferences

### DIFF
--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -64,12 +64,18 @@ class Api::NotificationsController < Api::BaseController
       "#{notification.actor.full_name} commented on your post"
     when 'update'
       "#{notification.actor.full_name} updated a task"
+    when 'calendar_reminder'
+      event_title = notification.metadata&.dig('event_title') || 'an event'
+      "Reminder: #{event_title} is coming up"
     when 'chat_message'
       conversation_name = notification.metadata&.dig('conversation_name') || 'a conversation'
       "#{notification.actor.full_name} sent a message in #{conversation_name}"
     when 'chat_ping'
       conversation_name = notification.metadata&.dig('conversation_name') || 'a conversation'
       "#{notification.actor.full_name} mentioned you in #{conversation_name}"
+    when 'reacted'
+      emoji = notification.metadata&.dig('emoji')
+      emoji.present? ? "#{notification.actor.full_name} reacted #{emoji} to your message" : "#{notification.actor.full_name} reacted to your message"
     else
       "New notification"
     end

--- a/app/javascript/pages/Notifications.jsx
+++ b/app/javascript/pages/Notifications.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Bell, Check, Clock, MessageSquare, Briefcase, FileText } from 'lucide-react';
+import { Bell, Calendar, Check, Clock, Heart, MessageSquare, Briefcase, FileText } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { fetchNotifications, markNotificationRead, markAllNotificationsRead } from '../components/api';
 
@@ -63,7 +63,12 @@ const Notifications = () => {
       case 'commented':
         return <MessageSquare className="w-4 h-4 text-blue-500" />;
       case 'chat_message':
+      case 'chat_ping':
         return <MessageSquare className="w-4 h-4 text-indigo-500" />;
+      case 'reacted':
+        return <Heart className="w-4 h-4 text-pink-500" />;
+      case 'calendar_reminder':
+        return <Calendar className="w-4 h-4 text-purple-500" />;
       case 'assigned':
         return <Briefcase className="w-4 h-4 text-green-500" />;
       case 'update':
@@ -144,6 +149,9 @@ const Notifications = () => {
             <option value="commented">Comments</option>
             <option value="update">Updates</option>
             <option value="chat_message">Chat messages</option>
+            <option value="chat_ping">Chat mentions</option>
+            <option value="reacted">Message reactions</option>
+            <option value="calendar_reminder">Calendar reminders</option>
           </select>
 
           <input

--- a/app/javascript/pages/Settings.jsx
+++ b/app/javascript/pages/Settings.jsx
@@ -9,14 +9,13 @@ import {
   Palette,
   Bell,
   Shield,
-  LogOut,
   Moon,
   Sun,
-  Check,
-  Laptop
+  Check
 } from "lucide-react";
 
 const landingPageOptions = [
+  { value: "calendar", label: "Calendar" },
   { value: "posts", label: "Posts Feed" },
   { value: "profile", label: "My Profile" },
   { value: "vault", label: "Personal Vault" },
@@ -24,6 +23,54 @@ const landingPageOptions = [
   { value: "worklog", label: "Work Logs" },
   { value: "projects", label: "Projects Dashboard" },
   { value: "teams", label: "Teams Overview" },
+  { value: "pdf", label: "PDF Tools" },
+  { value: "users", label: "People Directory" },
+  { value: "departments", label: "Departments" },
+  { value: "chat", label: "Chat" },
+  { value: "notifications", label: "Notifications" },
+];
+
+const notificationPreferenceOptions = [
+  {
+    key: "commented",
+    label: "Comments",
+    description: "Get notified when someone comments on your posts."
+  },
+  {
+    key: "assigned",
+    label: "Assignments",
+    description: "Get notified when a task or project is assigned to you."
+  },
+  {
+    key: "update",
+    label: "Task Updates",
+    description: "Get notified when a task assigned to you changes status."
+  },
+  {
+    key: "chat_message",
+    label: "Chat Messages",
+    description: "Get notified when someone sends a message in your conversations."
+  },
+  {
+    key: "chat_ping",
+    label: "Chat Mentions",
+    description: "Get notified when someone mentions you in chat."
+  },
+  {
+    key: "reacted",
+    label: "Message Reactions",
+    description: "Get notified when someone reacts to one of your chat messages."
+  },
+  {
+    key: "calendar_reminder",
+    label: "Calendar Reminders",
+    description: "Get notified when your calendar reminders are due."
+  },
+  {
+    key: "digest",
+    label: "Weekly Digest",
+    description: "Receive a weekly summary of your team's activity."
+  },
 ];
 
 function classNames(...classes) {
@@ -37,6 +84,10 @@ const Settings = () => {
     commented: true,
     assigned: true,
     update: true,
+    chat_message: true,
+    chat_ping: true,
+    reacted: true,
+    calendar_reminder: true,
     digest: false
   };
 
@@ -269,83 +320,28 @@ const Settings = () => {
                 </div>
 
                 <div className="space-y-4">
-                  <Switch.Group as="div" className="flex items-center justify-between py-3">
-                    <span className="flex-grow flex flex-col">
-                      <Switch.Label as="span" className="text-sm font-medium text-gray-900" passive>
-                        Comments
-                      </Switch.Label>
-                      <Switch.Description as="span" className="text-sm text-gray-500">
-                        Get notified when someone posts a comment on your task.
-                      </Switch.Description>
-                    </span>
-                  <Switch
-                      checked={notificationPrefs.commented}
-                      onChange={(val) => setNotificationPrefs((p) => ({ ...p, commented: val }))}
-                      className={`${notificationPrefs.commented ? 'bg-blue-600' : 'bg-gray-200'} relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
-                    >
-                      <span aria-hidden="true" className={`${notificationPrefs.commented ? 'translate-x-5' : 'translate-x-0'} pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200`} />
-                    </Switch>
-                  </Switch.Group>
-
-                  <div className="border-t border-gray-100"></div>
-
-                  <Switch.Group as="div" className="flex items-center justify-between py-3">
-                    <span className="flex-grow flex flex-col">
-                      <Switch.Label as="span" className="text-sm font-medium text-gray-900" passive>
-                        Task Assignment
-                      </Switch.Label>
-                      <Switch.Description as="span" className="text-sm text-gray-500">
-                        Get notified when a task is assigned to you.
-                      </Switch.Description>
-                    </span>
-                    <Switch
-                      checked={notificationPrefs.assigned}
-                      onChange={(val) => setNotificationPrefs((p) => ({ ...p, assigned: val }))}
-                      className={`${notificationPrefs.assigned ? 'bg-blue-600' : 'bg-gray-200'} relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
-                    >
-                      <span aria-hidden="true" className={`${notificationPrefs.assigned ? 'translate-x-5' : 'translate-x-0'} pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200`} />
-                    </Switch>
-                  </Switch.Group>
-
-                  <div className="border-t border-gray-100"></div>
-
-                  <Switch.Group as="div" className="flex items-center justify-between py-3">
-                    <span className="flex-grow flex flex-col">
-                      <Switch.Label as="span" className="text-sm font-medium text-gray-900" passive>
-                        Task Updates
-                      </Switch.Label>
-                      <Switch.Description as="span" className="text-sm text-gray-500">
-                        Get notified when a task assigned to you changes status.
-                      </Switch.Description>
-                    </span>
-                    <Switch
-                      checked={notificationPrefs.update}
-                      onChange={(val) => setNotificationPrefs((p) => ({ ...p, update: val }))}
-                      className={`${notificationPrefs.update ? 'bg-blue-600' : 'bg-gray-200'} relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
-                    >
-                      <span aria-hidden="true" className={`${notificationPrefs.update ? 'translate-x-5' : 'translate-x-0'} pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200`} />
-                    </Switch>
-                  </Switch.Group>
-
-                  <div className="border-t border-gray-100"></div>
-
-                  <Switch.Group as="div" className="flex items-center justify-between py-3">
-                    <span className="flex-grow flex flex-col">
-                      <Switch.Label as="span" className="text-sm font-medium text-gray-900" passive>
-                        Weekly Digest
-                      </Switch.Label>
-                      <Switch.Description as="span" className="text-sm text-gray-500">
-                        Receive a weekly summary of your team's activity.
-                      </Switch.Description>
-                    </span>
-                    <Switch
-                      checked={notificationPrefs.digest}
-                      onChange={(val) => setNotificationPrefs((p) => ({ ...p, digest: val }))}
-                      className={`${notificationPrefs.digest ? 'bg-blue-600' : 'bg-gray-200'} relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
-                    >
-                      <span aria-hidden="true" className={`${notificationPrefs.digest ? 'translate-x-5' : 'translate-x-0'} pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200`} />
-                    </Switch>
-                  </Switch.Group>
+                  {notificationPreferenceOptions.map((option, index) => (
+                    <React.Fragment key={option.key}>
+                      {index > 0 && <div className="border-t border-gray-100"></div>}
+                      <Switch.Group as="div" className="flex items-center justify-between gap-4 py-3">
+                        <span className="flex-grow flex flex-col">
+                          <Switch.Label as="span" className="text-sm font-medium text-gray-900" passive>
+                            {option.label}
+                          </Switch.Label>
+                          <Switch.Description as="span" className="text-sm text-gray-500">
+                            {option.description}
+                          </Switch.Description>
+                        </span>
+                        <Switch
+                          checked={Boolean(notificationPrefs[option.key])}
+                          onChange={(val) => setNotificationPrefs((p) => ({ ...p, [option.key]: val }))}
+                          className={`${notificationPrefs[option.key] ? 'bg-blue-600' : 'bg-gray-200'} relative inline-flex flex-shrink-0 h-6 w-11 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500`}
+                        >
+                          <span aria-hidden="true" className={`${notificationPrefs[option.key] ? 'translate-x-5' : 'translate-x-0'} pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow transform ring-0 transition ease-in-out duration-200`} />
+                        </Switch>
+                      </Switch.Group>
+                    </React.Fragment>
+                  ))}
                 </div>
 
                 <div className="flex justify-end pt-6 border-t border-gray-100">

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
 
   enum status: { invited: "invited", active: "active", locked: "locked" }, _default: "invited"
 
-  LANDING_PAGES = %w[posts profile vault knowledge worklog projects teams].freeze
+  LANDING_PAGES = %w[calendar posts profile vault knowledge worklog projects teams pdf users departments chat notifications].freeze
   AVAILABILITY_LABELS = {
     'available_now' => 'Available Now',
     'available_soon' => 'Available in 2 weeks',
@@ -18,6 +18,10 @@ class User < ApplicationRecord
     "commented" => true,
     "assigned" => true,
     "update" => true,
+    "chat_message" => true,
+    "chat_ping" => true,
+    "reacted" => true,
+    "calendar_reminder" => true,
     "digest" => false
   }.freeze
   AVATAR_COLOR_FORMAT = /\A#[0-9a-f]{6}\z/i

--- a/app/services/event_reminder_channels/deliverer.rb
+++ b/app/services/event_reminder_channels/deliverer.rb
@@ -32,7 +32,7 @@ module EventReminderChannels
       Notification.create(
         recipient: @recipient,
         actor: @recipient,
-        action: 'update',
+        action: 'calendar_reminder',
         notifiable: @event,
         metadata: {
           type: 'calendar_reminder',


### PR DESCRIPTION
### Motivation
- Add additional landing page options and more granular notification controls to the Settings page so users can choose newer app areas and fine‑tune how they are notified. 
- Surface calendar reminders as a distinct notification type so reminders are classified and displayed correctly in the notifications UI.

### Description
- Frontend: extended `landingPageOptions` and added a data‑driven `notificationPreferenceOptions` list in `app/javascript/pages/Settings.jsx`, and wired toggles for `chat_message`, `chat_ping`, `reacted`, and `calendar_reminder` preferences. 
- Backend: expanded allowed `LANDING_PAGES` and added new keys to `NOTIFICATION_PREFERENCES_DEFAULTS` in `app/models/user.rb` so the server accepts and defaults the new preference keys. 
- Reminders: changed in‑app calendar reminder creation to use the `calendar_reminder` action in `app/services/event_reminder_channels/deliverer.rb`. 
- Notifications UI/server: added message generation, icon handling and action filters for `calendar_reminder` and `reacted` (and included `chat_ping`) in `app/controllers/api/notifications_controller.rb` and `app/javascript/pages/Notifications.jsx`.

### Testing
- Ran Ruby syntax checks with `ruby -c` for the modified backend files and they returned `Syntax OK` for `app/models/user.rb`, `app/controllers/api/notifications_controller.rb`, and `app/services/event_reminder_channels/deliverer.rb`.
- Ran the frontend unit tests with `npm test` (Vitest) and all tests passed (`2 files, 8 tests` passed).
- Built the JS bundle with `npm run build` which completed successfully and produced assets in `app/assets/builds`.
- Ran `git diff --check` and repository checks showed no whitespace/error issues; an attempted `npm test -- --runInBand` failed because Vitest does not accept the Jest `--runInBand` option but tests were executed successfully without that flag.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b3c293c88322846bfe52c8701ff3)