### PR TITLE
Fix chat reaction update initialization

### DIFF
--- a/app/javascript/pages/Chat.jsx
+++ b/app/javascript/pages/Chat.jsx
@@ -786,6 +786,38 @@ const Chat = () => {
     textarea.style.height = `${Math.min(textarea.scrollHeight, 160)}px`;
   }, [messageBody]);
 
+  const applyReactionUpdate = useCallback((messageId, updates = {}) => {
+    setActiveConversation((previous) => {
+      if (!previous) return previous;
+
+      return {
+        ...previous,
+        messages: (previous.messages || []).map((message) => {
+          if (Number(message.id) !== Number(messageId)) return message;
+
+          const nextReactedEmojis = Array.isArray(updates.reacted_emojis)
+            ? updates.reacted_emojis
+            : (() => {
+                const reactedEmojis = new Set(message.reacted_emojis || []);
+
+                if (updates.last_actor_id && Number(updates.last_actor_id) === Number(user?.id) && updates.last_actor_emoji) {
+                  if (updates.last_actor_action === "added") reactedEmojis.add(updates.last_actor_emoji);
+                  if (updates.last_actor_action === "removed") reactedEmojis.delete(updates.last_actor_emoji);
+                }
+
+                return Array.from(reactedEmojis);
+              })();
+
+          return {
+            ...message,
+            reactions: updates.reactions || {},
+            reacted_emojis: nextReactedEmojis
+          };
+        })
+      };
+    });
+  }, [user?.id]);
+
   useEffect(() => {
     const userSub = subscribeToUserChat((payload) => {
       if (payload?.type === "conversation_refresh") {
@@ -1155,38 +1187,6 @@ const Chat = () => {
       "Can we sync on the next step here?"
     ];
   }, [activeConversation, activeConversationOtherParticipant?.name]);
-
-  const applyReactionUpdate = useCallback((messageId, updates = {}) => {
-    setActiveConversation((previous) => {
-      if (!previous) return previous;
-
-      return {
-        ...previous,
-        messages: (previous.messages || []).map((message) => {
-          if (Number(message.id) !== Number(messageId)) return message;
-
-          const nextReactedEmojis = Array.isArray(updates.reacted_emojis)
-            ? updates.reacted_emojis
-            : (() => {
-                const reactedEmojis = new Set(message.reacted_emojis || []);
-
-                if (updates.last_actor_id && Number(updates.last_actor_id) === Number(user?.id) && updates.last_actor_emoji) {
-                  if (updates.last_actor_action === "added") reactedEmojis.add(updates.last_actor_emoji);
-                  if (updates.last_actor_action === "removed") reactedEmojis.delete(updates.last_actor_emoji);
-                }
-
-                return Array.from(reactedEmojis);
-              })();
-
-          return {
-            ...message,
-            reactions: updates.reactions || {},
-            reacted_emojis: nextReactedEmojis
-          };
-        })
-      };
-    });
-  }, [user?.id]);
 
   const handleToggleReaction = useCallback(async (messageId, emoji, isActive) => {
     if (!conversationId) return;


### PR DESCRIPTION
### Motivation
- Prevent a runtime crash caused by referencing `applyReactionUpdate` in an effect dependency before the callback was initialized, which produced a `Cannot access 'applyReactionUpdate' before initialization` error. 

### Description
- Move the `applyReactionUpdate` `useCallback` above the conversation subscription `useEffect` so the callback is defined before the effect's dependency array is evaluated. 
- Remove the duplicate `applyReactionUpdate` declaration later in the file to avoid the temporal-dead-zone error. 
- Preserve existing realtime behavior where `message_reactions_updated` events invoke `applyReactionUpdate` and keep reaction toggle logic intact. 

### Testing
- Ran `yarn test` (Vitest) and all tests passed. 
- Ran `yarn build` and the application bundle completed successfully. 
- An attempt to run `yarn test --runInBand` failed because Vitest does not support the Jest-style `--runInBand` option.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04238cd7fc8322abf12a28651bfaee)