### PR TITLE
Optimize image loading and lazy-load PDF page

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { Suspense, lazy, useEffect, useRef, useState } from "react";
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { Toaster } from "react-hot-toast";
 import { AnimatePresence, motion } from "framer-motion";
@@ -9,7 +9,6 @@ import ProjectMemberRoute from "../components/ProjectMemberRoute";
 
 import Navbar from "../components/Navbar";
 import Footer from "./Footer";
-import PdfPage from "./PdfPage";
 import PostPage from "../pages/PostPage";
 import Profile from "../components/Profile";
 import KnowledgeDashboard from "../pages/KnowledgeDashboard";
@@ -39,6 +38,8 @@ import ObjectGallery from "../pages/ObjectGallery";
 import MetaverseLanding from "../pages/MetaverseLanding";
 import ProjectMetaverse from "../pages/ProjectMetaverse";
 import ChatLauncher from "./ChatLauncher";
+
+const PdfPage = lazy(() => import("./PdfPage"));
 
 const routeTransitionProps = {
   initial: { opacity: 0, y: 18, scale: 0.992, filter: "blur(12px)" },
@@ -154,7 +155,7 @@ const AppRoutes = () => {
             path="/pdf"
             element={
               <PrivateRoute>
-                <PdfPage />
+                <Suspense fallback={<PageLoader title="Loading PDF Workspace" message="Preparing document tools..." overlay />}><PdfPage /></Suspense>
               </PrivateRoute>
             }
           />

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -143,7 +143,7 @@ const HolographicAvatar = ({ user }) => {
         src={user.profile_picture || `https://ui-avatars.com/api/?name=${user.email}&background=random`}
         alt="User avatar"
         className="relative z-10 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
-      />
+      loading="lazy" />
       <div className="absolute inset-0 z-20 bg-[radial-gradient(circle_at_top,rgba(255,255,255,0.35),transparent_55%)]" />
       <div
         className="absolute inset-0 z-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
@@ -425,7 +425,7 @@ const Navbar = () => {
               src={logo}
               alt="NexusHub logo"
               className="relative z-10 h-8 w-auto transition-transform duration-500 group-hover:scale-110"
-            />
+            loading="lazy" />
           </span>
           <div className="min-w-0">
             <p className="text-[0.58rem] font-semibold uppercase tracking-[0.34em] text-slate-400">Nexus Shell</p>

--- a/app/javascript/components/NotificationCenter.jsx
+++ b/app/javascript/components/NotificationCenter.jsx
@@ -159,7 +159,7 @@ const NotificationCenter = () => {
                                 src={notification.actor_avatar}
                                 alt=""
                                 className="h-8 w-8 rounded-full object-cover border border-gray-200"
-                              />
+                              loading="lazy" />
                             )}
                             {!notification.actor_avatar && (
                               <div className="h-8 w-8 rounded-full bg-gray-200 flex items-center justify-center">

--- a/app/javascript/components/PostForm.jsx
+++ b/app/javascript/components/PostForm.jsx
@@ -118,7 +118,7 @@ const PostForm = ({ refreshPosts }) => {
                   src={imagePreview}
                   alt="Preview"
                   className="w-full h-auto max-h-80 object-contain"
-                />
+                loading="lazy" />
                 <button
                   type="button"
                   onClick={removeImage}

--- a/app/javascript/components/PostList.jsx
+++ b/app/javascript/components/PostList.jsx
@@ -350,7 +350,7 @@ const PostList = ({ posts, refreshPosts, onPostUpdate = () => {} }) => {
                 src={post.image_url} 
                 alt="Post content" 
                 className="w-full h-auto max-h-[500px] object-contain mx-auto" 
-              />
+              loading="lazy" />
             </div>
           )}
 

--- a/app/javascript/components/Profile.jsx
+++ b/app/javascript/components/Profile.jsx
@@ -20,7 +20,7 @@ const Avatar = ({ name, src, size = 'md', color }) => {
         src={src}
         alt={name}
         className={`${sizes[size]} rounded-full object-cover border-2 border-white/80 shadow-sm`}
-      />
+      loading="lazy" />
     );
   }
   const initial = getAvatarInitial(name);
@@ -539,7 +539,7 @@ const Profile = () => {
                 src={user.cover_photo} 
                 alt="Cover" 
                 className="absolute inset-0 w-full h-full object-cover" 
-              />
+              loading="lazy" />
             )}
             <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(7,17,32,0.08),rgba(7,17,32,0.72))]" />
             <div className="absolute left-6 top-6 flex flex-wrap items-center gap-2">
@@ -574,7 +574,7 @@ const Profile = () => {
                     src={user.profile_picture}
                     alt="Profile"
                     className="h-32 w-32 rounded-full border-4 border-white/90 object-cover shadow-[0_26px_54px_rgb(15_23_42_/_0.18)] transition-all duration-300 group-hover:scale-[1.03] md:h-40 md:w-40"
-                  />
+                  loading="lazy" />
                 ) : (
                   <div
                     className="flex h-32 w-32 items-center justify-center rounded-full border-4 border-white/90 text-5xl font-bold shadow-[0_26px_54px_rgb(15_23_42_/_0.18)] transition-all duration-300 group-hover:scale-[1.03] md:h-40 md:w-40 md:text-6xl"
@@ -910,7 +910,7 @@ const Profile = () => {
                               src={post.image_url}
                               alt="Post"
                               className="w-full h-48 object-cover"
-                            />
+                            loading="lazy" />
                           )}
                           <div className="p-5">
                             <div className="flex items-center text-sm text-gray-500 mb-2">
@@ -1234,7 +1234,7 @@ const Profile = () => {
                                   src={m.profile_picture}
                                   alt={m.name}
                                   className="w-8 h-8 rounded-full border-2 border-white object-cover"
-                                />
+                                loading="lazy" />
                               ) : (
                                 <div
                                   key={m.id}

--- a/app/javascript/components/ui/Avatar.jsx
+++ b/app/javascript/components/ui/Avatar.jsx
@@ -11,7 +11,7 @@ const Avatar = ({ name, src, className = "" }) => {
         src={src}
         alt={altText}
         className={`rounded-full object-cover ${className}`.trim()}
-      />
+      loading="lazy" />
     );
   }
 

--- a/app/javascript/pages/Chat.jsx
+++ b/app/javascript/pages/Chat.jsx
@@ -333,7 +333,7 @@ const Avatar = ({ name, src, size = "md", className = "" }) => {
         src={src}
         alt={name}
         className={`rounded-full object-cover ring-2 ring-white/90 shadow-[0_16px_40px_-24px_rgba(15,23,42,0.7)] ${currentSizeClass} ${className}`}
-      />
+      loading="lazy" />
     );
   }
 
@@ -454,7 +454,7 @@ const MessageAttachmentCard = ({ attachment, isMe, searchQuery }) => {
       <div className={`group/attachment relative overflow-hidden rounded-2xl border ${containerClass}`}>
         <a href={attachment.url} target="_blank" rel="noreferrer" className="block" title={`Open ${attachment.filename}`}>
           {isImage ? (
-            <img src={attachment.url} alt={attachment.filename} className="h-44 w-full object-cover" />
+            <img src={attachment.url} alt={attachment.filename} className="h-44 w-full object-cover" loading="lazy" />
           ) : (
             <video src={attachment.url} className="h-44 w-full bg-slate-950 object-cover" controls preload="metadata" />
           )}
@@ -1874,7 +1874,7 @@ const Chat = ({ embedded = false, initialConversationId = null }) => {
                               >
                                 {isImage && previewUrl ? (
                                   <div className="overflow-hidden rounded-2xl">
-                                    <img src={previewUrl} alt={file.name} className="h-24 w-full object-cover" />
+                                    <img src={previewUrl} alt={file.name} className="h-24 w-full object-cover" loading="lazy" />
                                   </div>
                                 ) : isVideo && previewUrl ? (
                                   <div className="overflow-hidden rounded-2xl">

--- a/app/javascript/pages/DepartmentDetails.jsx
+++ b/app/javascript/pages/DepartmentDetails.jsx
@@ -34,7 +34,7 @@ const Avatar = ({ name, src, size = 'md', className = '' }) => {
   const currentSizeClass = sizeClasses[size] || sizeClasses.md;
 
   if (src && src !== 'null') {
-    return <img src={src} alt={name} className={`rounded-full object-cover ring-2 ring-white dark:ring-zinc-800 shadow-sm ${currentSizeClass} ${className}`} />;
+    return <img src={src} alt={name} className={`rounded-full object-cover ring-2 ring-white dark:ring-zinc-800 shadow-sm ${currentSizeClass} ${className}`} loading="lazy" />;
   }
   const initial = name ? name.charAt(0).toUpperCase() : "?";
   const colors = ['bg-violet-500', 'bg-blue-500', 'bg-emerald-500', 'bg-amber-500', 'bg-rose-500'];

--- a/app/javascript/pages/Departments.jsx
+++ b/app/javascript/pages/Departments.jsx
@@ -43,7 +43,7 @@ const Avatar = ({ name, src, size = 'md', className = '' }) => {
         src={src}
         alt={`${name}'s avatar`}
         className={`rounded-full object-cover ring-2 ring-white dark:ring-zinc-800 shadow-sm ${currentSizeClass} ${className}`}
-      />
+      loading="lazy" />
     );
   }
   const initial = name ? name.charAt(0).toUpperCase() : "?";

--- a/app/javascript/pages/IssueTracker.jsx
+++ b/app/javascript/pages/IssueTracker.jsx
@@ -316,7 +316,7 @@ const IssueCard = ({ issue, onEdit, onDelete, isSelected, onSelect }) => {
             {/\.(mp4|webm|ogg)$/i.test(primaryAttachment.url) ? (
               <video src={primaryAttachment.url} className="h-full w-full object-cover" />
             ) : (
-              <img src={primaryAttachment.url} alt="Attachment" className="h-full w-full object-cover transition-transform group-hover/media:scale-105" />
+              <img src={primaryAttachment.url} alt="Attachment" className="h-full w-full object-cover transition-transform group-hover/media:scale-105" loading="lazy" />
             )}
             <div className="absolute inset-0 bg-black/40 opacity-0 group-hover/media:opacity-100 transition-opacity flex items-center justify-center">
               <a href={primaryAttachment.url} target="_blank" rel="noopener noreferrer" className="bg-white px-4 py-2 rounded-lg text-xs font-bold shadow-lg">View Full</a>

--- a/app/javascript/pages/Notifications.jsx
+++ b/app/javascript/pages/Notifications.jsx
@@ -427,7 +427,7 @@ const Notifications = () => {
                                   src={notification.actor_avatar}
                                   alt=""
                                   className="h-12 w-12 rounded-[18px] border border-white/70 object-cover shadow-[0_12px_26px_rgb(15_23_42_/_0.08)]"
-                                />
+                                loading="lazy" />
                               ) : (
                                 <div className="flex h-12 w-12 items-center justify-center rounded-[18px] border border-white/70 bg-white/90 shadow-[0_12px_26px_rgb(15_23_42_/_0.08)]">
                                   <Icon className="h-5 w-5 text-slate-700" />

--- a/app/javascript/pages/ProjectVault.jsx
+++ b/app/javascript/pages/ProjectVault.jsx
@@ -178,7 +178,7 @@ const VaultItemCard = ({ item, onEdit, onDelete, onCopy, showPassword, togglePas
             {/\.(mp4|webm|mov)$/i.test(item.content) ? (
               <video src={item.content} controls className="w-full max-h-48 object-contain" />
             ) : (
-              <img src={item.content} alt={item.title} className="w-full max-h-48 object-contain" />
+              <img src={item.content} alt={item.title} className="w-full max-h-48 object-contain" loading="lazy" />
             )}
           </div>
         ) : isCredential ? (

--- a/app/javascript/pages/Projects.jsx
+++ b/app/javascript/pages/Projects.jsx
@@ -27,7 +27,7 @@ const Avatar = ({ name, src, size = 'md', className = '' }) => {
                 src={src}
                 alt={`${name} 's avatar`}
                 className={`rounded-full object-cover ring-2 ring-white dark:ring-zinc-800 shadow-sm ${currentSizeClass} ${className}`}
-            />
+            loading="lazy" />
         );
     }
     const initial = name ? name.charAt(0).toUpperCase() : "?";

--- a/app/javascript/pages/SprintOverview.jsx
+++ b/app/javascript/pages/SprintOverview.jsx
@@ -67,7 +67,7 @@ const UserFilterOrb = ({ user, index, selected, onToggle }) => {
                     }}
                 >
                     {user.profile_picture && user.profile_picture !== 'null' ? (
-                        <img src={user.profile_picture} alt="" className="h-full w-full object-cover" />
+                        <img src={user.profile_picture} alt="" className="h-full w-full object-cover" loading="lazy" />
                     ) : (
                         <span className="text-sm font-semibold text-slate-800 drop-shadow-[0_1px_0_rgba(255,255,255,0.75)]">{initial}</span>
                     )}

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -50,7 +50,7 @@ const Avatar = ({ name, src, size = 'md', className = '' }) => {
                 src={src}
                 alt={`${name}'s avatar`}
                 className={`rounded-full object-cover ring-2 ring-white dark:ring-zinc-800 shadow-sm ${currentSizeClass} ${className}`}
-            />
+            loading="lazy" />
         );
     }
     const initial = name ? name.charAt(0).toUpperCase() : "?";

--- a/app/javascript/pages/Users.jsx
+++ b/app/javascript/pages/Users.jsx
@@ -374,7 +374,7 @@ const Users = () => {
         {/* Banner */}
         <div className={`h-24 w-full bg-gradient-to-r ${randomGradient} relative`}>
             {user.cover_photo && (
-                <img src={user.cover_photo} alt="cover" className="w-full h-full object-cover opacity-80" />
+                <img src={user.cover_photo} alt="cover" className="w-full h-full object-cover opacity-80" loading="lazy" />
             )}
             {canEditUsers && (
               <button
@@ -396,6 +396,7 @@ const Users = () => {
                 src={user.profile_picture || `https://ui-avatars.com/api/?name=${user.first_name}+${user.last_name}&background=random`}
                 alt="Profile"
                 className="w-20 h-20 rounded-2xl object-cover border-4 border-white shadow-md bg-white"
+                loading="lazy"
                 onError={(e) => { e.target.src=`https://placehold.co/100x100?text=${user.first_name?.[0]}`; }}
               />
               <span className={`absolute bottom-0 right-0 w-4 h-4 border-2 border-white rounded-full ${user.online ? "bg-green-400" : "bg-gray-300"}`} title={user.online ? "Online" : "Offline"}></span>


### PR DESCRIPTION
### Motivation
- Reduce initial page load cost by deferring below-the-fold and non-critical images so avatars, cover photos, post/media images, and chat previews do not fetch until needed.
- Avoid shipping the PDF viewer and `pdfjs` code in the main bundle so the large PDF library is only loaded when a user navigates to the PDF workspace.

### Description
- Added native lazy loading to image elements by adding `loading="lazy"` in shared avatar components and across page-level UI (`app/javascript/components/*` and `app/javascript/pages/*`) so offscreen images defer network requests; changes touch 17 frontend files.
- Code-split the PDF workspace by replacing the eager `PdfPage` import with `React.lazy` and rendering it inside `Suspense` with a `PageLoader` fallback in `app/javascript/components/App.jsx` so the `/pdf` route loads PDF code only when visited.
- Fixed a few malformed replacements from automated edits and normalized self-closing image tags to ensure JSX correctness across modified files.

### Testing
- Ran a quick scan to verify there are no remaining `<img>` tags missing `loading="lazy"` (custom script / search), and it reported no missing images.
- Ran the production build with `npm run -s build` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a8079e98832284424b3440c20bbd)