### PR TITLE
Fix sprint form action button visibility

### DIFF
--- a/app/javascript/components/Scheduler/SprintManager.jsx
+++ b/app/javascript/components/Scheduler/SprintManager.jsx
@@ -220,7 +220,7 @@ export default function SprintManager({ onSprintChange, projectId, projectName, 
         <motion.button
           whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}
           onClick={() => openForm()}
-          className="mt-3 sm:mt-0 flex items-center gap-2 px-4 py-2 bg-[var(--theme-color)] text-white rounded-lg shadow-sm hover:brightness-110 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-50 focus:ring-[var(--theme-color)]"
+          className="mt-3 sm:mt-0 flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg shadow-sm hover:bg-blue-700 transition-all focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-slate-50 focus:ring-blue-500"
         >
           <FiPlus /><span>New Sprint</span>
         </motion.button>
@@ -355,7 +355,7 @@ export default function SprintManager({ onSprintChange, projectId, projectName, 
                   <motion.button
                     type="submit"
                     disabled={isSubmitting || Number(formData.working_days_mask) === 0}
-                    className="px-4 py-2 bg-[var(--theme-color)] text-white rounded-md shadow-sm hover:brightness-110 transition disabled:bg-blue-300"
+                    className="px-4 py-2 bg-blue-600 text-white rounded-md shadow-sm hover:bg-blue-700 transition disabled:bg-slate-300 disabled:text-slate-500 disabled:cursor-not-allowed"
                     whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}
                   >
                     {isSubmitting ? 'Saving...' : (formData.id ? 'Update Sprint' : 'Create Sprint')}


### PR DESCRIPTION
### Motivation
- Create/Edit sprint action buttons could become effectively invisible when theme CSS variables were missing or had low contrast, preventing users from seeing the Create/Update controls.

### Description
- Replaced theme-variable-based Tailwind utilities with explicit blue button classes for the “New Sprint” trigger and the modal submit button in `app/javascript/components/Scheduler/SprintManager.jsx`.
- Added clearer disabled-state styling (`disabled:bg-slate-300 disabled:text-slate-500 disabled:cursor-not-allowed`) for the modal submit button so it remains visible and indicates when it is disabled.

### Testing
- Ran `git diff -- app/javascript/components/Scheduler/SprintManager.jsx` to verify the diff and it showed the expected class updates.
- Committed the changes with `git commit -m "Fix sprint form action button visibility"` and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13eae98dec832285b980dacabfa198)