### PR TITLE
Polish signup and password-recovery auth screens

### DIFF
--- a/app/javascript/components/landing/WorkspaceOrb.jsx
+++ b/app/javascript/components/landing/WorkspaceOrb.jsx
@@ -168,20 +168,20 @@ const WorkspaceOrb = ({
         </div>
       </div>
 
-      <div className={`relative z-10 mt-7 grid gap-4 ${normalizedFeatures.length >= 4 ? "md:grid-cols-2 xl:grid-cols-4" : "md:grid-cols-2"}`}>
+      <div className="relative z-10 mt-7 grid gap-4 md:grid-cols-2">
         {normalizedFeatures.map((feature, index) => (
           <article
             key={feature.title}
-            className="landing-feature-card rounded-3xl border border-white/12 bg-white/[0.08] p-5 shadow-xl shadow-slate-950/20 backdrop-blur-md"
+            className="landing-feature-card min-w-0 rounded-3xl border border-white/12 bg-white/[0.08] p-5 shadow-xl shadow-slate-950/20 backdrop-blur-md"
             style={{ "--card-delay": `${index * 0.08}s` }}
           >
-            <div className="flex items-center justify-between gap-4">
-              <h2 className="text-sm font-bold uppercase tracking-[0.2em] text-slate-300">{feature.title}</h2>
-              <span className="rounded-full border border-cyan-200/25 bg-cyan-200/10 px-3 py-1 text-xs font-black text-cyan-100">
+            <div className="flex min-w-0 items-center justify-between gap-4">
+              <h2 className="min-w-0 break-words text-sm font-bold uppercase tracking-[0.16em] text-slate-300">{feature.title}</h2>
+              <span className="shrink-0 rounded-full border border-cyan-200/25 bg-cyan-200/10 px-3 py-1 text-xs font-black text-cyan-100">
                 {feature.metric}
               </span>
             </div>
-            <p className="mt-4 text-sm leading-6 text-slate-300">{feature.copy}</p>
+            <p className="mt-4 break-words text-sm leading-6 text-slate-300">{feature.copy}</p>
           </article>
         ))}
       </div>

--- a/app/javascript/pages/AuthPage.jsx
+++ b/app/javascript/pages/AuthPage.jsx
@@ -1,9 +1,13 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Login from "./Login";
 import Signup from "./Signup";
 
 function AuthPage({ mode = "login" }) {
   const [current, setCurrent] = useState(mode);
+
+  useEffect(() => {
+    setCurrent(mode);
+  }, [mode]);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.22),transparent_32%),radial-gradient(circle_at_80%_20%,rgba(168,85,247,0.18),transparent_28%),linear-gradient(135deg,#020617_0%,#0f172a_48%,#111827_100%)]">

--- a/app/javascript/pages/ForgotPassword.jsx
+++ b/app/javascript/pages/ForgotPassword.jsx
@@ -3,11 +3,25 @@ import { useNavigate } from "react-router-dom";
 import { Toaster, toast } from "react-hot-toast";
 import { requestPasswordReset } from "../components/api";
 import SpinnerOverlay from "../components/ui/SpinnerOverlay";
+import WorkspaceOrb from "../components/landing/WorkspaceOrb";
 
-const statCards = [
-  { label: "Delivery rate", value: "99.7%", sub: "Emails land in inbox" },
-  { label: "Response time", value: "< 2 min", sub: "Reset link sent fast" },
-  { label: "Support", value: "24/7", sub: "We are here to help" },
+const resetMetrics = [
+  ["Secure", "Reset flow"],
+  ["Fast", "Inbox link"],
+  ["Private", "Account safe"],
+];
+
+const resetFeatures = [
+  {
+    title: "Recovery Brief",
+    metric: "Email",
+    copy: "Send a protected reset link and get back to planning without leaving the premium workspace feel.",
+  },
+  {
+    title: "Security First",
+    metric: "Vault",
+    copy: "Your address stays private, reset links are time-sensitive, and sign-in remains protected.",
+  },
 ];
 
 const ForgotPassword = () => {
@@ -31,83 +45,84 @@ const ForgotPassword = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-blue-50 text-slate-900">
+    <div className="relative min-h-screen overflow-hidden bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.22),transparent_32%),radial-gradient(circle_at_80%_20%,rgba(168,85,247,0.18),transparent_28%),linear-gradient(135deg,#020617_0%,#0f172a_48%,#111827_100%)] text-slate-900">
       <Toaster position="top-right" />
       {loading && <SpinnerOverlay />}
-      <div className="mx-auto flex max-w-6xl flex-col gap-10 px-6 py-14 lg:flex-row lg:items-center">
-        <div className="relative w-full overflow-hidden rounded-3xl border border-slate-100 bg-white p-10 shadow-2xl lg:w-1/2">
-          <div className="pointer-events-none absolute inset-0">
-            <div className="absolute -left-16 top-10 h-40 w-40 rounded-full bg-blue-400/15 blur-3xl" />
-            <div className="absolute -right-10 bottom-0 h-32 w-32 rounded-full bg-indigo-300/20 blur-3xl" />
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-24 top-10 h-72 w-72 rounded-full bg-cyan-300/20 blur-3xl" />
+        <div className="absolute right-0 top-1/3 h-80 w-80 rounded-full bg-indigo-400/20 blur-3xl" />
+        <div className="absolute bottom-0 left-1/4 h-72 w-72 rounded-full bg-fuchsia-300/10 blur-3xl" />
+        <div
+          className="absolute inset-0 opacity-45"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(148,163,184,0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(148,163,184,0.08) 1px, transparent 1px)",
+            backgroundSize: "44px 44px",
+          }}
+        />
+      </div>
+      <div className="relative z-10 min-h-screen px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-8 lg:flex-row lg:items-center lg:gap-10 xl:gap-14">
+          <div className="lg:w-[58%]">
+            <WorkspaceOrb
+              eyebrow="Secure Recovery"
+              title="Reset access without breaking your flow."
+              description="Request a password link from the same cinematic command experience and return to your projects, chat, vault, and daily focus."
+              metrics={resetMetrics}
+              featureCards={resetFeatures}
+            />
           </div>
-          <p className="mb-3 inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-100">
-            🔒 Security first
-          </p>
-          <h1 className="text-3xl font-bold text-slate-900 sm:text-4xl">Forgot your password?</h1>
-          <p className="mt-4 text-base text-slate-600">
-            We will send a reset link to your inbox. Use it within the next few minutes to set a new password and get back in.
-          </p>
-          <div className="mt-8 grid gap-4 sm:grid-cols-3">
-            {statCards.map((card) => (
-              <div key={card.label} className="rounded-2xl border border-slate-100 bg-white p-4 shadow-sm">
-                <p className="text-xs uppercase tracking-[0.14em] text-slate-500">{card.label}</p>
-                <p className="mt-2 text-2xl font-bold text-slate-900">{card.value}</p>
-                <p className="text-xs text-slate-500">{card.sub}</p>
-              </div>
-            ))}
-          </div>
-          <div className="mt-6 flex items-center gap-3 text-sm text-slate-600">
-            <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">✓</span>
-            We will never share your address or send unwanted messages.
-          </div>
-        </div>
 
-        <div className="w-full lg:w-1/2">
-          <div className="w-full max-w-md rounded-2xl border border-slate-100 bg-white p-8 shadow-2xl">
-            <h2 className="mb-2 text-center text-2xl font-bold text-slate-900">Send reset link</h2>
-            <p className="mb-8 text-center text-sm text-slate-600">
-              Enter the email you use to sign in. We will email a secure link to reset your password.
-            </p>
-            <form onSubmit={handleSubmit} className="space-y-5">
-              <div>
-                <label className="mb-1 block text-sm font-semibold text-slate-700 required-label" htmlFor="email">
-                  Email address
-                </label>
-                <input
-                  id="email"
-                  type="email"
-                  name="email"
-                  placeholder="you@example.com"
-                  required
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full rounded-xl border-2 border-slate-200 bg-white px-4 py-3 text-slate-800 placeholder-slate-400 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
-                />
-              </div>
-              <button
-                type="submit"
-                className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-3 text-base font-semibold text-white shadow-lg transition hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
-              >
-                Send reset email
-              </button>
-            </form>
+          <div className="lg:w-[42%]">
+            <div className="w-full max-w-md rounded-3xl border border-white/60 bg-white/95 p-8 shadow-2xl shadow-slate-900/10 transition-transform duration-200 hover:-translate-y-1">
+              <p className="mb-3 inline-flex items-center gap-2 rounded-full bg-blue-50 px-3 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-100">
+                🔒 Security first
+              </p>
+              <h2 className="mb-2 text-center text-3xl font-bold text-slate-900">Forgot password?</h2>
+              <p className="mb-8 text-center text-sm text-slate-600">
+                Enter the email you use to sign in. We will send a secure link to reset your password.
+              </p>
+              <form onSubmit={handleSubmit} className="space-y-5">
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700 required-label" htmlFor="email">
+                    Email address
+                  </label>
+                  <input
+                    id="email"
+                    type="email"
+                    name="email"
+                    placeholder="you@example.com"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="w-full rounded-xl border-2 border-slate-200 bg-white px-4 py-3 text-slate-800 placeholder-slate-400 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                  />
+                </div>
+                <button
+                  type="submit"
+                  className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 px-4 py-3 text-base font-semibold text-white shadow-lg transition hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+                >
+                  Send reset email
+                </button>
+              </form>
 
-            {sent && (
-              <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
-                Check your inbox for the reset link. If it is not there, look in Spam or try again.
-              </div>
-            )}
+              {sent && (
+                <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">
+                  Check your inbox for the reset link. If it is not there, look in Spam or try again.
+                </div>
+              )}
 
-            <p className="mt-6 text-center text-sm text-slate-600">
-              Remembered it?{" "}
-              <button
-                type="button"
-                onClick={() => navigate("/", { state: { mode: "login" } })}
-                className="font-semibold text-blue-600 hover:text-blue-700"
-              >
-                Go back to sign in
-              </button>
-            </p>
+              <p className="mt-6 text-center text-sm text-slate-600">
+                Remembered it?{" "}
+                <button
+                  type="button"
+                  onClick={() => navigate("/", { state: { mode: "login" } })}
+                  className="font-semibold text-blue-600 transition hover:text-blue-700"
+                >
+                  Go back to sign in
+                </button>
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/app/javascript/pages/Signup.jsx
+++ b/app/javascript/pages/Signup.jsx
@@ -4,9 +4,29 @@ import { useNavigate } from "react-router-dom";
 import submitForm from "../utils/formSubmit";
 import { Toaster, toast } from "react-hot-toast";
 import SpinnerOverlay from "../components/ui/SpinnerOverlay";
+import WorkspaceOrb from "../components/landing/WorkspaceOrb";
+
+const signupMetrics = [
+  ["2 min", "Quick setup"],
+  ["SSO", "Google ready"],
+  ["Vault", "Secure profile"],
+];
+
+const signupFeatures = [
+  {
+    title: "Team Launch",
+    metric: "Ready",
+    copy: "Create your profile, join the workspace, and start planning from one premium command deck.",
+  },
+  {
+    title: "Smart Flow",
+    metric: "AI",
+    copy: "Unlock momentum, knowledge prompts, chat, tasks, and vault access with a focused account.",
+  },
+];
 
 const Signup = ({ switchToLogin }) => {
-  const { handleSignup, handleGoogleLogin } = useContext(AuthContext);
+  const { handleGoogleLogin } = useContext(AuthContext);
   const [formData, setFormData] = useState({
     first_name: "",
     last_name: "",
@@ -37,7 +57,9 @@ const Signup = ({ switchToLogin }) => {
     submissionData.append("auth[last_name]", formData.last_name);
     submissionData.append("auth[email]", formData.email);
     submissionData.append("auth[password]", formData.password);
-    submissionData.append("auth[profile_picture]", formData.profile_picture);
+    if (formData.profile_picture) {
+      submissionData.append("auth[profile_picture]", formData.profile_picture);
+    }
 
     try {
       await submitForm("/api/signup", "POST", submissionData);
@@ -54,147 +76,161 @@ const Signup = ({ switchToLogin }) => {
   };
 
   return (
-    <div className="flex min-h-full items-center justify-center">
+    <div className="min-h-full">
       <Toaster position="top-right" />
       {loading && <SpinnerOverlay />}
-      <div className="w-full max-w-md rounded-2xl border border-blue-100/70 bg-white/95 p-8 shadow-xl transition-transform hover:scale-[1.01]">
-        <h2 className="mb-8 text-center text-3xl font-bold text-slate-900">Create Account</h2>
-
-        {/* Signup Form */}
-        <form onSubmit={handleSubmit} className="space-y-5" encType="multipart/form-data">
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-semibold text-gray-700 mb-1 required-label" htmlFor="first_name">
-                First Name
-              </label>
-              <input
-                id="first_name"
-                type="text"
-                name="first_name"
-                placeholder="First Name"
-                required
-                className="w-full px-4 py-3 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-all placeholder-gray-400"
-                value={formData.first_name}
-                onChange={handleChange}
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-semibold text-gray-700 mb-1 required-label" htmlFor="last_name">
-                Last Name
-              </label>
-              <input
-                id="last_name"
-                type="text"
-                name="last_name"
-                placeholder="Last Name"
-                required
-                className="w-full px-4 py-3 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-all placeholder-gray-400"
-                value={formData.last_name}
-                onChange={handleChange}
-              />
-            </div>
-          </div>
-
-          <div>
-            <label className="block text-sm font-semibold text-gray-700 mb-1 required-label" htmlFor="email">
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              name="email"
-              placeholder="Email"
-              required
-              className="w-full px-4 py-3 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-all placeholder-gray-400"
-              value={formData.email}
-              onChange={handleChange}
-            />
-          </div>
-          
-          <div className="relative">
-            <label className="block text-sm font-semibold text-gray-700 mb-1 required-label" htmlFor="password">
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              name="password"
-              placeholder="Password"
-              required
-              className="w-full px-4 py-3 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-all placeholder-gray-400"
-              value={formData.password}
-              onChange={handleChange}
-            />
-          </div>
-
-          <div className="relative">
-            <label htmlFor="profile_picture" className="block text-sm font-medium text-gray-600 mb-2">
-              Profile Picture
-            </label>
-            <input
-              type="file"
-              id="profile_picture"
-              name="profile_picture"
-              accept="image/*"
-              title="Profile Picture"
-              onChange={handleChange}
-              className="w-full px-4 py-3 border-2 border-gray-200 rounded-lg focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-all file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
-            />
-          </div>
-
-          <button
-            type="submit"
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white py-2.5 rounded-lg font-medium transition-all transform hover:scale-[1.01] shadow-md"
-          >
-            Sign Up
-          </button>
-        </form>
-
-        {/* Error Message */}
-        {error && (
-          <div className="mt-5 p-3 bg-red-50 border border-red-200 text-red-600 rounded-lg flex items-center gap-2">
-            ⚠️ {error}
-          </div>
-        )}
-
-        {/* Divider */}
-        <div className="relative my-6">
-          <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-gray-200"></div>
-          </div>
-          <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white text-gray-500">OR</span>
-          </div>
+      <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-8 lg:flex-row lg:items-center lg:gap-10 xl:gap-14">
+        <div className="lg:w-[58%]">
+          <WorkspaceOrb
+            eyebrow="Start NexusHub"
+            title="Build your workspace identity in one polished flow."
+            description="Create an account to unlock sprints, conversations, knowledge signals, secure vaults, and a calmer daily operating rhythm."
+            metrics={signupMetrics}
+            featureCards={signupFeatures}
+          />
         </div>
 
-        {/* Google Signup Button */}
-        <button
-          onClick={async () => {
-            setLoading(true);
-            try {
-              await handleGoogleLogin();
-            } finally {
-              setLoading(false);
-            }
-          }}
-          className="w-full bg-red-500 hover:bg-red-600 text-white py-2.5 rounded-lg font-medium transition-all flex items-center justify-center gap-2 shadow-md"
-        >
-          <svg className="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-            <path fill="currentColor" d="M12.545 10.239v3.821h5.445c-.712 2.315-2.647 3.972-5.445 3.972a6.033 6.033 0 110-12.064c1.835 0 3.456.705 4.691 1.942l3.099-3.101A10.113 10.113 0 0012.545 2C7.021 2 2.545 6.477 2.545 12s4.476 10 10 10c5.523 0 10-4.477 10-10a10.1 10.1 0 00-.167-1.785l-9.833-.006z"/>
-          </svg>
-          Sign up with Google
-        </button>
+        <div className="lg:w-[42%]">
+          <div className="w-full max-w-md rounded-3xl border border-white/60 bg-white/95 p-8 shadow-2xl shadow-slate-900/10 transition-transform duration-200 hover:-translate-y-1">
+            <h2 className="mb-1 text-center text-3xl font-bold text-slate-900">Create account</h2>
+            <p className="mb-8 text-center text-sm text-slate-500">Join the workspace and start your command deck.</p>
 
-        <p className="mt-6 text-center text-gray-600">
-          Already have an account?{" "}
-          <button
-            type="button"
-            onClick={switchToLogin}
-            className="text-blue-500 hover:text-blue-600 font-medium transition-colors"
-          >
-            Log in
-          </button>
-        </p>
+            <form onSubmit={handleSubmit} className="space-y-5" encType="multipart/form-data">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700 required-label" htmlFor="first_name">
+                    First name
+                  </label>
+                  <input
+                    id="first_name"
+                    type="text"
+                    name="first_name"
+                    placeholder="Ada"
+                    required
+                    className="w-full rounded-xl border-2 border-slate-200 px-4 py-3 text-slate-800 placeholder-slate-400 shadow-sm transition focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                    value={formData.first_name}
+                    onChange={handleChange}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-sm font-semibold text-slate-700 required-label" htmlFor="last_name">
+                    Last name
+                  </label>
+                  <input
+                    id="last_name"
+                    type="text"
+                    name="last_name"
+                    placeholder="Lovelace"
+                    required
+                    className="w-full rounded-xl border-2 border-slate-200 px-4 py-3 text-slate-800 placeholder-slate-400 shadow-sm transition focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                    value={formData.last_name}
+                    onChange={handleChange}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700 required-label" htmlFor="email">
+                  Email
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  name="email"
+                  placeholder="you@example.com"
+                  required
+                  className="w-full rounded-xl border-2 border-slate-200 px-4 py-3 text-slate-800 placeholder-slate-400 shadow-sm transition focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  value={formData.email}
+                  onChange={handleChange}
+                />
+              </div>
+
+              <div>
+                <label className="mb-1 block text-sm font-semibold text-slate-700 required-label" htmlFor="password">
+                  Password
+                </label>
+                <input
+                  id="password"
+                  type="password"
+                  name="password"
+                  placeholder="Create a strong password"
+                  required
+                  className="w-full rounded-xl border-2 border-slate-200 px-4 py-3 text-slate-800 placeholder-slate-400 shadow-sm transition focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                  value={formData.password}
+                  onChange={handleChange}
+                />
+              </div>
+
+              <div>
+                <label htmlFor="profile_picture" className="mb-2 block text-sm font-semibold text-slate-700">
+                  Profile picture <span className="font-normal text-slate-400">optional</span>
+                </label>
+                <input
+                  type="file"
+                  id="profile_picture"
+                  name="profile_picture"
+                  accept="image/*"
+                  title="Profile Picture"
+                  onChange={handleChange}
+                  className="w-full rounded-xl border-2 border-slate-200 px-4 py-3 text-sm text-slate-700 shadow-sm transition file:mr-4 file:rounded-lg file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-semibold file:text-blue-700 hover:file:bg-blue-100 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                />
+              </div>
+
+              <button
+                type="submit"
+                className="flex w-full items-center justify-center gap-2 rounded-xl bg-gradient-to-r from-blue-600 to-indigo-600 py-3 font-semibold text-white shadow-lg transition hover:from-blue-700 hover:to-indigo-700 focus:outline-none focus:ring-2 focus:ring-blue-200"
+              >
+                Sign Up
+              </button>
+            </form>
+
+            {error && (
+              <div className="mt-5 flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-600">
+                ⚠️ {error}
+              </div>
+            )}
+
+            <div className="relative my-6">
+              <div className="absolute inset-0 flex items-center">
+                <div className="w-full border-t border-slate-200" />
+              </div>
+              <div className="relative flex justify-center text-sm">
+                <span className="bg-white px-2 text-slate-500">OR</span>
+              </div>
+            </div>
+
+            <button
+              onClick={async () => {
+                setLoading(true);
+                try {
+                  await handleGoogleLogin();
+                } finally {
+                  setLoading(false);
+                }
+              }}
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white py-3 font-medium text-slate-700 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+            >
+              <svg className="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                <path
+                  fill="currentColor"
+                  d="M12.545 10.239v3.821h5.445c-.712 2.315-2.647 3.972-5.445 3.972a6.033 6.033 0 110-12.064c1.835 0 3.456.705 4.691 1.942l3.099-3.101A10.113 10.113 0 0012.545 2C7.021 2 2.545 6.477 2.545 12s4.476 10 10 10c5.523 0 10-4.477 10-10a10.1 10.1 0 00-.167-1.785l-9.833-.006z"
+                />
+              </svg>
+              Sign up with Google
+            </button>
+
+            <p className="mt-6 text-center text-sm text-slate-600">
+              Already have an account?{" "}
+              <button
+                type="button"
+                onClick={switchToLogin}
+                className="font-semibold text-blue-600 transition hover:text-blue-700"
+              >
+                Log in
+              </button>
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
### Motivation
- Unify the signup and forgot-password flows with the polished login UI so all auth entry points share the same premium workspace hero and card treatment.
- Ensure the navbar "Get Started" action reliably opens the signup view when the app is already on the root route.
- Prevent text overflow inside the `WorkspaceOrb` feature cards that caused copy to run outside card bounds.

### Description
- Restyled `app/javascript/pages/Signup.jsx` to use the same two-column layout and `WorkspaceOrb` hero as the login page, updated inputs, gradient CTA, and Google sign-in flow, and made the profile picture submission conditional.
- Restyled `app/javascript/pages/ForgotPassword.jsx` to share the same dark auth shell and `WorkspaceOrb` hero as login/signup and updated the reset card to match the new visual language.
- Updated `app/javascript/pages/AuthPage.jsx` to sync internal mode with the incoming `mode` prop via `useEffect`, so `Get Started` reliably switches to the signup panel when routing to `/` with `state: { mode: 'signup' }`.
- Fixed `app/javascript/components/landing/WorkspaceOrb.jsx` to force a two-column feature grid and added `min-w-0`/`break-words`/`shrink-0` utility classes to prevent title/body overflow in feature cards.

### Testing
- Built frontend assets with `npm run build` which completed successfully and produced the app builds (`app/assets/builds/*`).
- Running `npm test -- --runInBand` failed because Vitest does not recognise the Jest-only `--runInBand` flag.
- Running `npm test` (Vitest) succeeded with all test files passing (`3` test files, `15` tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b15a79610832294aec6b36c34745c)