### PR TITLE
Encrypt Keka API keys and restrict CORS resource scope

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 gem "rack-cors"
+gem "attr_encrypted", "~> 4.2"
 
 # connection_pool 3.0.x has a Ruby 3.3 syntax issue in this app stack.
 gem "connection_pool", "~> 2.5"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,6 +60,10 @@ class User < ApplicationRecord
   has_many :calendar_events, dependent: :destroy
   belongs_to :department, optional: true
 
+  attr_encrypted :keka_api_key,
+                 key: ENV.fetch("KEKA_API_KEY_ENCRYPTION_KEY"),
+                 algorithm: "aes-256-gcm"
+
   enum availability_status: {
     available_now: 'available_now',
     available_soon: 'available_soon',

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -2,7 +2,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
     origins ENV.fetch("CORS_ALLOWED_ORIGINS", "http://localhost:5173,http://127.0.0.1:5173").split(",").map(&:strip)
 
-    resource "*",
+    resource ENV.fetch("CORS_ALLOWED_PATH", "/api/*"),
       headers: :any,
       methods: %i[get post put patch delete options head],
       expose: %w[Authorization],

--- a/db/migrate/20260527000000_encrypt_keka_api_keys_on_users.rb
+++ b/db/migrate/20260527000000_encrypt_keka_api_keys_on_users.rb
@@ -1,0 +1,25 @@
+class EncryptKekaApiKeysOnUsers < ActiveRecord::Migration[7.1]
+  def up
+    add_column :users, :encrypted_keka_api_key, :string
+    add_column :users, :encrypted_keka_api_key_iv, :string
+
+    User.reset_column_information
+    User.where.not(keka_api_key: [nil, ""]).find_each do |user|
+      plaintext_key = user[:keka_api_key]
+      user[:keka_api_key] = nil
+      user.keka_api_key = plaintext_key
+      user.save!(validate: false)
+    end
+  end
+
+  def down
+    User.reset_column_information
+    User.where.not(encrypted_keka_api_key: [nil, ""]).find_each do |user|
+      decrypted_key = user.keka_api_key
+      user.update_columns(keka_api_key: decrypted_key)
+    end
+
+    remove_column :users, :encrypted_keka_api_key_iv
+    remove_column :users, :encrypted_keka_api_key
+  end
+end


### PR DESCRIPTION
### Motivation
- Prevent storage of sensitive Keka API keys in plaintext by enabling model-level encryption for `keka_api_key`.
- Reduce CSRF/credential exposure risk by removing a CORS wildcard resource and scoping allowed routes.

### Description
- Add `attr_encrypted` gem (`gem "attr_encrypted", "~> 4.2"`) to the `Gemfile` to support attribute encryption.
- Configure `User` to use `attr_encrypted :keka_api_key` with `key: ENV.fetch("KEKA_API_KEY_ENCRYPTION_KEY")` and `algorithm: "aes-256-gcm"` so the model stores encrypted values.
- Add migration `EncryptKekaApiKeysOnUsers` to create `encrypted_keka_api_key` and `encrypted_keka_api_key_iv`, migrate existing plaintext values into the encrypted field, and clear the legacy plaintext column.
- Tighten CORS in `config/initializers/cors.rb` by replacing `resource "*"` with a configurable path `ENV.fetch("CORS_ALLOWED_PATH", "/api/*")` while keeping allowed origins env-driven.

### Testing
- Ran Ruby syntax checks: `bundle exec ruby -c app/models/user.rb` succeeded.
- Ran Ruby syntax checks: `bundle exec ruby -c config/initializers/cors.rb` succeeded.
- Ran Ruby syntax checks: `bundle exec ruby -c db/migrate/20260527000000_encrypt_keka_api_keys_on_users.rb` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a168ed8e1508322af432e536a86d33f)