### PR TITLE
Remove 3D-objects button/route and lighten login hero styling

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -27,7 +27,6 @@ const KnowledgeDashboard = lazy(() => import("../pages/KnowledgeDashboard"));
 const Legal = lazy(() => import("../pages/Legal"));
 const MetaverseLanding = lazy(() => import("../pages/MetaverseLanding"));
 const Notifications = lazy(() => import("../pages/Notifications"));
-const ObjectGallery = lazy(() => import("../pages/ObjectGallery"));
 const PdfPage = lazy(() => import("./PdfPage"));
 const PostPage = lazy(() => import("../pages/PostPage"));
 const Profile = lazy(() => import("../components/Profile"));
@@ -65,7 +64,6 @@ const AppRoutes = () => {
         <Routes location={location}>
             <Route path="/contact" element={<Contact />} />
             <Route path="/legal" element={<Legal />} />
-            <Route path="/3d-objects" element={<ObjectGallery />} />
             <Route path="/metaverse-landing" element={<MetaverseLanding />} />
             <Route path="/forgot-password" element={<ForgotPassword />} />
             <Route path="/reset-password" element={<ResetPassword />} />

--- a/app/javascript/components/PageTitle.jsx
+++ b/app/javascript/components/PageTitle.jsx
@@ -8,7 +8,6 @@ const routeTitles = {
   "/calendar": "Calendar",
   "/contact": "Contact",
   "/legal": "Legal",
-  "/3d-objects": "3D Object Review",
   "/metaverse-landing": "Metaverse Landing",
   "/pdf": "PDF",
   "/momentum": "Daily Momentum Hub",

--- a/app/javascript/components/landing/WorkspaceOrb.jsx
+++ b/app/javascript/components/landing/WorkspaceOrb.jsx
@@ -89,7 +89,7 @@ const WorkspaceOrb = ({
 
   return (
     <section
-      className={`landing-hero-3d group relative isolate overflow-hidden rounded-[2rem] border border-white/15 bg-slate-950/70 p-5 text-white shadow-2xl shadow-cyan-950/40 backdrop-blur-xl sm:p-7 ${className}`}
+      className={`landing-hero-3d group relative isolate overflow-hidden rounded-2xl border border-slate-200/80 bg-white/85 p-5 text-slate-900 shadow-xl shadow-slate-900/10 backdrop-blur-xl sm:p-7 ${className}`}
       onMouseMove={handleMouseMove}
       onMouseLeave={resetTilt}
       style={{ "--tilt-x": `${tilt.y}deg`, "--tilt-y": `${tilt.x}deg` }}
@@ -97,31 +97,31 @@ const WorkspaceOrb = ({
     >
       <FloatingParticles />
 
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.32),transparent_30%),radial-gradient(circle_at_82%_24%,rgba(168,85,247,0.28),transparent_28%),linear-gradient(135deg,rgba(15,23,42,0.96),rgba(15,23,42,0.72))]" />
-      <div className="absolute inset-x-10 top-6 h-px bg-gradient-to-r from-transparent via-cyan-200/70 to-transparent" />
-      <div className="absolute -bottom-24 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full bg-cyan-400/20 blur-3xl" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_10%,rgba(34,211,238,0.18),transparent_30%),radial-gradient(circle_at_82%_24%,rgba(147,197,253,0.2),transparent_28%),linear-gradient(135deg,rgba(255,255,255,0.96),rgba(239,246,255,0.84))]" />
+      <div className="absolute inset-x-10 top-6 h-px bg-gradient-to-r from-transparent via-cyan-300/60 to-transparent" />
+      <div className="absolute -bottom-24 left-1/2 h-56 w-56 -translate-x-1/2 rounded-full bg-cyan-200/35 blur-3xl" />
 
       <div className="relative z-10 grid gap-7 lg:grid-cols-[1fr_0.95fr] lg:items-center">
         <div className="space-y-6">
-          <span className="inline-flex items-center gap-2 rounded-full border border-cyan-200/30 bg-white/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.28em] text-cyan-100 shadow-lg shadow-cyan-950/20">
+          <span className="inline-flex items-center gap-2 rounded-full border border-cyan-200/70 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.28em] text-cyan-700 shadow-lg shadow-cyan-100/70">
             <span className="h-2 w-2 rounded-full bg-emerald-300 shadow-[0_0_18px_rgba(110,231,183,0.9)]" />
             {eyebrow}
           </span>
 
           <div>
-            <h1 className="max-w-xl text-4xl font-black leading-[0.95] tracking-tight text-white sm:text-5xl xl:text-6xl">
+            <h1 className="max-w-xl text-4xl font-black leading-[0.95] tracking-tight text-slate-950 sm:text-5xl xl:text-6xl">
               {title}
             </h1>
-            <p className="mt-5 max-w-xl text-base leading-8 text-slate-300 sm:text-lg">
+            <p className="mt-5 max-w-xl text-base leading-8 text-slate-600 sm:text-lg">
               {description}
             </p>
           </div>
 
           <div className={`grid gap-3 ${normalizedMetrics.length >= 4 ? "sm:grid-cols-2 xl:grid-cols-4" : "sm:grid-cols-3"}`}>
             {normalizedMetrics.map(([value, label]) => (
-              <div key={label} className="rounded-2xl border border-white/10 bg-white/[0.07] p-4 shadow-inner shadow-white/5">
-                <p className="text-2xl font-black text-cyan-100">{value}</p>
-                <p className="mt-1 text-xs font-semibold uppercase tracking-widest text-slate-400">{label}</p>
+              <div key={label} className="rounded-2xl border border-slate-200/80 bg-white/75 p-4 shadow-inner shadow-cyan-50/80">
+                <p className="text-2xl font-black text-cyan-700">{value}</p>
+                <p className="mt-1 text-xs font-semibold uppercase tracking-widest text-slate-500">{label}</p>
               </div>
             ))}
           </div>
@@ -172,16 +172,16 @@ const WorkspaceOrb = ({
         {normalizedFeatures.map((feature, index) => (
           <article
             key={feature.title}
-            className="landing-feature-card min-w-0 rounded-3xl border border-white/12 bg-white/[0.08] p-5 shadow-xl shadow-slate-950/20 backdrop-blur-md"
+            className="landing-feature-card min-w-0 rounded-2xl border border-slate-200/80 bg-white/75 p-5 shadow-lg shadow-slate-900/10 backdrop-blur-md"
             style={{ "--card-delay": `${index * 0.08}s` }}
           >
             <div className="flex min-w-0 items-center justify-between gap-4">
-              <h2 className="min-w-0 break-words text-sm font-bold uppercase tracking-[0.16em] text-slate-300">{feature.title}</h2>
-              <span className="shrink-0 rounded-full border border-cyan-200/25 bg-cyan-200/10 px-3 py-1 text-xs font-black text-cyan-100">
+              <h2 className="min-w-0 break-words text-sm font-bold uppercase tracking-[0.16em] text-slate-600">{feature.title}</h2>
+              <span className="shrink-0 rounded-full border border-cyan-200/80 bg-cyan-50 px-3 py-1 text-xs font-black text-cyan-700">
                 {feature.metric}
               </span>
             </div>
-            <p className="mt-4 break-words text-sm leading-6 text-slate-300">{feature.copy}</p>
+            <p className="mt-4 break-words text-sm leading-6 text-slate-600">{feature.copy}</p>
           </article>
         ))}
       </div>

--- a/app/javascript/pages/Login.jsx
+++ b/app/javascript/pages/Login.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext, useEffect } from "react";
 import { AuthContext } from "../context/AuthContext";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { auth, getRedirectResult } from "../firebaseConfig";
 import { Toaster, toast } from "react-hot-toast";
 import SpinnerOverlay from "../components/ui/SpinnerOverlay";
@@ -54,18 +54,10 @@ const Login = ({ switchToSignup }) => {
       <div className="mx-auto flex w-full max-w-7xl flex-col gap-8 py-8 lg:flex-row lg:items-center lg:gap-10 xl:gap-14">
         <div className="lg:w-[58%]">
           <WorkspaceOrb />
-          <div className="mt-4 flex justify-center lg:justify-start">
-            <Link
-              to="/3d-objects"
-              className="inline-flex items-center rounded-full border border-cyan-200/30 bg-white/10 px-5 py-2 text-sm font-bold text-cyan-50 shadow-lg shadow-cyan-950/20 backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/15"
-            >
-              Review more 3D object options
-            </Link>
-          </div>
         </div>
 
         <div className="lg:w-[42%]">
-          <div className="w-full max-w-md rounded-3xl border border-white/60 bg-white/95 p-8 shadow-2xl shadow-slate-900/10 transition-transform duration-200 hover:-translate-y-1">
+          <div className="w-full max-w-md rounded-2xl border border-slate-200/80 bg-white/95 p-8 shadow-xl shadow-slate-900/10 transition-transform duration-200 hover:-translate-y-1">
             <h2 className="mb-1 text-center text-3xl font-bold text-slate-900">Welcome back</h2>
             <p className="mb-8 text-center text-sm text-slate-500">Sign in to continue where you left off.</p>
 

--- a/app/javascript/stylesheets/application.css
+++ b/app/javascript/stylesheets/application.css
@@ -710,8 +710,8 @@ textarea {
   height: var(--particle-size);
   border-radius: 9999px;
   opacity: 0.78;
-  background: rgba(165, 243, 252, 0.82);
-  box-shadow: 0 0 18px rgba(34, 211, 238, 0.72);
+  background: rgba(14, 165, 233, 0.32);
+  box-shadow: 0 0 18px rgba(125, 211, 252, 0.42);
   animation: landing-particle-drift 7s ease-in-out infinite;
   animation-delay: var(--particle-delay);
 }
@@ -736,9 +736,9 @@ textarea {
   position: absolute;
   inset: 12%;
   border-radius: 9999px;
-  border: 1px solid rgba(125, 211, 252, 0.42);
+  border: 1px solid rgba(14, 165, 233, 0.28);
   transform-style: preserve-3d;
-  box-shadow: 0 0 44px rgba(34, 211, 238, 0.18), inset 0 0 28px rgba(34, 211, 238, 0.12);
+  box-shadow: 0 0 44px rgba(14, 165, 233, 0.1), inset 0 0 28px rgba(14, 165, 233, 0.08);
 }
 
 .landing-timeline-ring::before,
@@ -748,8 +748,8 @@ textarea {
   width: 10px;
   height: 10px;
   border-radius: 9999px;
-  background: #a5f3fc;
-  box-shadow: 0 0 24px rgba(103, 232, 249, 0.95);
+  background: #38bdf8;
+  box-shadow: 0 0 24px rgba(125, 211, 252, 0.7);
 }
 
 .landing-timeline-ring::before {
@@ -768,7 +768,7 @@ textarea {
 
 .landing-timeline-ring-two {
   inset: 21%;
-  border-color: rgba(216, 180, 254, 0.36);
+  border-color: rgba(147, 197, 253, 0.34);
   transform: rotateX(64deg) rotateZ(28deg);
   animation: landing-orbit-spin-reverse 15s linear infinite;
 }
@@ -776,7 +776,7 @@ textarea {
 .landing-timeline-ring-three {
   inset: 5%;
   border-style: dashed;
-  border-color: rgba(255, 255, 255, 0.18);
+  border-color: rgba(14, 165, 233, 0.18);
   transform: rotateY(58deg) rotateX(18deg);
   animation: landing-orbit-spin 26s linear infinite;
 }
@@ -795,7 +795,7 @@ textarea {
   width: 56%;
   height: 1px;
   transform-origin: left center;
-  background: linear-gradient(90deg, rgba(103, 232, 249, 0), rgba(103, 232, 249, 0.54), rgba(216, 180, 254, 0));
+  background: linear-gradient(90deg, rgba(14, 165, 233, 0), rgba(14, 165, 233, 0.34), rgba(147, 197, 253, 0));
 }
 
 .landing-network-lines span:nth-child(1) {
@@ -817,9 +817,9 @@ textarea {
   place-items: center;
   border-radius: 9999px;
   background:
-    radial-gradient(circle at 32% 22%, rgba(255, 255, 255, 0.95), rgba(125, 211, 252, 0.65) 18%, rgba(59, 130, 246, 0.34) 42%, rgba(15, 23, 42, 0.2) 72%),
-    linear-gradient(135deg, rgba(34, 211, 238, 0.4), rgba(168, 85, 247, 0.28));
-  box-shadow: 0 0 44px rgba(34, 211, 238, 0.5), 0 0 100px rgba(79, 70, 229, 0.34), inset -18px -20px 36px rgba(15, 23, 42, 0.42);
+    radial-gradient(circle at 32% 22%, rgba(255, 255, 255, 0.98), rgba(186, 230, 253, 0.76) 24%, rgba(147, 197, 253, 0.42) 52%, rgba(224, 242, 254, 0.32) 78%),
+    linear-gradient(135deg, rgba(224, 242, 254, 0.95), rgba(219, 234, 254, 0.78));
+  box-shadow: 0 0 36px rgba(125, 211, 252, 0.42), 0 0 80px rgba(147, 197, 253, 0.28), inset -18px -20px 36px rgba(14, 165, 233, 0.12);
   transform-style: preserve-3d;
   animation: landing-pulse-orb 4.2s ease-in-out infinite;
 }
@@ -836,8 +836,8 @@ textarea {
   position: absolute;
   inset: 0;
   border: 1px solid rgba(255, 255, 255, 0.55);
-  background: linear-gradient(135deg, rgba(255, 255, 255, 0.32), rgba(34, 211, 238, 0.12));
-  box-shadow: inset 0 0 28px rgba(255, 255, 255, 0.16);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(186, 230, 253, 0.34));
+  box-shadow: inset 0 0 28px rgba(14, 165, 233, 0.08);
   backdrop-filter: blur(8px);
 }
 
@@ -890,7 +890,7 @@ textarea {
   font-size: 0.74rem;
   font-weight: 900;
   white-space: nowrap;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.28), 0 0 24px rgba(255, 255, 255, 0.2);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14), 0 0 24px rgba(255, 255, 255, 0.42);
   transform: translate(-50%, -50%) rotateX(0deg) scale(1);
   transition: transform 220ms ease, filter 220ms ease;
 }
@@ -911,7 +911,7 @@ textarea {
 .landing-feature-card:hover {
   transform: translateY(-8px) rotateX(7deg);
   border-color: rgba(125, 211, 252, 0.42);
-  background: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.86);
 }
 
 @keyframes shell-float {


### PR DESCRIPTION
### Motivation
- Remove the 3D objects review CTA from the login flow and stop exposing the `/3d-objects` route in the app shell.
- Shift the login landing/hero visuals from a dark, high-contrast 3D look to a lighter, white-and-soft-blue UI so the auth form feels lighter and more consistent with a light theme.

### Description
- Removed the in-page link and its `Link` import from the login page so the “Review more 3D object options” button is no longer rendered (`app/javascript/pages/Login.jsx`).
- Unregistered the `/3d-objects` route and removed its `ObjectGallery` route mapping and page title entry so the page is no longer reachable via the router (`app/javascript/components/App.jsx`, `app/javascript/components/PageTitle.jsx`).
- Reworked the hero/orb component markup and classes to a lighter design (softer borders, white surfaces, slate text) in `WorkspaceOrb` (`app/javascript/components/landing/WorkspaceOrb.jsx`).
- Updated related landing CSS to lighten particles, orbit rings, core-orb gradients, cube faces, card backgrounds, and shadows so the entire hero reads as a light UI (`app/javascript/stylesheets/application.css`).

### Testing
- Ran unit tests with `npm test` (Vitest) and all test files passed (3 files, 17 tests). ✅
- Built the frontend with `npm run build` (esbuild) and the build artifacts were produced successfully. ✅
- Ran `git diff --check` to ensure no whitespace or merge problems. ✅
- Attempted to launch the Rails server for a visual check but it failed due to a local Ruby version mismatch (`Gemfile` requires Ruby `3.3.0` while environment has `3.4.4`). ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a196de888048322af6f1006aaea420a)