### PR TITLE
Set Posts as default home and refine Knowledge/Calendar hero layout

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -112,7 +112,7 @@ const AppRoutes = () => {
             path="/"
             element={
               <PrivateRoute>
-                <Calendar />
+                <PostPage />
               </PrivateRoute>
             }
           />

--- a/app/javascript/pages/Calendar.jsx
+++ b/app/javascript/pages/Calendar.jsx
@@ -484,7 +484,7 @@ const Calendar = () => {
         .calendar-rail::-webkit-scrollbar { height: 10px; }
         .calendar-rail::-webkit-scrollbar-thumb { background: rgba(125, 211, 252, 0.35); border-radius: 999px; }
       `}</style>
-      <section className="relative overflow-hidden rounded-[2rem] border border-white/20 bg-slate-950 p-6 text-white shadow-2xl shadow-blue-950/30">
+      <section className="relative overflow-hidden rounded-[2.4rem] border border-white/20 bg-slate-950 p-7 text-white shadow-2xl shadow-blue-950/30 sm:p-8 lg:p-10">
         <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(59,130,246,0.38),transparent_32%),radial-gradient(circle_at_80%_8%,rgba(168,85,247,0.34),transparent_30%),linear-gradient(135deg,rgba(15,23,42,0.95),rgba(30,41,59,0.9))]" />
         <div className="pointer-events-none absolute -right-20 top-8 h-72 w-72 rounded-full border border-cyan-300/20 bg-cyan-300/10 blur-sm" />
         <div className="relative grid gap-6 xl:grid-cols-[1.05fr_1.4fr]">
@@ -492,8 +492,8 @@ const Calendar = () => {
             <div className="flex flex-wrap items-start justify-between gap-4">
               <div>
                 <p className="text-xs font-semibold uppercase tracking-[0.35em] text-cyan-200">Temporal command center</p>
-                <h1 className="mt-2 text-3xl font-black tracking-tight sm:text-4xl">Calendar workspace</h1>
-                <p className="mt-2 max-w-xl text-sm leading-6 text-slate-300">A dimensional planning surface for meetings, deadlines, reminders, focus blocks, and sprint ceremonies.</p>
+                <h1 className="mt-2 text-4xl font-black tracking-tight sm:text-5xl">Calendar workspace</h1>
+                <p className="mt-3 max-w-2xl text-base leading-7 text-slate-300">A dimensional planning surface for meetings, deadlines, reminders, focus blocks, and sprint ceremonies.</p>
               </div>
               <button type="button" onClick={load} disabled={loading} className="inline-flex items-center gap-2 rounded-2xl border border-white/15 bg-white/10 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-cyan-950/30 backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/15 disabled:opacity-60">
                 <FiRefreshCw className={loading ? "animate-spin" : ""} />

--- a/app/javascript/pages/KnowledgeDashboard.jsx
+++ b/app/javascript/pages/KnowledgeDashboard.jsx
@@ -455,8 +455,8 @@ function KnowledgeDashboardContent() {
 
   return (
     <div className="min-h-screen pb-16 text-slate-900">
-      <div className="mx-auto max-w-[98%] space-y-6 px-4 pt-6 sm:px-6 lg:px-8">
-        <section className="shell-panel shell-panel-strong sticky top-[6rem] z-20 overflow-hidden rounded-[32px]">
+      <div className="mx-auto max-w-[98%] space-y-6 px-4 pt-10 sm:px-6 lg:px-8">
+        <section className="shell-panel shell-panel-strong sticky top-[6rem] z-20 mb-4 overflow-hidden rounded-[32px]">
           <div className="absolute inset-x-10 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent" />
 
           <div className="space-y-4 p-4 sm:p-5 lg:p-6">

--- a/app/javascript/pages/PostPage.jsx
+++ b/app/javascript/pages/PostPage.jsx
@@ -23,7 +23,6 @@ import {
   FiMessageSquare,
   FiPlus,
   FiSearch,
-  FiTrendingUp,
   FiUsers,
   FiZap,
   FiAlertTriangle,
@@ -312,15 +311,9 @@ const PostPage = () => {
               <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,_rgba(59,130,246,0.45),_transparent_35%),radial-gradient(circle_at_bottom_right,_rgba(168,85,247,0.4),_transparent_35%)]" />
               <div className="relative grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-end">
                 <div>
-                  <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.22em] text-blue-100">
-                    <FiTrendingUp /> Updated workspace
-                  </span>
-                  <h1 className="mt-5 max-w-3xl text-4xl font-black tracking-tight text-white sm:text-5xl">
+                  <h1 className="max-w-3xl text-4xl font-black tracking-tight text-white sm:text-5xl">
                     Welcome back, {[user?.first_name, user?.last_name].filter(Boolean).join(' ') || 'User'} — run your day from Updates.
                   </h1>
-                  <p className="mt-4 max-w-2xl text-base leading-7 text-slate-200">
-                    The old updates feed is now a command center with posts, shortcuts, tasks, projects, birthdays, and quick entry points for the newest app features.
-                  </p>
                   <div className="mt-6 flex flex-wrap gap-3">
                     <button
                       type="button"


### PR DESCRIPTION
### Motivation
- Make the Posts/Updates feed the default landing page so users see posts first. 
- Remove the “Updated workspace” promo and explanatory copy to simplify the Posts hero. 
- Prevent the Knowledge Signal Matrix header from touching the cards below by adding spacing. 
- Make the Calendar hero visually larger and more prominent for improved UI balance.

### Description
- Changed the authenticated `/` route to render the Posts page by default in `app/javascript/components/App.jsx` (replace `<Calendar />` with `<PostPage />`).
- Removed the promo chip and the descriptive paragraph from the Posts hero and cleaned up the unused `FiTrendingUp` import in `app/javascript/pages/PostPage.jsx`.
- Added extra top padding and a bottom margin to the Knowledge header panel by modifying layout classes in `app/javascript/pages/KnowledgeDashboard.jsx`.
- Increased the Calendar hero panel radius/padding and bumped heading/body sizes by updating classes in `app/javascript/pages/Calendar.jsx`.

### Testing
- Attempted a frontend build with `npm run build` to validate JSX changes, but the build failed in this environment because `esbuild` is not available (`sh: 1: esbuild: not found`).
- No automated unit tests were run in this environment due to the build tool missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c03ac0c808322a34efd7c11bd9219)