### PR TITLE
Sync PDF placement marker with form inputs and support file/form submissions

### DIFF
--- a/app/javascript/components/DraggableOverlay.jsx
+++ b/app/javascript/components/DraggableOverlay.jsx
@@ -1,50 +1,74 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import Draggable from "react-draggable";
-import { X, Check } from "lucide-react";
+import { Check, X } from "lucide-react";
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
 /**
- * DraggableOverlay Component
- * 
  * Allows users to place elements (Text, Stamps, Signatures) on top of the PDF page.
- * returns the X/Y coordinates relative to the page.
+ * Coordinates emitted to the form are unscaled PDF coordinates, while the marker is
+ * rendered in screen pixels so it stays accurate at every zoom level.
  */
 const DraggableOverlay = ({
   activeTool,
   onConfirmPosition,
+  onPlacementChange,
   onCancel,
+  placementCoordinates,
   scale = 1,
   pageWidth,
-  pageHeight
+  pageHeight,
 }) => {
   const nodeRef = React.useRef(null);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [bounds, setBounds] = useState("parent");
+
+  const markerWidth = 120;
+  const markerHeight = 90;
 
   useEffect(() => {
     if (pageWidth && pageHeight) {
       setBounds({
         left: 0,
         top: 0,
-        right: pageWidth - 100, // Approximate width of the element
-        bottom: pageHeight - 50 // Approximate height
+        right: Math.max(0, pageWidth - markerWidth),
+        bottom: Math.max(0, pageHeight - markerHeight),
       });
     } else {
       setBounds("parent");
     }
   }, [pageWidth, pageHeight]);
 
-  const handleStop = (e, data) => {
-    setPosition({ x: data.x, y: data.y });
+  useEffect(() => {
+    if (!placementCoordinates) return;
+
+    const maxX = Math.max(0, (pageWidth || 0) - markerWidth);
+    const maxY = Math.max(0, (pageHeight || 0) - markerHeight);
+    const nextX = clamp((Number(placementCoordinates.x) || 0) * scale, 0, maxX || Infinity);
+    const nextY = clamp((Number(placementCoordinates.y) || 0) * scale, 0, maxY || Infinity);
+
+    setPosition({ x: nextX, y: nextY });
+  }, [placementCoordinates, scale, pageWidth, pageHeight]);
+
+  const emitPosition = (nextPosition) => {
+    const nextCoordinates = {
+      x: Math.round(nextPosition.x / scale),
+      y: Math.round(nextPosition.y / scale),
+      scale,
+    };
+
+    onPlacementChange?.(nextCoordinates);
+    return nextCoordinates;
+  };
+
+  const handleDrag = (e, data) => {
+    const nextPosition = { x: data.x, y: data.y };
+    setPosition(nextPosition);
+    emitPosition(nextPosition);
   };
 
   const handleConfirm = () => {
-    // Return coordinates normalized to the PDF scale (unscaled)
-    // If the PDF is displayed at 1.5x (scale=1.5), we need to divide by scale to get original PDF points
-    // However, react-pdf usually handles scale internally. 
-    // We typically want the coordinates relative to the *rendered* size, 
-    // and then the parent component converts them to PDF points.
-    // Let's pass the raw rendered coordinates and the scale.
-    onConfirmPosition({ x: position.x, y: position.y, scale });
+    onConfirmPosition(emitPosition(position));
   };
 
   if (!activeTool) return null;
@@ -54,7 +78,8 @@ const DraggableOverlay = ({
       <Draggable
         nodeRef={nodeRef}
         position={position}
-        onStop={handleStop}
+        onDrag={handleDrag}
+        onStop={handleDrag}
         bounds={bounds}
         handle=".handle"
       >
@@ -63,14 +88,15 @@ const DraggableOverlay = ({
             <span className="text-sm font-bold capitalize">{activeTool.replace(/([A-Z])/g, ' $1').trim()}</span>
           </div>
 
-          {/* Visual Preview of the Element */}
           <div className="mt-2 border-2 border-dashed border-[var(--theme-color)] bg-[rgba(var(--theme-color-rgb),0.1)] p-2 rounded min-w-[100px] min-h-[40px] flex items-center justify-center">
-            <span className="text-xs text-[var(--theme-color)] opacity-70">Drop Here</span>
+            <span className="text-xs text-[var(--theme-color)] opacity-70">
+              X {Math.round(position.x / scale)}, Y {Math.round(position.y / scale)}
+            </span>
           </div>
 
-          {/* Action Buttons */}
           <div className="flex gap-2 mt-2 opacity-0 group-hover:opacity-100 transition-opacity">
             <button
+              type="button"
               onClick={handleConfirm}
               className="bg-green-500 text-white p-1 rounded-full hover:bg-green-600 shadow-md"
               title="Confirm Position"
@@ -78,6 +104,7 @@ const DraggableOverlay = ({
               <Check size={16} />
             </button>
             <button
+              type="button"
               onClick={onCancel}
               className="bg-red-500 text-white p-1 rounded-full hover:bg-red-600 shadow-md"
               title="Cancel"

--- a/app/javascript/components/FormComponent.jsx
+++ b/app/javascript/components/FormComponent.jsx
@@ -1,58 +1,119 @@
-import React, { useState } from "react";
-import { FaArrowLeft } from "react-icons/fa";
+import React, { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 
-const FormComponent = ({ setActiveForm, setPdfUpdated, setPdfUrl, formFields = [], endpoint, title, pdfPath, droppedCoordinates }) => {
-  const [formData, setFormData] = useState(
-    formFields.reduce((acc, field) => ({ ...acc, [field.name]: "" }), { pdf_path: pdfPath })
-  );
+const placementFieldNames = new Set(["x", "y", "page_number"]);
 
-  // Update form data when coordinates are dropped
-  React.useEffect(() => {
-    if (droppedCoordinates) {
-      setFormData(prev => ({
-        ...prev,
-        x: Math.round(droppedCoordinates.x),
-        y: Math.round(droppedCoordinates.y),
-        page_number: droppedCoordinates.pageNumber || prev.page_number
-      }));
-    }
-  }, [droppedCoordinates]);
+const FormComponent = ({
+  setActiveForm,
+  setPdfUpdated,
+  setPdfUrl,
+  formFields = [],
+  endpoint,
+  title,
+  pdfPath,
+  placementCoordinates,
+  setPlacementCoordinates,
+}) => {
+  const initialFormData = useMemo(
+    () => formFields.reduce((acc, field) => ({ ...acc, [field.name]: "" }), { pdf_path: pdfPath }),
+    [formFields, pdfPath]
+  );
+  const [formData, setFormData] = useState(initialFormData);
+  const [errorMessage, setErrorMessage] = useState("");
+  const hasPlacementFields = formFields.some((field) => placementFieldNames.has(field.name));
+
+  useEffect(() => {
+    setFormData((prev) => ({ ...initialFormData, ...prev, pdf_path: pdfPath }));
+  }, [initialFormData, pdfPath]);
+
+  useEffect(() => {
+    if (!placementCoordinates) return;
+
+    setFormData((prev) => {
+      const next = { ...prev };
+
+      if (placementCoordinates.x !== undefined && "x" in next) {
+        next.x = Math.round(placementCoordinates.x);
+      }
+
+      if (placementCoordinates.y !== undefined && "y" in next) {
+        next.y = Math.round(placementCoordinates.y);
+      }
+
+      if (placementCoordinates.pageNumber !== undefined && "page_number" in next) {
+        next.page_number = placementCoordinates.pageNumber;
+      }
+
+      return next;
+    });
+  }, [placementCoordinates]);
+
+  const updatePlacementFromForm = (name, value) => {
+    if (!placementFieldNames.has(name) || !setPlacementCoordinates) return;
+
+    const numericValue = Number(value);
+    if (value === "" || Number.isNaN(numericValue)) return;
+
+    setPlacementCoordinates((previous) => ({
+      ...(previous || {}),
+      [name === "page_number" ? "pageNumber" : name]: numericValue,
+    }));
+  };
 
   const handleChange = (e) => {
-    setFormData({ ...formData, [e.target.name]: e.target.value });
+    const { name, type, files, value } = e.target;
+    const nextValue = type === "file" ? files?.[0] || null : value;
+
+    setFormData((prev) => ({ ...prev, [name]: nextValue }));
+    updatePlacementFromForm(name, value);
+  };
+
+  const buildRequest = () => {
+    const hasFile = formFields.some((field) => field.type === "file" && formData[field.name]);
+
+    if (hasFile) {
+      const multipart = new FormData();
+      Object.entries({ ...formData, pdf_path: pdfPath }).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) multipart.append(key, value);
+      });
+
+      return { body: multipart };
+    }
+
+    return {
+      body: JSON.stringify({ ...formData, pdf_path: pdfPath }),
+      headers: { "Content-Type": "application/json" },
+    };
   };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setErrorMessage("");
+
     try {
+      const request = buildRequest();
       const response = await fetch(endpoint, {
         method: "POST",
         headers: {
-          "Content-Type": "application/json",
+          ...(request.headers || {}),
           "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
         },
-        body: JSON.stringify({ ...formData, pdf_path: pdfPath }),
+        body: request.body,
       });
 
-      if (!response.ok) throw new Error("Request failed");
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.error || "Request failed");
 
-      const data = await response.json();
-
-      // If the backend returns a new PDF URL (because it created a new file), update it.
       if (data.pdf_url && setPdfUrl) {
         setPdfUrl(data.pdf_url);
         localStorage.setItem("pdfUrl", data.pdf_url);
       }
 
-      // Always bust the viewer cache after a successful mutation.
-      // Some backend actions overwrite the same file path, so relying only on
-      // a URL change can miss refreshes (e.g. add/remove/duplicate page).
       setPdfUpdated((prev) => prev + 1);
-
       setActiveForm(null);
     } catch (error) {
       console.error(error);
+      setErrorMessage(error.message || "Request failed");
     }
   };
 
@@ -65,6 +126,15 @@ const FormComponent = ({ setActiveForm, setPdfUpdated, setPdfUrl, formFields = [
       transition={{ duration: 0.3, ease: "easeInOut" }}
     >
       <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <h3 className="text-sm font-bold text-gray-900">{title}</h3>
+          {hasPlacementFields && (
+            <p className="text-xs text-gray-500">
+              Drag the marker on the PDF or type X/Y/page values here. Both controls stay in sync.
+            </p>
+          )}
+        </div>
+
         {formFields.map((field, index) => (
           <div key={index} className="flex flex-col">
             <label className="mb-1 text-sm font-medium text-gray-700">
@@ -73,6 +143,9 @@ const FormComponent = ({ setActiveForm, setPdfUpdated, setPdfUrl, formFields = [
             <input
               type={field.type}
               name={field.name}
+              min={field.min}
+              max={field.max}
+              step={field.step || (field.type === "number" ? "1" : undefined)}
               placeholder={field.placeholder}
               value={field.type === "file" ? undefined : formData[field.name] || ""}
               onChange={handleChange}
@@ -80,6 +153,11 @@ const FormComponent = ({ setActiveForm, setPdfUpdated, setPdfUrl, formFields = [
             />
           </div>
         ))}
+
+        {errorMessage && (
+          <p className="rounded bg-red-50 px-3 py-2 text-sm text-red-700">{errorMessage}</p>
+        )}
+
         <input type="hidden" name="pdf_path" value={pdfPath} />
         <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded w-full hover:bg-blue-700">Submit</button>
       </form>

--- a/app/javascript/components/FormRenderer.jsx
+++ b/app/javascript/components/FormRenderer.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import FormComponent from "./FormComponent";
 
-const FormRenderer = ({ activeForm, setActiveForm, setPdfUpdated, setPdfUrl, pdfPath, droppedCoordinates }) => {
+const FormRenderer = ({ activeForm, setActiveForm, setPdfUpdated, setPdfUrl, pdfPath, placementCoordinates, setPlacementCoordinates }) => {
   // ... (formConfigs remains unchanged) ...
 
   const formConfigs = {
@@ -61,8 +61,8 @@ const FormRenderer = ({ activeForm, setActiveForm, setPdfUpdated, setPdfUrl, pdf
       title: "Add Watermark",
       endpoint: "/add_watermark",
       formFields: [
-        { name: "text", type: "text", label: "Watermark Text" },
-        { name: "opacity", type: "number", label: "Opacity (0-1)" },
+        { name: "watermark_text", type: "text", label: "Watermark Text" },
+        { name: "opacity", type: "number", label: "Opacity (0-1)", min: "0", max: "1", step: "0.1" },
       ],
     },
     addStamp: {
@@ -123,7 +123,8 @@ const FormRenderer = ({ activeForm, setActiveForm, setPdfUpdated, setPdfUrl, pdf
       setPdfUpdated={setPdfUpdated}
       setPdfUrl={setPdfUrl} // Pass down
       pdfPath={pdfPath}
-      droppedCoordinates={droppedCoordinates} // Pass coordinates
+      placementCoordinates={placementCoordinates}
+      setPlacementCoordinates={setPlacementCoordinates}
       {...config}
     />
   );

--- a/app/javascript/components/PdfEditor.jsx
+++ b/app/javascript/components/PdfEditor.jsx
@@ -21,7 +21,7 @@ import {
   ArrowLeft,     // For the back button
 } from "lucide-react";
 
-const PdfEditor = ({ setPdfUpdated, setPdfUrl, pdfPath, activeForm, setActiveForm, droppedCoordinates }) => {
+const PdfEditor = ({ setPdfUpdated, setPdfUrl, pdfPath, activeForm, setActiveForm, placementCoordinates, setPlacementCoordinates }) => {
   // PdfEditor now acts solely as the container for the FormRenderer in the right panel.
   // The tool selection is handled by SidebarToolbar in the parent PdfPage.
 
@@ -41,7 +41,8 @@ const PdfEditor = ({ setPdfUpdated, setPdfUrl, pdfPath, activeForm, setActiveFor
         setPdfUpdated={setPdfUpdated}
         setPdfUrl={setPdfUrl}
         pdfPath={pdfPath}
-        droppedCoordinates={droppedCoordinates}
+        placementCoordinates={placementCoordinates}
+        setPlacementCoordinates={setPlacementCoordinates}
       />
     </div>
   );

--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -22,7 +22,7 @@ const PdfPage = () => {
   const [uploadMessage, setUploadMessage] = useState("");
   const [isError, setIsError] = useState(false);
   const [activeForm, setActiveForm] = useState(null);
-  const [droppedCoordinates, setDroppedCoordinates] = useState(null);
+  const [placementCoordinates, setPlacementCoordinates] = useState(null);
 
   useEffect(() => {
     const storedPdf = localStorage.getItem("pdfUrl");
@@ -71,9 +71,19 @@ const PdfPage = () => {
     multiple: false,
   });
 
-  const handleConfirmPosition = (coordinates) => {
-    setDroppedCoordinates(coordinates);
-  };
+  const handlePlacementChange = useCallback((coordinates) => {
+    setPlacementCoordinates((previous) => ({
+      ...(previous || {}),
+      ...coordinates,
+      x: coordinates.x === undefined ? previous?.x : coordinates.x,
+      y: coordinates.y === undefined ? previous?.y : coordinates.y,
+      pageNumber: coordinates.pageNumber || previous?.pageNumber || 1,
+    }));
+  }, []);
+
+  const handleConfirmPosition = useCallback((coordinates) => {
+    handlePlacementChange(coordinates);
+  }, [handlePlacementChange]);
 
   if (!pdfUrl) {
     return (
@@ -139,7 +149,8 @@ const PdfPage = () => {
                         pdfPath={pdfUrl}
                         activeForm={activeForm}
                         setActiveForm={setActiveForm}
-                        droppedCoordinates={droppedCoordinates}
+                        placementCoordinates={placementCoordinates}
+                        setPlacementCoordinates={setPlacementCoordinates}
                     />
                 </div>
               </motion.div>
@@ -152,6 +163,8 @@ const PdfPage = () => {
               pdfUrl={`${pdfUrl}?updated=${pdfUpdated}`}
               activeTool={activeForm}
               onConfirmPosition={handleConfirmPosition}
+              onPlacementChange={handlePlacementChange}
+              placementCoordinates={placementCoordinates}
               onCancelTool={() => setActiveForm(null)}
               setPdfUpdated={setPdfUpdated}
             />

--- a/app/javascript/components/PdfViewer.jsx
+++ b/app/javascript/components/PdfViewer.jsx
@@ -18,7 +18,7 @@ import {
 // Set worker URL to the specific version required by react-pdf 9.2.1
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@4.8.69/build/pdf.worker.min.mjs`;
 
-const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool, setPdfUpdated }) => {
+const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onPlacementChange, placementCoordinates, onCancelTool, setPdfUpdated }) => {
   const [numPages, setNumPages] = useState(null);
   const [pageNumber, setPageNumber] = useState(1);
   const [scale, setScale] = useState(1.0);
@@ -27,6 +27,16 @@ const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool, setPdf
   const [processing, setProcessing] = useState(false);
   const placementTools = new Set(["addText", "addSignature", "addStamp"]);
   const shouldShowOverlay = placementTools.has(activeTool);
+
+  const changePage = (requestedPage) => {
+    const maxPage = numPages || requestedPage;
+    const nextPage = Math.min(Math.max(1, requestedPage), maxPage);
+
+    setPageNumber(nextPage);
+    if (shouldShowOverlay) {
+      onPlacementChange?.({ pageNumber: nextPage });
+    }
+  };
 
   useEffect(() => {
     // Only reset to Page 1 if the actual FILE changed, not just a cache-bust update
@@ -42,6 +52,22 @@ const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool, setPdf
     if (!numPages) return;
     setPageNumber((prev) => Math.min(prev, numPages));
   }, [numPages]);
+
+  useEffect(() => {
+    if (!shouldShowOverlay || placementCoordinates?.pageNumber) return;
+
+    onPlacementChange?.({ pageNumber });
+  }, [shouldShowOverlay, placementCoordinates?.pageNumber, pageNumber]);
+
+  useEffect(() => {
+    if (!shouldShowOverlay || !placementCoordinates?.pageNumber) return;
+
+    const requestedPage = Number(placementCoordinates.pageNumber);
+    if (Number.isNaN(requestedPage)) return;
+
+    const maxPage = numPages || requestedPage;
+    setPageNumber(clampedPage => Math.min(Math.max(1, requestedPage), maxPage));
+  }, [shouldShowOverlay, placementCoordinates?.pageNumber, numPages]);
 
   function onDocumentLoadSuccess({ numPages }) {
     setNumPages(numPages);
@@ -99,7 +125,7 @@ const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool, setPdf
           <div className="flex items-center space-x-1">
             <button
               disabled={pageNumber <= 1 || processing}
-              onClick={() => setPageNumber(prev => prev - 1)}
+              onClick={() => changePage(pageNumber - 1)}
               className="p-1 hover:bg-white rounded transition-all disabled:opacity-20"
             >
               <ChevronLeft className="h-3.5 w-3.5 text-gray-500" />
@@ -109,7 +135,7 @@ const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool, setPdf
             </span>
             <button
               disabled={pageNumber >= numPages || processing}
-              onClick={() => setPageNumber(prev => prev + 1)}
+              onClick={() => changePage(pageNumber + 1)}
               className="p-1 hover:bg-white rounded transition-all disabled:opacity-20"
             >
               <ChevronRight className="h-3.5 w-3.5 text-gray-500" />
@@ -156,6 +182,8 @@ const PdfViewer = ({ pdfUrl, activeTool, onConfirmPosition, onCancelTool, setPdf
                   <DraggableOverlay
                     activeTool={activeTool}
                     onConfirmPosition={(pos) => onConfirmPosition({ ...pos, pageNumber })}
+                    onPlacementChange={(pos) => onPlacementChange?.({ ...pos, pageNumber })}
+                    placementCoordinates={placementCoordinates}
                     onCancel={onCancelTool}
                     scale={scale}
                     pageWidth={pageWidth ? pageWidth * scale : 600}


### PR DESCRIPTION
### Motivation
- Ensure PDF placement tools (drag overlay) and the right-hand form stay in sync so typing X/Y/page updates the marker and dragging the marker updates the form, and page changes are reflected across both UIs. 
- Make file-based actions (stamp/signature/merge) submit as `FormData` while keeping JSON submissions for non-file tools and surface backend errors to the user. 
- Improve UX by clamping the marker to the visible page and displaying live X/Y coordinates on the draggable marker, and fix mismatched watermark parameter name.

### Description
- Added a shared placement state (`placementCoordinates`, `setPlacementCoordinates`) in `PdfPage.jsx` and threaded it through `PdfEditor.jsx`, `FormRenderer.jsx`, `FormComponent.jsx` and `PdfViewer.jsx` so both overlay and form use a single source of truth. 
- Reworked `DraggableOverlay.jsx` to emit live unscaled coordinates while dragging, follow form-entered coordinates, clamp bounds to the rendered page, and show current `X/Y` in the marker. 
- Rewrote `FormComponent.jsx` to consume `placementCoordinates`, update form fields when placement changes, push changes back to placement when `x`, `y` or `page_number` inputs change, support `FormData` for file uploads and JSON for other endpoints, and display backend error messages. 
- Updated `FormRenderer.jsx` to pass placement props and fixed the watermark field name to `watermark_text`, and adjusted `PdfViewer.jsx` to synchronize page changes with placement via `onPlacementChange` and a `changePage` helper. 
- Files changed: `app/javascript/components/PdfPage.jsx`, `PdfViewer.jsx`, `DraggableOverlay.jsx`, `FormComponent.jsx`, `FormRenderer.jsx`, and `PdfEditor.jsx`.

### Testing
- Built the JS assets with `npm run build` and the build completed successfully. 
- Ran the test suite with `npm test` (Vitest), which executed 3 test files containing 15 tests and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06bfea616083228eb30cbc303d284b)