### PR TITLE
Fix hidden Create/Update buttons in Sprint modal

### DIFF
--- a/app/javascript/components/Scheduler/SprintManager.jsx
+++ b/app/javascript/components/Scheduler/SprintManager.jsx
@@ -293,11 +293,11 @@ export default function SprintManager({ onSprintChange, projectId, projectName, 
           >
             <motion.div
               initial={{ scale: 0.95, y: 20 }} animate={{ scale: 1, y: 0 }} exit={{ scale: 0.95, opacity: 0 }}
-              className="bg-white rounded-xl shadow-2xl w-full max-w-md"
+              className="bg-white rounded-xl shadow-2xl w-full max-w-md max-h-[90vh] flex flex-col"
               onClick={e => e.stopPropagation()}
             >
-              <form onSubmit={handleSubmit}>
-                <div className="p-6">
+              <form onSubmit={handleSubmit} className="flex flex-col min-h-0">
+                <div className="p-6 overflow-y-auto">
                   <div className="flex justify-between items-center mb-4">
                     <h3 className="text-lg font-bold text-slate-800">{formData.id ? 'Edit Sprint' : 'Create New Sprint'}</h3>
                     <button type="button" onClick={() => setFormVisible(false)} className="p-1.5 rounded-full hover:bg-slate-100 text-slate-500"><FiX size={20} /></button>
@@ -350,7 +350,7 @@ export default function SprintManager({ onSprintChange, projectId, projectName, 
                     </div>
                   </div>
                 </div>
-                <div className="bg-slate-50 px-6 py-4 flex justify-end gap-3 rounded-b-xl border-t border-slate-200">
+                <div className="bg-slate-50 px-6 py-4 flex justify-end gap-3 rounded-b-xl border-t border-slate-200 shrink-0">
                   <motion.button type="button" onClick={() => setFormVisible(false)} className="px-4 py-2 bg-white text-slate-700 rounded-md border border-slate-300 hover:bg-slate-100 transition" whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>Cancel</motion.button>
                   <motion.button
                     type="submit"


### PR DESCRIPTION
### Motivation
- The sprint create/edit modal could grow taller than the viewport on short screens, pushing the action footer out of view and hiding the Create/Update buttons. 
- Ensure the modal always keeps the action bar accessible without changing form behavior.

### Description
- Constrain the modal height with `max-h-[90vh]` and make the modal container a column flex (`flex flex-col`).
- Make the form a column flex with `min-h-0` and make the form body scrollable via `overflow-y-auto` so content can scroll inside the modal.
- Keep the footer fixed and visible by adding `shrink-0` to the footer container so action buttons remain accessible.

### Testing
- Ran `git -C /workspace/rails_vite diff -- app/javascript/components/Scheduler/SprintManager.jsx` and it completed successfully. 
- Inspected the updated file with `nl -ba /workspace/rails_vite/app/javascript/components/Scheduler/SprintManager.jsx | sed -n '288,360p'` and it completed successfully. 
- Committed the changes with `git -C /workspace/rails_vite commit` which succeeded; no unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ed30d8f4832280260873e46d743d)