### PR TITLE
Harden JWT handling, require auth for Sheets, and make Firebase project configurable

### DIFF
--- a/app/controllers/api/sheets_controller.rb
+++ b/app/controllers/api/sheets_controller.rb
@@ -1,5 +1,4 @@
 class Api::SheetsController < Api::BaseController
-  skip_before_action :authenticate_user!, only: [:show]
   around_action :log_sheet_request_exceptions
 
   def show

--- a/app/services/jwt_service.rb
+++ b/app/services/jwt_service.rb
@@ -11,9 +11,11 @@ class JwtService
     decoded.with_indifferent_access
   rescue JWT::ExpiredSignature => e
     Rails.logger.warn("JwtService.decode expired token: #{e.message}")
+    Rails.error.report(e, handled: true, context: { service: 'JwtService', operation: 'decode', token_state: 'expired' })
     { error: :expired_token }
   rescue JWT::DecodeError => e
     Rails.logger.warn("JwtService.decode invalid token: #{e.message}")
+    Rails.error.report(e, handled: true, context: { service: 'JwtService', operation: 'decode', token_state: 'invalid' })
     { error: :invalid_token }
   end
 end

--- a/config/initializers/firebase.rb
+++ b/config/initializers/firebase.rb
@@ -1,4 +1,5 @@
 FirebaseIdToken.configure do |config|
-  config.project_ids = ['temppdfmodifier']
+  project_id = ENV.fetch('FIREBASE_PROJECT_ID')
+  config.project_ids = [project_id]
   config.redis = nil
 end


### PR DESCRIPTION
### Motivation
- Improve observability for silent JWT failures by surfacing expired/invalid tokens to error tracking. 
- Ensure the Sheets `show` endpoint no longer bypasses API authentication to prevent unauthorized data access. 
- Remove a hardcoded Firebase project id so environments control the active Firebase project.

### Description
- Add structured error reporting to `JwtService.decode` by calling `Rails.error.report` for `JWT::ExpiredSignature` and `JWT::DecodeError` while preserving `Rails.logger.warn` and returning explicit error hashes. (see `app/services/jwt_service.rb`).
- Remove the `skip_before_action :authenticate_user!` line so `Api::SheetsController#show` uses the normal authentication flow. (see `app/controllers/api/sheets_controller.rb`).
- Replace the hardcoded Firebase project id with `ENV.fetch('FIREBASE_PROJECT_ID')` and assign it to `config.project_ids` in the initializer. (see `config/initializers/firebase.rb`).

### Testing
- Ran `ruby -c app/services/jwt_service.rb` which returned `Syntax OK`.
- Ran `ruby -c app/controllers/api/sheets_controller.rb` which returned `Syntax OK`.
- Ran `ruby -c config/initializers/firebase.rb` which returned `Syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168e75a47883229fef4746e75e2944)