### PR TITLE
Add premium ambient AppShell with lightweight 3D background and updated PageLoader

### DIFF
--- a/app/javascript/components/Ambient3DBackground.jsx
+++ b/app/javascript/components/Ambient3DBackground.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+const PARTICLES = [
+  { left: "8%", top: "14%", size: "10px", depth: "42px", delay: "-1.8s", duration: "14s" },
+  { left: "18%", top: "72%", size: "7px", depth: "88px", delay: "-6.2s", duration: "18s" },
+  { left: "31%", top: "28%", size: "12px", depth: "64px", delay: "-3.5s", duration: "16s" },
+  { left: "47%", top: "82%", size: "8px", depth: "112px", delay: "-9.1s", duration: "20s" },
+  { left: "62%", top: "18%", size: "9px", depth: "76px", delay: "-4.4s", duration: "15s" },
+  { left: "74%", top: "62%", size: "13px", depth: "52px", delay: "-7.6s", duration: "19s" },
+  { left: "88%", top: "34%", size: "7px", depth: "96px", delay: "-2.2s", duration: "17s" },
+  { left: "93%", top: "79%", size: "11px", depth: "68px", delay: "-10.5s", duration: "21s" },
+];
+
+const Ambient3DBackground = () => {
+  return (
+    <div className="premium-ambient" aria-hidden="true">
+      <div className="premium-gradient-mesh" />
+      <div className="premium-grid-plane" />
+      <div className="premium-particle-stage">
+        {PARTICLES.map((particle, index) => (
+          <span
+            key={`${particle.left}-${particle.top}`}
+            className="premium-particle"
+            style={{
+              "--particle-left": particle.left,
+              "--particle-top": particle.top,
+              "--particle-size": particle.size,
+              "--particle-depth": particle.depth,
+              "--particle-delay": particle.delay,
+              "--particle-duration": particle.duration,
+              "--particle-index": index,
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Ambient3DBackground;

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -6,8 +6,7 @@ import { AuthProvider } from "../context/AuthContext";
 import PrivateRoute from "../components/PrivateRoute";
 import ProjectMemberRoute from "../components/ProjectMemberRoute";
 
-import Navbar from "../components/Navbar";
-import Footer from "./Footer";
+import AppShell from "./AppShell";
 import PdfPage from "./PdfPage";
 import PostPage from "../pages/PostPage";
 import Profile from "../components/Profile";
@@ -33,7 +32,6 @@ import DepartmentDetails from "../pages/DepartmentDetails";
 import PageLoader from "./ui/PageLoader";
 import Chat from "../pages/Chat";
 import Notifications from "../pages/Notifications";
-import ChatLauncher from "./ChatLauncher";
 
 const RouteTransitionLoader = ({ children }) => {
   const location = useLocation();
@@ -59,53 +57,41 @@ const App = () => {
       <AuthProvider> {/* ✅ Wrap the entire app with AuthProvider */}
         <Toaster position="top-right" />
         <PageTitle />
-        <div className="flex min-h-screen flex-col">
+        <AppShell>
+          <RouteTransitionLoader>
+            <Routes>
+              <Route path="/contact" element={<Contact />} />
+              <Route path="/legal" element={<Legal />} />
+              <Route path="/forgot-password" element={<ForgotPassword />} />
+              <Route path="/reset-password" element={<ResetPassword />} />
+              <Route path="/projects/:projectId/issues" element={<ProjectMemberRoute><IssueTracker standalone /></ProjectMemberRoute>} />
 
-          {/* ✅ Navbar */}
-          <Navbar />
-
-          {/* ✅ Page Content */}
-          <main className="flex min-h-0 flex-1 flex-col">
-            <RouteTransitionLoader>
-              <Routes>
-                <Route path="/contact" element={<Contact />} />
-                <Route path="/legal" element={<Legal />} />
-                <Route path="/forgot-password" element={<ForgotPassword />} />
-                <Route path="/reset-password" element={<ResetPassword />} />
-                <Route path="/projects/:projectId/issues" element={<ProjectMemberRoute><IssueTracker standalone /></ProjectMemberRoute>} />
-
-                {/* 🔐 Protected */}
-                <Route path="/" element={<PrivateRoute><Calendar /></PrivateRoute>} />
-                <Route path="/momentum" element={<Navigate to="/calendar" replace />} />
-                <Route path="/pdf" element={<PrivateRoute><PdfPage /></PrivateRoute>} />
-                <Route path="/posts" element={<PrivateRoute><PostPage /></PrivateRoute>} />
-                <Route path="/vault" element={<PrivateRoute><Vault /></PrivateRoute>} />
-                <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
-                <Route path="/profile/:userId" element={<PrivateRoute><Profile /></PrivateRoute>} />
-                <Route path="/knowledge" element={<PrivateRoute><KnowledgeDashboard /></PrivateRoute>} />
-                <Route path="/worklog" element={<PrivateRoute><WorkLog /></PrivateRoute>} />
-                <Route path="/calendar" element={<PrivateRoute><Calendar /></PrivateRoute>} />
-                <Route path="/projects" element={<PrivateRoute><Projects /></PrivateRoute>} />
-                <Route path="/teams" element={<PrivateRoute><Teams /></PrivateRoute>} />
-                <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><SprintDashboard /></ProjectMemberRoute>} />
-                <Route path="/users" element={<PrivateRoute><Users /></PrivateRoute>} />
-                <Route path="/departments" element={<PrivateRoute><Departments /></PrivateRoute>} />
-                <Route path="/departments/:id" element={<PrivateRoute><DepartmentDetails /></PrivateRoute>} />
-                <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
-                <Route path="/admin/login-as-user" element={<PrivateRoute ownerOnly><AdminImpersonation /></PrivateRoute>} />
-                <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
-                <Route path="/chat" element={<PrivateRoute><Chat /></PrivateRoute>} />
-                <Route path="/chat/:conversationId" element={<PrivateRoute><Chat /></PrivateRoute>} />
-                <Route path="/notifications" element={<PrivateRoute><Notifications /></PrivateRoute>} />
-              </Routes>
-            </RouteTransitionLoader>
-          </main>
-
-          <ChatLauncher />
-          {/* ✅ Footer */}
-          <Footer />
-
-        </div>
+              {/* 🔐 Protected */}
+              <Route path="/" element={<PrivateRoute><Calendar /></PrivateRoute>} />
+              <Route path="/momentum" element={<Navigate to="/calendar" replace />} />
+              <Route path="/pdf" element={<PrivateRoute><PdfPage /></PrivateRoute>} />
+              <Route path="/posts" element={<PrivateRoute><PostPage /></PrivateRoute>} />
+              <Route path="/vault" element={<PrivateRoute><Vault /></PrivateRoute>} />
+              <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
+              <Route path="/profile/:userId" element={<PrivateRoute><Profile /></PrivateRoute>} />
+              <Route path="/knowledge" element={<PrivateRoute><KnowledgeDashboard /></PrivateRoute>} />
+              <Route path="/worklog" element={<PrivateRoute><WorkLog /></PrivateRoute>} />
+              <Route path="/calendar" element={<PrivateRoute><Calendar /></PrivateRoute>} />
+              <Route path="/projects" element={<PrivateRoute><Projects /></PrivateRoute>} />
+              <Route path="/teams" element={<PrivateRoute><Teams /></PrivateRoute>} />
+              <Route path="/projects/:projectId/dashboard" element={<ProjectMemberRoute><SprintDashboard /></ProjectMemberRoute>} />
+              <Route path="/users" element={<PrivateRoute><Users /></PrivateRoute>} />
+              <Route path="/departments" element={<PrivateRoute><Departments /></PrivateRoute>} />
+              <Route path="/departments/:id" element={<PrivateRoute><DepartmentDetails /></PrivateRoute>} />
+              <Route path="/admin" element={<PrivateRoute ownerOnly><Admin /></PrivateRoute>} />
+              <Route path="/admin/login-as-user" element={<PrivateRoute ownerOnly><AdminImpersonation /></PrivateRoute>} />
+              <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
+              <Route path="/chat" element={<PrivateRoute><Chat /></PrivateRoute>} />
+              <Route path="/chat/:conversationId" element={<PrivateRoute><Chat /></PrivateRoute>} />
+              <Route path="/notifications" element={<PrivateRoute><Notifications /></PrivateRoute>} />
+            </Routes>
+          </RouteTransitionLoader>
+        </AppShell>
       </AuthProvider>
     </Router>
   );

--- a/app/javascript/components/AppShell.jsx
+++ b/app/javascript/components/AppShell.jsx
@@ -1,0 +1,30 @@
+import React, { Suspense, lazy } from "react";
+
+import Navbar from "./Navbar";
+import Footer from "./Footer";
+import ChatLauncher from "./ChatLauncher";
+
+const Ambient3DBackground = lazy(() => import("./Ambient3DBackground"));
+
+const AppShell = ({ children }) => {
+  return (
+    <div className="premium-app-shell flex min-h-screen flex-col overflow-hidden">
+      <Suspense fallback={null}>
+        <Ambient3DBackground />
+      </Suspense>
+
+      <div className="premium-shell-content flex min-h-screen flex-col">
+        <Navbar />
+
+        <main className="relative z-10 flex min-h-0 flex-1 flex-col">
+          {children}
+        </main>
+
+        <ChatLauncher />
+        <Footer />
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/app/javascript/components/ui/PageLoader.jsx
+++ b/app/javascript/components/ui/PageLoader.jsx
@@ -13,21 +13,23 @@ export default function PageLoader({
   overlay = false,
 }) {
   const containerClass = overlay
-    ? "fixed inset-0 z-50 flex items-center justify-center bg-slate-900/35 px-4 backdrop-blur-[2px]"
-    : `flex items-center justify-center ${compact ? "py-10" : "min-h-[55vh] px-4"}`;
+    ? "fixed inset-0 z-50 flex items-center justify-center bg-slate-950/35 px-4 backdrop-blur-[3px]"
+    : `relative flex items-center justify-center ${compact ? "py-10" : "min-h-[55vh] px-4"}`;
 
   return (
     <div className={containerClass}>
-      <div className={`w-full max-w-md rounded-2xl border border-slate-200 bg-white/95 p-6 ${overlay ? "shadow-2xl" : "shadow-sm"}`}>
-        <div className="mb-4 flex items-center gap-3">
-          <span className="h-10 w-10 animate-spin rounded-full border-4 border-slate-200 border-t-[var(--theme-color)]" />
+      <div className={`premium-loader-card w-full max-w-md rounded-[1.75rem] border border-white/70 bg-white/90 p-6 ${overlay ? "shadow-2xl" : "shadow-sm"}`}>
+        <div className="mb-5 flex items-center gap-4">
+          <span className="premium-loader-mark" aria-hidden="true">
+            <span />
+          </span>
           <div>
-            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">{title}</p>
-            <p className="text-base font-medium text-slate-700">{message}</p>
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-slate-500">{title}</p>
+            <p className="text-base font-semibold text-slate-800">{message}</p>
           </div>
         </div>
-        <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
-          <div className="h-full w-1/2 animate-pulse rounded-full bg-[var(--theme-color)]" />
+        <div className="premium-loader-track" aria-hidden="true">
+          <div className="premium-loader-bar" />
         </div>
       </div>
     </div>

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -332,3 +332,205 @@ body {
     display: none;
   }
 }
+
+@layer components {
+  .premium-app-shell {
+    position: relative;
+    isolation: isolate;
+    background:
+      radial-gradient(circle at 14% 16%, rgba(var(--theme-color-rgb), 0.18), transparent 34rem),
+      radial-gradient(circle at 88% 10%, rgba(168, 85, 247, 0.13), transparent 30rem),
+      linear-gradient(135deg, #eef6ff 0%, #f8fbff 42%, #f7f2ff 100%);
+  }
+
+  .premium-shell-content {
+    position: relative;
+    z-index: 1;
+  }
+
+  .premium-ambient {
+    position: fixed;
+    inset: 0;
+    z-index: 0;
+    overflow: hidden;
+    pointer-events: none;
+    perspective: 1200px;
+  }
+
+  .premium-gradient-mesh {
+    position: absolute;
+    inset: -18%;
+    opacity: 0.72;
+    filter: blur(36px) saturate(1.2);
+    background:
+      radial-gradient(circle at 18% 22%, rgba(var(--theme-color-rgb), 0.28) 0 12%, transparent 28%),
+      radial-gradient(circle at 82% 18%, rgba(168, 85, 247, 0.22) 0 10%, transparent 26%),
+      radial-gradient(circle at 66% 78%, rgba(20, 184, 166, 0.18) 0 13%, transparent 30%),
+      radial-gradient(circle at 8% 82%, rgba(249, 115, 22, 0.12) 0 10%, transparent 24%);
+    animation: premium-mesh-drift 24s ease-in-out infinite alternate;
+  }
+
+  .premium-grid-plane {
+    position: absolute;
+    left: 50%;
+    bottom: -34%;
+    width: 150vw;
+    height: 72vh;
+    opacity: 0.28;
+    transform: translateX(-50%) rotateX(66deg) translateZ(-160px);
+    transform-origin: center bottom;
+    background-image:
+      linear-gradient(rgba(var(--theme-color-rgb), 0.18) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(var(--theme-color-rgb), 0.16) 1px, transparent 1px);
+    background-size: 48px 48px;
+    mask-image: linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent 72%);
+    animation: premium-grid-float 18s linear infinite;
+  }
+
+  .premium-particle-stage {
+    position: absolute;
+    inset: 0;
+    transform-style: preserve-3d;
+  }
+
+  .premium-particle {
+    position: absolute;
+    left: var(--particle-left);
+    top: var(--particle-top);
+    width: var(--particle-size);
+    height: var(--particle-size);
+    border-radius: 9999px;
+    opacity: 0.28;
+    background: rgba(255, 255, 255, 0.86);
+    box-shadow:
+      0 0 18px rgba(var(--theme-color-rgb), 0.4),
+      0 0 36px rgba(168, 85, 247, 0.2);
+    transform: translate3d(-50%, -50%, var(--particle-depth));
+    animation: premium-particle-orbit var(--particle-duration) ease-in-out infinite;
+    animation-delay: var(--particle-delay);
+  }
+
+  .premium-loader-card {
+    position: relative;
+    overflow: hidden;
+    backdrop-filter: blur(18px);
+  }
+
+  .premium-loader-card::before {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    z-index: -1;
+    background: linear-gradient(120deg, rgba(var(--theme-color-rgb), 0.12), rgba(168, 85, 247, 0.12), rgba(20, 184, 166, 0.1));
+  }
+
+  .premium-loader-mark {
+    position: relative;
+    display: grid;
+    height: 3rem;
+    width: 3rem;
+    place-items: center;
+    border-radius: 1rem;
+    background: linear-gradient(135deg, rgba(var(--theme-color-rgb), 0.92), rgba(124, 58, 237, 0.86));
+    box-shadow: 0 18px 40px rgba(var(--theme-color-rgb), 0.25);
+    transform-style: preserve-3d;
+    animation: premium-loader-tilt 2.8s ease-in-out infinite;
+  }
+
+  .premium-loader-mark::before,
+  .premium-loader-mark::after,
+  .premium-loader-mark span {
+    content: "";
+    position: absolute;
+    border-radius: 9999px;
+  }
+
+  .premium-loader-mark::before {
+    inset: 0.45rem;
+    border: 2px solid rgba(255, 255, 255, 0.72);
+    border-top-color: rgba(255, 255, 255, 0.18);
+    animation: premium-loader-spin 1.05s linear infinite;
+  }
+
+  .premium-loader-mark::after {
+    inset: 1.05rem;
+    background: rgba(255, 255, 255, 0.9);
+    box-shadow: 0 0 22px rgba(255, 255, 255, 0.65);
+  }
+
+  .premium-loader-mark span {
+    inset: -0.32rem;
+    border: 1px solid rgba(var(--theme-color-rgb), 0.28);
+    transform: rotateX(72deg) rotateZ(18deg);
+  }
+
+  .premium-loader-track {
+    height: 0.55rem;
+    overflow: hidden;
+    border-radius: 9999px;
+    background: rgba(226, 232, 240, 0.9);
+  }
+
+  .premium-loader-bar {
+    height: 100%;
+    width: 42%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, rgba(var(--theme-color-rgb), 0.95), rgba(168, 85, 247, 0.9), rgba(20, 184, 166, 0.85));
+    box-shadow: 0 0 18px rgba(var(--theme-color-rgb), 0.28);
+    animation: premium-loader-sweep 1.25s ease-in-out infinite;
+  }
+}
+
+@keyframes premium-mesh-drift {
+  0% { transform: translate3d(-2%, -1%, 0) scale(1); }
+  100% { transform: translate3d(3%, 2%, 0) scale(1.05); }
+}
+
+@keyframes premium-grid-float {
+  0% { background-position: 0 0, 0 0; }
+  100% { background-position: 48px 48px, 48px 48px; }
+}
+
+@keyframes premium-particle-orbit {
+  0%, 100% { transform: translate3d(-50%, -50%, var(--particle-depth)) rotateX(0deg) rotateY(0deg); }
+  50% { transform: translate3d(calc(-50% + 24px), calc(-50% - 18px), calc(var(--particle-depth) + 44px)) rotateX(18deg) rotateY(28deg); }
+}
+
+@keyframes premium-loader-spin {
+  to { transform: rotate(360deg); }
+}
+
+@keyframes premium-loader-sweep {
+  0% { transform: translateX(-115%); }
+  55% { transform: translateX(70%); }
+  100% { transform: translateX(245%); }
+}
+
+@keyframes premium-loader-tilt {
+  0%, 100% { transform: rotateX(0deg) rotateY(0deg); }
+  50% { transform: rotateX(8deg) rotateY(-12deg); }
+}
+
+@media (max-width: 767px) {
+  .premium-gradient-mesh {
+    opacity: 0.48;
+    filter: blur(28px) saturate(1.05);
+    animation-duration: 36s;
+  }
+
+  .premium-grid-plane,
+  .premium-particle-stage {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .premium-gradient-mesh,
+  .premium-grid-plane,
+  .premium-particle,
+  .premium-loader-mark,
+  .premium-loader-mark::before,
+  .premium-loader-bar {
+    animation: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a shared app shell to consistently wrap the navbar, routed content, chat launcher and footer and to host an ambient, brandable background behind all pages.
- Add a very lightweight, low-opacity ambient 3D background that is lazy-loaded and reduced on mobile and for users who prefer reduced motion.

### Description
- Introduce `AppShell` and wire it into `App.jsx` so all routes render inside the shared shell (`app/javascript/components/AppShell.jsx` and updated `app/javascript/components/App.jsx`).
- Add a lazy-loaded `Ambient3DBackground` component with gradient mesh, optional grid plane and low-opacity particles (`app/javascript/components/Ambient3DBackground.jsx`).
- Refresh the `PageLoader` to a branded glass card with an animated mark and gradient progress sweep (`app/javascript/components/ui/PageLoader.jsx`).
- Add component-scoped styles (mesh, grid, particles, loader, and responsive/reduced-motion rules) to the stylesheet (`app/javascript/stylesheets/application.css`).

### Testing
- Ran unit tests with `npm test` (`vitest`) and all tests passed (`15 passed`).
- Built assets with `npm run build` (esbuild) which completed successfully and produced updated `app/assets/builds` files.
- Ran `npx vite build` which completed successfully (produced production bundles with warnings about large chunks and some module-level directive warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a043b6f2abc83229e56fdc9b910fa1d)