### PR TITLE
Parametrize dev ngrok host and PdfMaster path; sanitize Sheets API errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
 
-  gem 'PdfMaster', path: "/home/divyarajs/rails_project/newgems/PdfMaster"
+  gem 'PdfMaster', path: ENV.fetch('PDF_MASTER_PATH', 'lib/PdfMaster')
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/app/controllers/api/sheets_controller.rb
+++ b/app/controllers/api/sheets_controller.rb
@@ -24,6 +24,6 @@ class Api::SheetsController < Api::BaseController
       exception: e,
       payload: { project_id: project&.id || params[:project_id], sheet_name: sheet_name, spreadsheet_id: project&.sheet_id }
     )
-    render json: { error: e.message }, status: :internal_server_error
+    render json: { error: "An unexpected error occurred" }, status: :internal_server_error
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ module RailsVite
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
     config.middleware.use ActionDispatch::Cookies
-    config.hosts << "10ac-122-170-1-30.ngrok-free.app"
+    config.hosts << ENV["ALLOWED_NGROK_HOST"] if Rails.env.development? && ENV["ALLOWED_NGROK_HOST"].present?
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION
### Motivation
- Remove machine- and tunnel-specific hardcoded values to make development configuration portable and secure. 
- Avoid leaking internal exception details to API clients to reduce information exposure. 
- Confirm that API authentication is enforced via the shared base controller. 

### Description
- Replace the hardcoded ngrok host in `config/application.rb` with an environment-driven development-only entry using `ENV["ALLOWED_NGROK_HOST"]`. 
- Make the `PdfMaster` gem path configurable in the `Gemfile` via `ENV.fetch('PDF_MASTER_PATH', 'lib/PdfMaster')` instead of an absolute local path. 
- Change the `Api::SheetsController` error response to return a generic message (`"An unexpected error occurred"`) instead of surfacing `e.message`. 

### Testing
- Ran `ruby -c config/application.rb` and the file is syntactically valid (OK). 
- Ran `ruby -c app/controllers/api/sheets_controller.rb` and the file is syntactically valid (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a169bc03c4c832296cb0f00954126bb)