### PR TITLE
Harden JWT decoding, default role assignment, and Keka Faraday error handling

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -201,7 +201,13 @@ class User < ApplicationRecord
   end
 
   def assign_default_role
+    return unless roles.empty?
+
     member_role = Role.find_by(name: 'member')
-    roles << member_role if roles.empty? && member_role.present?
+    if member_role.present?
+      roles << member_role
+    else
+      Rails.logger.error("User##{id} default role assignment failed: role 'member' not found")
+    end
   end
 end

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -9,9 +9,11 @@ class JwtService
   def self.decode(token)
     decoded = JWT.decode(token, SECRET_KEY, true, { algorithm: "HS256" })[0]
     decoded.with_indifferent_access
-  rescue JWT::ExpiredSignature
-    nil # Token expired
-  rescue JWT::DecodeError
-    nil # Invalid token
+  rescue JWT::ExpiredSignature => e
+    Rails.logger.warn("JwtService.decode expired token: #{e.message}")
+    { error: :expired_token }
+  rescue JWT::DecodeError => e
+    Rails.logger.warn("JwtService.decode invalid token: #{e.message}")
+    { error: :invalid_token }
   end
 end

--- a/app/services/keka/client.rb
+++ b/app/services/keka/client.rb
@@ -62,8 +62,15 @@ module Keka
       else
         { success: false, status: response.status, error: response.body.presence || response.reason_phrase }
       end
+    rescue Faraday::TimeoutError => e
+      Rails.logger.error("Keka::Client timeout error on #{path}: #{e.message}")
+      { success: false, error: "Request to Keka timed out", error_type: :timeout }
+    rescue Faraday::ConnectionFailed => e
+      Rails.logger.error("Keka::Client connection error on #{path}: #{e.message}")
+      { success: false, error: "Could not connect to Keka", error_type: :connection_failed }
     rescue Faraday::Error => e
-      { success: false, error: e.message }
+      Rails.logger.error("Keka::Client request error on #{path}: #{e.message}")
+      { success: false, error: e.message, error_type: :request_error }
     end
   end
 end


### PR DESCRIPTION
### Motivation

- Prevent silent authentication failures by avoiding `nil` returns from JWT decoding so callers cannot accidentally bypass checks.
- Avoid runtime crashes when assigning the default `member` role if that role is missing, and ensure such failures are observable in logs.
- Improve observability and error handling for Keka API calls by distinguishing timeouts, connection failures, and generic request errors.
- Confirm that `pdf_master.log*` patterns are already present in `.gitignore` so no additional ignore changes were required in this tree.

### Description

- Updated `JwtService.decode` to log warnings on `JWT::ExpiredSignature` and `JWT::DecodeError` and return structured error hashes (`{ error: :expired_token }` / `{ error: :invalid_token }`) instead of `nil`.
- Changed `User#assign_default_role` to return early when roles exist, to check for a `member` role before appending, and to log an error if the `member` role is not found.
- Broke out Faraday error handling in `Keka::Client#get` into `Faraday::TimeoutError`, `Faraday::ConnectionFailed`, and a generic `Faraday::Error`, each with distinct log messages and structured responses including an `error_type` field.
- Did not modify `.gitignore` because `pdf_master.log` and `*.log.*` patterns were already present.

### Testing

- Ran `ruby -c app/services/jwt_service.rb` and it returned `Syntax OK`.
- Ran `ruby -c app/models/user.rb` and it returned `Syntax OK`.
- Ran `ruby -c app/services/keka/client.rb` and it returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a154410c52c83229733fa1d36032e51)