### PR TITLE
Reduce route loader delay and parallelize WorkLog API requests

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 import { AnimatePresence, motion } from "framer-motion";
@@ -57,11 +57,34 @@ const routeTransitionProps = {
 const RouteTransitionLoader = ({ children }) => {
   const location = useLocation();
   const [isRouteLoading, setIsRouteLoading] = useState(false);
+  const startTimeRef = useRef(Date.now());
+  const hideTimerRef = useRef(null);
 
   useEffect(() => {
+    if (hideTimerRef.current) {
+      clearTimeout(hideTimerRef.current);
+    }
+
     setIsRouteLoading(true);
-    const timer = setTimeout(() => setIsRouteLoading(false), 420);
-    return () => clearTimeout(timer);
+    startTimeRef.current = Date.now();
+
+    hideTimerRef.current = setTimeout(() => {
+      const elapsed = Date.now() - startTimeRef.current;
+      const minDelay = Math.max(150 - elapsed, 0);
+
+      if (minDelay === 0) {
+        setIsRouteLoading(false);
+        return;
+      }
+
+      hideTimerRef.current = setTimeout(() => setIsRouteLoading(false), minDelay);
+    }, 0);
+
+    return () => {
+      if (hideTimerRef.current) {
+        clearTimeout(hideTimerRef.current);
+      }
+    };
   }, [location.pathname, location.search]);
 
   return (

--- a/app/javascript/pages/WorkLog.jsx
+++ b/app/javascript/pages/WorkLog.jsx
@@ -151,17 +151,14 @@ const WorkLog = () => {
   useEffect(() => {
     const loadInitialData = async () => {
       try {
-        const { data: priorityData } = await fetchWorkPriorities();
+        const [{ data: priorityData }, { data: categoryData }, { data: tagData }] = await Promise.all([
+          fetchWorkPriorities(),
+          fetchWorkCategories(),
+          fetchWorkTags()
+        ]);
+
         setPriorities(priorityData.sort((a, b) => a.id - b.id));
-      } catch { }
-
-      try {
-        const { data: categoryData } = await fetchWorkCategories();
         setCategories(categoryData.sort((a, b) => a.id - b.id));
-      } catch { }
-
-      try {
-        const { data: tagData } = await fetchWorkTags();
         setTags(tagData.map(t => t.name));
       } catch { }
     };
@@ -170,22 +167,25 @@ const WorkLog = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        const params = viewMode === 'weekly'
-          ? {
-            from: format(startOfWeek(selectedDate), 'yyyy-MM-dd'),
-            to: format(endOfWeek(selectedDate), 'yyyy-MM-dd')
-          }
-          : { date: format(selectedDate, 'yyyy-MM-dd') };
-        const { data } = await getWorkLogs(params);
-        setTasks(data.map(formatLog));
-      } catch { }
+      const params = viewMode === 'weekly'
+        ? {
+          from: format(startOfWeek(selectedDate), 'yyyy-MM-dd'),
+          to: format(endOfWeek(selectedDate), 'yyyy-MM-dd')
+        }
+        : { date: format(selectedDate, 'yyyy-MM-dd') };
+      const selectedDateKey = format(selectedDate, 'yyyy-MM-dd');
 
       try {
-        const { data: noteData } = await getWorkNote(format(selectedDate, 'yyyy-MM-dd'));
+        const [{ data: logsData }, { data: noteData }] = await Promise.all([
+          getWorkLogs(params),
+          getWorkNote(selectedDateKey)
+        ]);
+
+        setTasks(logsData.map(formatLog));
         setDailyNote(noteData.content || '');
         setNoteId(noteData.id || null);
       } catch {
+        setTasks([]);
         setDailyNote('');
         setNoteId(null);
       }


### PR DESCRIPTION
### Motivation
- Remove an artificial 420ms route-loading delay that caused unnecessary spinner time on every navigation and replace it with a shorter, minimum display window to improve perceived performance.
- Reduce WorkLog mount latency by parallelizing independent API requests that were previously executed sequentially.

### Description
- Reworked `RouteTransitionLoader` in `app/javascript/components/App.jsx` to use `useRef`-backed timers and cleanup, replace the fixed 420ms hide delay with a dynamic minimum window (150ms), and avoid stale timers on rapid route changes.
- Batched initial WorkLog metadata requests (`fetchWorkPriorities`, `fetchWorkCategories`, `fetchWorkTags`) using `Promise.all` so they run in parallel in `app/javascript/pages/WorkLog.jsx`.
- Batched per-date WorkLog fetches (`getWorkLogs` and `getWorkNote`) with `Promise.all` and added a safe fallback to clear `tasks` on error.

### Testing
- Ran `git diff --check`, which produced no issues and passed successfully.
- Attempted `npm run lint` for the modified files, but the repository has no `lint` npm script so the lint step failed to run (not a code error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a2149b788322b0ed722c1ea38d12)