### PR TITLE
Allow renaming PDF download filename in editor header

### DIFF
--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -4,6 +4,7 @@ class PdfsController < ApplicationController
     if params[:pdf]
       session[:pdf_id] = SecureRandom.uuid
       session[:original_filename] = params[:pdf].original_filename
+      session[:download_filename] = params[:pdf].original_filename
       original_path = Rails.root.join('public', 'uploads', "#{session[:pdf_id]}_original.pdf")
       working_path = Rails.root.join('public', 'uploads', "#{session[:pdf_id]}_working.pdf")
 
@@ -12,7 +13,11 @@ class PdfsController < ApplicationController
       File.open(original_path, 'wb') { |file| file.write(params[:pdf].read) }
       FileUtils.cp(original_path, working_path)
 
-      render json: { pdf_url: "/uploads/#{session[:pdf_id]}_working.pdf" }, status: :ok
+      render json: {
+        pdf_url: "/uploads/#{session[:pdf_id]}_working.pdf",
+        original_filename: session[:original_filename],
+        download_filename: session[:download_filename]
+      }, status: :ok
     else
       render json: { error: "No file uploaded" }, status: :unprocessable_entity
     end
@@ -36,7 +41,7 @@ class PdfsController < ApplicationController
 
   def download
     working_path = download_path_from_session || download_path_from_param
-    file_name = session[:original_filename].presence || default_download_name(working_path)
+    file_name = requested_download_name.presence || session[:download_filename].presence || session[:original_filename].presence || default_download_name(working_path)
 
     if working_path.present? && File.exist?(working_path)
       send_file working_path, type: 'application/pdf', filename: file_name
@@ -48,6 +53,16 @@ class PdfsController < ApplicationController
   end
 
   private
+
+  def requested_download_name
+    return if params[:download_name].blank?
+
+    base_name = File.basename(params[:download_name].to_s.strip)
+    sanitized_name = base_name.gsub(/[^0-9A-Za-z. _-]/, '')
+    return if sanitized_name.blank?
+
+    sanitized_name.end_with?('.pdf') ? sanitized_name : "#{sanitized_name}.pdf"
+  end
 
   def download_path_from_session
     return if session[:pdf_id].blank?

--- a/app/javascript/components/PdfPage.jsx
+++ b/app/javascript/components/PdfPage.jsx
@@ -23,10 +23,13 @@ const PdfPage = () => {
   const [isError, setIsError] = useState(false);
   const [activeForm, setActiveForm] = useState(null);
   const [placementCoordinates, setPlacementCoordinates] = useState(null);
+  const [downloadName, setDownloadName] = useState("document.pdf");
 
   useEffect(() => {
     const storedPdf = localStorage.getItem("pdfUrl");
     if (storedPdf) setPdfUrl(storedPdf);
+    const storedDownloadName = localStorage.getItem("pdfDownloadName");
+    if (storedDownloadName) setDownloadName(storedDownloadName);
 
     const handlePdfUpdate = (event) => {
       const newUrl = event.detail;
@@ -55,6 +58,9 @@ const PdfPage = () => {
       const data = await response.json();
       setPdfUrl(data.pdf_url);
       localStorage.setItem("pdfUrl", data.pdf_url);
+      const nextDownloadName = data.download_filename || data.original_filename || file.name || "document.pdf";
+      setDownloadName(nextDownloadName);
+      localStorage.setItem("pdfDownloadName", nextDownloadName);
     } catch (error) {
       console.error(error);
       setUploadMessage("Upload failed.");
@@ -111,13 +117,25 @@ const PdfPage = () => {
             <Plus className="h-4 w-4" />
           </div>
           <h2 className="text-sm font-bold text-gray-800 truncate max-w-xs">{pdfUrl.split('/').pop()}</h2>
+          <input
+            type="text"
+            value={downloadName}
+            onChange={(event) => {
+              setDownloadName(event.target.value);
+              localStorage.setItem("pdfDownloadName", event.target.value);
+            }}
+            placeholder="Rename download file"
+            className="h-8 w-56 rounded-md border border-gray-200 px-2.5 text-xs text-gray-700 shadow-sm outline-none focus:border-indigo-400 focus:ring-2 focus:ring-indigo-100"
+          />
         </div>
         <div className="flex items-center space-x-4">
-          <button onClick={() => { setPdfUrl(null); localStorage.removeItem("pdfUrl"); }} className="text-xs font-bold text-gray-400 hover:text-red-500 transition-colors">Close</button>
+          <button onClick={() => { setPdfUrl(null); localStorage.removeItem("pdfUrl"); localStorage.removeItem("pdfDownloadName"); }} className="text-xs font-bold text-gray-400 hover:text-red-500 transition-colors">Close</button>
           <button 
             onClick={() => {
               const cleanPath = (pdfUrl || "").split("?")[0].replace(/^\//, "");
-              const downloadUrl = cleanPath ? `/download_pdf?pdf_path=${encodeURIComponent(cleanPath)}` : "/download_pdf";
+              const requestedName = downloadName?.trim();
+              const nameParam = requestedName ? `&download_name=${encodeURIComponent(requestedName)}` : "";
+              const downloadUrl = cleanPath ? `/download_pdf?pdf_path=${encodeURIComponent(cleanPath)}${nameParam}` : `/download_pdf${nameParam ? `?${nameParam.slice(1)}` : ""}`;
               window.open(downloadUrl, "_blank");
             }}
             className="flex items-center px-4 py-1.5 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg text-xs font-bold transition-all shadow-lg shadow-indigo-100 active:scale-95"


### PR DESCRIPTION
### Motivation
- Provide users a small, polished UI to rename a PDF before downloading from the PDF workspace so downloaded files use a friendly name.
- Preserve a sensible default filename from the upload and let the frontend persist a user-chosen name across refreshes for a smoother UX.

### Description
- Store an initial `download_filename` in session during `upload_pdf` and return it in the upload JSON payload as `download_filename` and `original_filename`.
- Accept a `download_name` query parameter in the `download` action and prioritize it when determining the download filename, using `requested_download_name` to sanitize and ensure a `.pdf` suffix.
- Add a compact filename text input in the PDF workspace header (`app/javascript/components/PdfPage.jsx`) that is initialized from upload metadata, persisted to `localStorage`, and cleared on close.
- Wire the Download button to include the `download_name` parameter when opening `/download_pdf` so the backend can use the sanitized name for `send_file`.

### Testing
- Ran Ruby syntax check: `bundle exec ruby -c app/controllers/pdfs_controller.rb`, which reported `Syntax OK`.
- Ran frontend unit tests: `npm run -s test -- app/javascript/utils/taskUtils.test.js`, and the test suite passed (`1 file, 3 tests` all passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f07cba4308322aa88c524a65dccb3)