### PR TITLE
Add API rate limiting and pagination for list endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem "stimulus-rails"
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem "jbuilder"
 gem "rack-cors"
+gem "rack-attack"
+gem "kaminari"
 gem "attr_encrypted", "~> 4.2"
 
 # connection_pool 3.0.x has a Ruby 3.3 syntax issue in this app stack.

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -99,4 +99,27 @@ class Api::BaseController < ApplicationController
       AppEventLogger.error(channel, source: controller_action_source, message: message, exception: exception, payload: full_payload)
     end
   end
+
+  def render_paginated_collection(scope, serializer: nil, per_page: nil)
+    page = params[:page].to_i
+    page = 1 if page < 1
+    per = (params[:per_page] || per_page || 25).to_i
+    per = 25 if per < 1
+
+    paginated_scope = scope.respond_to?(:page) ? scope : Kaminari.paginate_array(Array(scope))
+    paginated = paginated_scope.page(page).per(per)
+    data = serializer ? paginated.map { |record| serializer.call(record) } : paginated
+
+    render json: {
+      data: data,
+      meta: {
+        current_page: paginated.current_page,
+        next_page: paginated.next_page,
+        prev_page: paginated.prev_page,
+        total_pages: paginated.total_pages,
+        total_count: paginated.total_count,
+        per_page: paginated.limit_value
+      }
+    }
+  end
 end

--- a/app/controllers/api/developers_controller.rb
+++ b/app/controllers/api/developers_controller.rb
@@ -2,7 +2,7 @@ class Api::DevelopersController < Api::BaseController
   def index
     users = User.order(:first_name, :last_name, :email)
     users = users.joins(:project_users).where(project_users: { project_id: params[:project_id] }).distinct if params[:project_id].present?
-    render json: users.map { |user| serialize_developer(user) }
+    render_paginated_collection(users, serializer: method(:serialize_developer))
   end
 
   private

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -6,7 +6,7 @@ class Api::ProjectsController < Api::BaseController
 
   def index
     projects = Project.includes(project_users: :user).order(:name)
-    render json: projects.map { |p| serialize_project(p) }
+    render_paginated_collection(projects, serializer: method(:serialize_project))
   end
 
   def create

--- a/app/controllers/api/roles_controller.rb
+++ b/app/controllers/api/roles_controller.rb
@@ -2,7 +2,7 @@ class Api::RolesController < Api::BaseController
   before_action :authorize_role_access!
 
   def index
-    render json: available_role_names
+    render_paginated_collection(available_role_names)
   end
 
   private

--- a/app/controllers/api/skills_controller.rb
+++ b/app/controllers/api/skills_controller.rb
@@ -1,7 +1,7 @@
 class Api::SkillsController < Api::BaseController
   def index
     skills = Skill.alphabetical
-    render json: skills.map { |skill| serialize(skill) }
+    render_paginated_collection(skills, serializer: method(:serialize))
   end
 
   private

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -8,8 +8,8 @@ class Api::UsersController < Api::BaseController
 
   # GET /api/users.json
   def index
-    @users = User.order(created_at: :desc)
-    render json: @users.map { |user| serialize_user(user) }
+    users = User.order(created_at: :desc)
+    render_paginated_collection(users, serializer: method(:serialize_user))
   end
 
 

--- a/app/controllers/api/work_categories_controller.rb
+++ b/app/controllers/api/work_categories_controller.rb
@@ -2,7 +2,7 @@ class Api::WorkCategoriesController < Api::BaseController
   before_action :set_category, only: [:update, :destroy]
 
   def index
-    render json: WorkCategory.all
+    render_paginated_collection(WorkCategory.order(:name))
   end
 
   def create

--- a/app/controllers/api/work_logs_controller.rb
+++ b/app/controllers/api/work_logs_controller.rb
@@ -7,7 +7,7 @@ class Api::WorkLogsController < Api::BaseController
     if params[:from].present? && params[:to].present?
       logs = logs.where(log_date: params[:from]..params[:to])
     end
-    render json: logs.map { |log| serialize_log(log) }
+    render_paginated_collection(logs.order(log_date: :desc), serializer: method(:serialize_log))
   end
 
   def create

--- a/app/controllers/api/work_priorities_controller.rb
+++ b/app/controllers/api/work_priorities_controller.rb
@@ -2,7 +2,7 @@ class Api::WorkPrioritiesController < Api::BaseController
   before_action :set_priority, only: [:update, :destroy]
 
   def index
-    render json: WorkPriority.all
+    render_paginated_collection(WorkPriority.order(:name))
   end
 
   def create

--- a/app/controllers/api/work_tags_controller.rb
+++ b/app/controllers/api/work_tags_controller.rb
@@ -2,7 +2,7 @@ class Api::WorkTagsController < Api::BaseController
   before_action :set_tag, only: [:update, :destroy]
 
   def index
-    render json: WorkTag.all
+    render_paginated_collection(WorkTag.order(:name))
   end
 
   def create

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module RailsVite
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
     config.middleware.use ActionDispatch::Cookies
+    config.middleware.use Rack::Attack
     config.hosts << ENV["ALLOWED_NGROK_HOST"] if Rails.env.development? && ENV["ALLOWED_NGROK_HOST"].present?
 
     # Configuration for the application, engines, and railties goes here.

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,17 @@
+class Rack::Attack
+  throttle('req/ip', limit: ENV.fetch('RACK_ATTACK_REQUESTS_PER_MINUTE', 300).to_i, period: 1.minute) do |req|
+    req.ip if req.path.start_with?('/api')
+  end
+
+  throttle('logins/ip', limit: ENV.fetch('RACK_ATTACK_LOGIN_PER_MINUTE', 20).to_i, period: 1.minute) do |req|
+    req.ip if req.path == '/api/login' && req.post?
+  end
+
+  throttle('signup/ip', limit: ENV.fetch('RACK_ATTACK_SIGNUP_PER_HOUR', 10).to_i, period: 1.hour) do |req|
+    req.ip if req.path == '/api/users' && req.post?
+  end
+
+  self.throttled_responder = lambda do |_request|
+    [429, { 'Content-Type' => 'application/json' }, [{ error: 'Rate limit exceeded. Please try again later.' }.to_json]]
+  end
+end


### PR DESCRIPTION
### Motivation
- Prevent API abuse and brute-force attacks by adding request throttling for API routes, logins, and signups.
- Fix missing pagination on list endpoints (BUG #6) so large collections are returned in pages with consistent metadata.

### Description
- Added `rack-attack` and `kaminari` to the `Gemfile` to provide request throttling and pagination support, respectively.
- Introduced `config/initializers/rack_attack.rb` with API-focused throttles (general `/api` traffic, `/api/login` POSTs, and `/api/users` POSTs) and a JSON `429` responder, with rates configurable via environment variables.
- Enabled `Rack::Attack` in the middleware stack in `config/application.rb`.
- Added `render_paginated_collection` to `Api::BaseController` which normalizes `page`/`per_page`, supports Kaminari relations and arrays via `Kaminari.paginate_array`, and returns `data` plus `meta` pagination fields.
- Replaced several controllers' index responses to use the new pagination helper, including `Api::UsersController`, `Api::ProjectsController`, `Api::DevelopersController`, `Api::SkillsController`, `Api::RolesController`, `Api::WorkLogsController`, and work taxonomy endpoints (`WorkCategories`, `WorkPriorities`, `WorkTags`).

### Testing
- Attempted to run `bundle install`, but the run failed in this environment due to a Ruby/Bundler version mismatch and gem fetch errors (403), so dependencies could not be installed and runtime verification was not completed.
- No automated test suite was executed in this environment after the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a1c2aad883229a809c5e58c44542)