### PR TITLE
Guard getVisibleMembersForView against non-array API responses

### DIFF
--- a/app/javascript/utils/sprintViewUtils.js
+++ b/app/javascript/utils/sprintViewUtils.js
@@ -80,8 +80,11 @@ export function getVisibleMembersForView({
   viewMode = "combined",
   records = [],
 } = {}) {
+  const safeMembers = Array.isArray(members) ? members : [];
+  const safeRecords = Array.isArray(records) ? records : [];
+
   const assignedIds = new Set(
-    records
+    safeRecords
       .map((record) => {
         const recordType = String(record?.type || "").toLowerCase();
         const preferredQaAssignee = record?.assigned_to_user ?? record?.assignedUser ?? record?.assigned_user?.id;
@@ -97,5 +100,5 @@ export function getVisibleMembersForView({
       .map((id) => String(id))
   );
 
-  return members.filter((member) => assignedIds.has(String(member.id)));
+  return safeMembers.filter((member) => assignedIds.has(String(member.id)));
 }

--- a/app/javascript/utils/sprintViewUtils.test.js
+++ b/app/javascript/utils/sprintViewUtils.test.js
@@ -76,6 +76,24 @@ describe("sprintViewUtils", () => {
     ).toEqual([2]);
   });
 
+  it("returns an empty list when members or records are not arrays", () => {
+    expect(
+      getVisibleMembersForView({
+        members: { id: 1 },
+        viewMode: "combined",
+        records: [{ type: "Code", developer_id: 1 }],
+      })
+    ).toEqual([]);
+
+    expect(
+      getVisibleMembersForView({
+        members: [{ id: 1, name: "Dev One" }],
+        viewMode: "combined",
+        records: { type: "Code", developer_id: 1 },
+      })
+    ).toEqual([]);
+  });
+
   it("uses assigned sprint members only in combined mode", () => {
     const members = [
       { id: 1, name: "Dev One" },


### PR DESCRIPTION
### Motivation
- The Scheduler could crash with `members.filter is not a function` when backend responses for `members` or `records` arrived as non-array objects instead of arrays. This hardens the helper to avoid runtime errors during render.

### Description
- Normalize inputs in `getVisibleMembersForView` by introducing `safeMembers` and `safeRecords` and use them instead of the raw parameters in the mapping/filtering logic (`app/javascript/utils/sprintViewUtils.js`).
- Replace `records` usage with `safeRecords` and `members.filter` with `safeMembers.filter` to avoid calling array methods on non-array values.
- Add a unit test that verifies the function returns an empty array when `members` or `records` are not arrays (`app/javascript/utils/sprintViewUtils.test.js`).

### Testing
- Ran `npm test -- app/javascript/utils/sprintViewUtils.test.js` (Vitest) and the test file passed: 1 file, 6 tests all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b33d7ca8832285846f8e7afed571)