### PR TITLE
Add API CORS middleware and improve Slack webhook failure handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem "stimulus-rails"
 
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
+gem "rack-cors"
 
 # connection_pool 3.0.x has a Ruby 3.3 syntax issue in this app stack.
 gem "connection_pool", "~> 2.5"

--- a/app/services/issue_notifier.rb
+++ b/app/services/issue_notifier.rb
@@ -8,9 +8,14 @@ class IssueNotifier
     @previous_assignee = previous_assignee
   end
 
+  SLACK_MAX_RETRIES = 3
+
   def notify
     send_email if email_targets.any?
-    send_slack if slack_webhook.present?
+
+    return unless slack_webhook.present?
+
+    send_slack
   end
 
   private
@@ -46,9 +51,36 @@ class IssueNotifier
     }
 
     uri = URI(slack_webhook)
-    Net::HTTP.post(uri, payload.to_json, { "Content-Type" => "application/json" })
-  rescue StandardError => e
-    Rails.logger.warn("IssueNotifier Slack error: #{e.message}")
+
+    with_slack_retries do
+      response = Net::HTTP.post(uri, payload.to_json, { "Content-Type" => "application/json" })
+      next if response.is_a?(Net::HTTPSuccess)
+
+      raise "Slack webhook returned #{response.code}: #{response.body.to_s.first(200)}"
+    end
+  end
+
+  def with_slack_retries
+    attempts = 0
+
+    begin
+      attempts += 1
+      yield
+    rescue StandardError => e
+      if attempts < SLACK_MAX_RETRIES
+        sleep(0.2 * attempts)
+        retry
+      end
+
+      AppEventLogger.error(
+        :application_errors,
+        source: self.class.name,
+        message: "IssueNotifier Slack delivery failed",
+        exception: e,
+        payload: { issue_id: issue.id, issue_key: issue.issue_key }
+      )
+      raise
+    end
   end
 
   def status_line

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,11 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins ENV.fetch("CORS_ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173").split(",").map(&:strip)
+
+    resource "*",
+      headers: :any,
+      methods: %i[get post put patch delete options head],
+      expose: %w[Authorization],
+      credentials: true
+  end
+end


### PR DESCRIPTION
### Motivation
- Ensure the API sets explicit CORS headers so browser frontends are not vulnerable to cross-origin issues. 
- Make Slack notifications from `IssueNotifier` fail loudly and be retried so deliveries are observable and actionable instead of silently ignored. 

### Description
- Add the `rack-cors` dependency in the `Gemfile` to enable CORS middleware. 
- Add `config/initializers/cors.rb` which configures allowed origins from `CORS_ALLOWED_ORIGINS` with localhost defaults for development and enables common methods, headers, and credentials. 
- Harden `app/services/issue_notifier.rb` by adding `SLACK_MAX_RETRIES`, introducing `with_slack_retries` retry/backoff logic, treating non-2xx Slack responses as errors, logging terminal failures via `AppEventLogger.error`, and re-raising after final failure. 

### Testing
- Attempted `bundle install` in this environment, which failed due to a Ruby/Bundler mismatch (the `Gemfile` specifies `ruby "3.3.0"` and the lockfile expects Bundler `4.0.6` while the runtime is different), so the new `rack-cors` gem was not installed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15444fb5ac8322886421eb069012b1)