### PR TITLE
Compact project dashboard header

### DIFF
--- a/app/javascript/pages/SprintDashboard.jsx
+++ b/app/javascript/pages/SprintDashboard.jsx
@@ -242,16 +242,16 @@ export default function SprintDashboard() {
 
   return (
     <div className="space-y-5 pb-8">
-      <header className="shell-panel shell-panel-strong landing-hero-3d overflow-hidden rounded-[34px]">
+      <header className="shell-panel shell-panel-strong dashboard-command-deck landing-hero-3d overflow-hidden rounded-[30px]">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(103,232,249,0.16),transparent_24%),radial-gradient(circle_at_left,rgba(52,109,255,0.12),transparent_26%)]" />
-        <div className="relative space-y-4 p-4 sm:p-5 lg:p-6">
-          <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+        <div className="relative space-y-3 p-3.5 sm:p-4 lg:p-5">
+          <div className="flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
             <div className="max-w-3xl">
               <span className="shell-eyebrow">Project Command Deck</span>
-              <h1 className="mt-2 text-[clamp(2rem,3vw,3rem)] font-semibold tracking-[-0.05em] text-slate-950">
+              <h1 className="mt-1.5 text-[clamp(1.65rem,2.35vw,2.35rem)] font-semibold tracking-[-0.045em] text-slate-950">
                 {project?.name || 'Project Dashboard'}
               </h1>
-              <p className="mt-1.5 max-w-2xl text-sm leading-6 text-slate-600 sm:text-[0.95rem]">
+              <p className="mt-1 max-w-2xl text-sm leading-5 text-slate-600">
                 {project?.description || 'Plan sprint delivery, review project health, and move between execution surfaces from one shared control room.'}
               </p>
             </div>
@@ -274,8 +274,8 @@ export default function SprintDashboard() {
             </div>
           </div>
 
-          <div className="grid gap-3 xl:grid-cols-[minmax(0,1.25fr)_minmax(320px,0.92fr)]">
-            <div className="grid gap-3 sm:grid-cols-3">
+          <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1.25fr)_minmax(300px,0.88fr)]">
+            <div className="grid gap-2.5 sm:grid-cols-3">
               <div className="shell-kpi-card">
                 <span className="shell-kpi-label">Sprint Window</span>
                 <span className="shell-kpi-value">{sprint ? sprint.name : 'Awaiting sprint'}</span>
@@ -295,23 +295,23 @@ export default function SprintDashboard() {
               </div>
             </div>
 
-            <div className="overflow-hidden rounded-[28px] border border-white/12 bg-[linear-gradient(135deg,rgba(7,17,32,0.96),rgba(30,41,59,0.92))] p-4 text-white shadow-[0_28px_54px_rgb(15_23_42_/_0.22)] sm:p-5">
+            <div className="overflow-hidden rounded-[24px] border border-white/12 bg-[linear-gradient(135deg,rgba(7,17,32,0.96),rgba(30,41,59,0.92))] p-3.5 text-white shadow-[0_22px_42px_rgb(15_23_42_/_0.18)] sm:p-4">
               <p className="text-[0.68rem] font-semibold uppercase tracking-[0.26em] text-white/45">
                 {sprint && isCurrentSprint(sprint) ? 'Current Sprint' : 'Sprint Status'}
               </p>
-              <div className="mt-2.5 flex items-end justify-between gap-3">
+              <div className="mt-2 flex items-end justify-between gap-2.5">
                 <div>
-                  <p className="text-[1.8rem] font-semibold tracking-[-0.04em]">
+                  <p className="text-[1.45rem] font-semibold tracking-[-0.04em]">
                     {sprint ? sprint.name : 'No sprint selected'}
                   </p>
-                  <p className="mt-1.5 text-sm leading-6 text-white/66">
+                  <p className="mt-1 text-sm leading-5 text-white/66">
                     Use the sprint manager to swap windows, review dates, and shift this dashboard into the correct execution lane.
                   </p>
                 </div>
                 <button
                   type="button"
                   onClick={() => setIsHeaderExpanded((value) => !value)}
-                  className="shell-button-secondary shrink-0 bg-white/10 px-4 py-2.5 text-white shadow-none hover:bg-white/16"
+                  className="shell-button-secondary shrink-0 bg-white/10 px-3.5 py-2 text-white shadow-none hover:bg-white/16"
                 >
                   {isHeaderExpanded ? <ChevronUpIcon className="h-5 w-5" /> : <ChevronDownIcon className="h-5 w-5" />}
                   {isHeaderExpanded ? 'Hide' : 'Manage'}
@@ -320,7 +320,7 @@ export default function SprintDashboard() {
             </div>
           </div>
 
-          <div className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_auto]">
+          <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1fr)_auto]">
             <div className="shell-segmented scrollbar-hide overflow-x-auto">
               {dashboardTabs.map((tab) => (
                 <button

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -422,6 +422,57 @@ textarea {
   color: var(--shell-muted-strong);
 }
 
+
+.dashboard-command-deck .shell-chip {
+  gap: 0.38rem;
+  padding: 0.34rem 0.7rem;
+  font-size: 0.66rem;
+  letter-spacing: 0.14em;
+}
+
+.dashboard-command-deck .shell-chip-dot {
+  width: 0.38rem;
+  height: 0.38rem;
+}
+
+.dashboard-command-deck .shell-eyebrow {
+  font-size: 0.62rem;
+  letter-spacing: 0.2em;
+}
+
+.dashboard-command-deck .shell-kpi-card {
+  padding: 0.78rem 0.9rem;
+  border-radius: 1.15rem;
+  box-shadow: 0 14px 28px rgb(15 23 42 / 0.05);
+}
+
+.dashboard-command-deck .shell-kpi-label {
+  font-size: 0.66rem;
+  letter-spacing: 0.15em;
+}
+
+.dashboard-command-deck .shell-kpi-value {
+  margin-top: 0.38rem;
+  font-size: clamp(1.05rem, 1.55vw, 1.42rem);
+}
+
+.dashboard-command-deck .shell-kpi-meta {
+  margin-top: 0.25rem;
+  font-size: 0.76rem;
+  line-height: 1.32;
+}
+
+.dashboard-command-deck .shell-segmented {
+  gap: 0.25rem;
+  padding: 0.25rem;
+}
+
+.dashboard-command-deck .shell-segmented-button {
+  min-height: 2.35rem;
+  padding: 0.55rem 0.9rem;
+  font-size: 0.82rem;
+}
+
 .shell-input {
   width: 100%;
   border: 1px solid rgb(255 255 255 / 0.7);


### PR DESCRIPTION
### Motivation
- The Project Command Deck header was taking too much vertical space on the sprint dashboard and needed to be visually more compact while avoiding global UI regressions.

### Description
- Toned down header spacing, title sizing, description line-height, KPI grid gaps, sprint status card radius/padding, and Manage button padding in `app/javascript/pages/SprintDashboard.jsx` to reduce the initial section height.
- Scoped a `.dashboard-command-deck` CSS block in `app/javascript/stylesheets/application.css` that reduces chip sizing, KPI card padding, KPI label/value/meta sizes, and segmented control sizing so the changes affect only this header.
- Updated the header element to include the `dashboard-command-deck` class and adjusted several Tailwind utility classes to match the new compact layout.

### Testing
- Ran `npm test` and all tests passed (3 test files, 15 tests passed).
- Ran `npm run build` and the build completed successfully producing the JS build artifacts.
- Ran `npm test -- --runInBand` which failed because Vitest does not support the `--runInBand` option, but this did not affect the normal test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b1d248e74832284fe113975cbb704)