### PR TITLE
Fix scheduler crash when members payload is not an array

### DIFF
--- a/app/javascript/utils/sprintViewUtils.js
+++ b/app/javascript/utils/sprintViewUtils.js
@@ -80,8 +80,11 @@ export function getVisibleMembersForView({
   viewMode = "combined",
   records = [],
 } = {}) {
+  const safeMembers = Array.isArray(members) ? members : [];
+  const safeRecords = Array.isArray(records) ? records : [];
+
   const assignedIds = new Set(
-    records
+    safeRecords
       .map((record) => {
         const recordType = String(record?.type || "").toLowerCase();
         const preferredQaAssignee = record?.assigned_to_user ?? record?.assignedUser ?? record?.assigned_user?.id;
@@ -97,5 +100,5 @@ export function getVisibleMembersForView({
       .map((id) => String(id))
   );
 
-  return members.filter((member) => assignedIds.has(String(member.id)));
+  return safeMembers.filter((member) => assignedIds.has(String(member.id)));
 }

--- a/app/javascript/utils/sprintViewUtils.test.js
+++ b/app/javascript/utils/sprintViewUtils.test.js
@@ -94,4 +94,23 @@ describe("sprintViewUtils", () => {
       }).map((member) => member.id)
     ).toEqual([1, 2]);
   });
+
+  it("gracefully handles non-array API payloads", () => {
+    expect(
+      getVisibleMembersForView({
+        members: { id: 1, name: "Dev One" },
+        viewMode: "dev",
+        records: [{ type: "Code", developer_id: 1 }],
+      })
+    ).toEqual([]);
+
+    expect(
+      getVisibleMembersForView({
+        members: [{ id: 1, name: "Dev One" }],
+        viewMode: "dev",
+        records: { id: "bad" },
+      })
+    ).toEqual([]);
+  });
+
 });


### PR DESCRIPTION
### Motivation

- Prevent the runtime error (`members.filter is not a function`) caused when the backend returns non-array shapes for `members` or `records`. 
- Make `getVisibleMembersForView` resilient to malformed API payloads and add a regression to avoid regressions.

### Description

- Normalize inputs by introducing `safeMembers` and `safeRecords` (`Array.isArray` checks) inside `getVisibleMembersForView` so it always iterates over arrays. 
- Use `safeRecords` when building `assignedIds` and `safeMembers` when filtering results to avoid calling `.map()`/`.filter()` on non-arrays. 
- Add a new unit test that asserts the function gracefully handles non-array `members` and non-array `records` inputs. 
- Modified files: `app/javascript/utils/sprintViewUtils.js` and `app/javascript/utils/sprintViewUtils.test.js`.

### Testing

- Ran the unit tests with `npm test -- app/javascript/utils/sprintViewUtils.test.js`. 
- All tests passed: the test file ran and reported `6 passed` (the new regression test included).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b2b5d87883228c2f34897c6eb09c)