### PR TITLE
Harden PDF upload/download and Google Sheets ID validation

### DIFF
--- a/app/controllers/pdfs_controller.rb
+++ b/app/controllers/pdfs_controller.rb
@@ -1,7 +1,13 @@
 class PdfsController < ApplicationController
+  MAX_PDF_UPLOAD_SIZE = 50.megabytes
 
   def upload_pdf
     if params[:pdf]
+      if params[:pdf].size.to_i > MAX_PDF_UPLOAD_SIZE
+        render json: { error: 'File is too large. Maximum size is 50MB.' }, status: :payload_too_large
+        return
+      end
+
       session[:pdf_id] = SecureRandom.uuid
       session[:original_filename] = params[:pdf].original_filename
       session[:download_filename] = params[:pdf].original_filename
@@ -74,10 +80,12 @@ class PdfsController < ApplicationController
     return if params[:pdf_path].blank?
 
     requested_path = params[:pdf_path].to_s.sub(%r{\A/+}, '')
-    full_path = Rails.root.join('public', requested_path).cleanpath
-    public_root = Rails.root.join('public').to_s
+    return unless requested_path.match?(/\Auploads\/[0-9a-f\-]+_(?:original|working)\.pdf\z/i)
 
-    return unless full_path.to_s.start_with?(public_root)
+    full_path = Rails.root.join('public', requested_path).cleanpath
+    uploads_root = Rails.root.join('public', 'uploads').to_s
+
+    return unless full_path.to_s.start_with?(uploads_root)
     return unless File.extname(full_path.to_s).casecmp('.pdf').zero?
 
     full_path.to_s

--- a/app/services/google_sheets_reader.rb
+++ b/app/services/google_sheets_reader.rb
@@ -44,5 +44,9 @@ class GoogleSheetsReader
 
   def ensure_spreadsheet_id!
     raise ArgumentError, 'Spreadsheet ID is missing' if @spreadsheet_id.blank?
+
+    @service.get_spreadsheet(@spreadsheet_id, fields: 'spreadsheetId')
+  rescue Google::Apis::ClientError => e
+    raise ArgumentError, "Spreadsheet ID is invalid or inaccessible: #{e.message}"
   end
 end


### PR DESCRIPTION
### Motivation
- Prevent unbounded PDF uploads that can be used for denial-of-service by enforcing a maximum upload size.  
- Eliminate path traversal and arbitrary file access via the `pdf_path` parameter by whitelisting allowed download paths and scoping to the uploads directory.  
- Fail fast and provide a clearer error when a configured Google Sheets spreadsheet ID is missing, invalid, or inaccessible by verifying access with the Sheets API.

### Description
- In `GoogleSheetsReader#ensure_spreadsheet_id!` added a lightweight API call `@service.get_spreadsheet(@spreadsheet_id, fields: 'spreadsheetId')` and rescue of `Google::Apis::ClientError` to raise a descriptive `ArgumentError` for invalid or inaccessible IDs.  
- In `PdfsController` added `MAX_PDF_UPLOAD_SIZE = 50.megabytes` and a size check in `upload_pdf` that returns `413 Payload Too Large` when exceeded.  
- In `PdfsController#download_path_from_param` introduced a strict whitelist regex for `uploads/<uuid>_(original|working).pdf`, ensured the resolved path is under `public/uploads`, and kept the PDF extension check to prevent path traversal and arbitrary file access.  

### Testing
- Ran `bundle exec ruby -c app/services/google_sheets_reader.rb` and the file passed Ruby syntax checks.  
- Ran `bundle exec ruby -c app/controllers/pdfs_controller.rb` and the file passed Ruby syntax checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168ea6daa083228ad30e997cc2fa58)