### PR TITLE
Consolidate drag-and-drop to @hello-pangea/dnd

### DIFF
--- a/PERFORMANCE_OPTIMIZATION_SUMMARY.md
+++ b/PERFORMANCE_OPTIMIZATION_SUMMARY.md
@@ -19,7 +19,7 @@
 
 2. **Cleaned [package.json](package.json):**
    - Converted chart.js + react-chartjs-2 to recharts (single charting library)
-   - Kept @dnd-kit for drag-drop (kept @hello-pangea/dnd as fallback for now - migration in progress)
+   - Consolidated drag-and-drop on @hello-pangea/dnd and removed @dnd-kit duplicates
    - Removed duplicate charting imports
    - Deduped transitive dependencies
 
@@ -170,7 +170,6 @@ Promise.all([
 - [ ] Verify PDF & Three.js lazy loading on actual pages
 
 ### Medium Term (2-4 weeks)
-- [ ] Migrate @hello-pangea/dnd to @dnd-kit completely (now keeping as fallback)
 - [ ] Add Firebase lazy loading (currently loads globally)
 - [ ] Implement Service Worker for offline support
 - [ ] Add image lazy loading (`loading="lazy"`) to posts and components
@@ -216,7 +215,7 @@ Promise.all([
 
 ## ⚠️ Important Notes
 
-- **Drag-drop Library Consolidation**: Kept @hello-pangea/dnd as fallback for stability. Can migrate to @dnd-kit fully after thorough testing
+- **Drag-drop Library Consolidation**: Drag-and-drop now uses @hello-pangea/dnd as the single shared library.
 - **PDF Lazy Loading**: Created wrapper but not integrated into PdfPage yet (PdfPage is already route-level lazy loaded)
 - **Three.js Lazy Loading**: Created wrapper but can be integrated at component level if needed
 - **Cache Headers**: HTTP caching not yet fully configured (can add via Rails cache_control)

--- a/app/javascript/components/Scheduler/Scheduler.jsx
+++ b/app/javascript/components/Scheduler/Scheduler.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { createPortal } from 'react-dom';
-import { DndContext, useDraggable, useDroppable, closestCenter } from '@dnd-kit/core';
-import { CSS } from '@dnd-kit/utilities';
+import { DragDropContext, Droppable, Draggable } from '@hello-pangea/dnd';
 import { SchedulerAPI } from '../api';
 import { Toaster, toast } from 'react-hot-toast';
 import SpinnerOverlay from '../ui/SpinnerOverlay';
@@ -80,17 +79,8 @@ function Modal({ isOpen, onClose, title, children, panelClassName = 'max-w-2xl' 
 
 // --- Main Scheduler Components ---
 
-function TaskCard({ task, onEdit, onTaskUpdate, onDuplicate }) {
-  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({ id: task.id });
+function TaskCard({ task, index, onEdit, onTaskUpdate, onDuplicate }) {
   const [copied, setCopied] = useState(false);
-
-  const style = {
-    transform: CSS.Translate.toString(transform),
-    // **FIX 2: Increased z-index for dragging item**
-    zIndex: isDragging ? 9999 : 'auto',
-    opacity: isDragging ? 0.8 : 1,
-    boxShadow: isDragging ? '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)' : '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
-  };
 
   const typeColors = {
     'Code': 'bg-green-50 border-green-300 text-green-800',
@@ -151,70 +141,81 @@ function TaskCard({ task, onEdit, onTaskUpdate, onDuplicate }) {
   };
 
   return (
-    <div
-      ref={setNodeRef}
-      style={style}
-      className={`p-2.5 mb-2 border rounded-lg shadow-sm hover:shadow-md transition-shadow duration-150 ${cardColor} ${task.status === 'completed' ? 'opacity-70' : ''}`}
-    >
-      <div className="flex items-start justify-between">
-        <div className="flex items-start min-w-0">
-          <span {...listeners} {...attributes} className="cursor-move p-1 mr-2 text-gray-400 hover:text-gray-700" title="Drag task">
-            <Bars3Icon className="h-5 w-5" />
-          </span>
-          <div>
-            {task.task?.task_url || task.task_url ? (
-              <a
-                href={task.task?.task_url || task.task_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-                className={`font-semibold text-sm hover:underline ${task.status === 'completed' ? 'line-through text-gray-500' : 'text-indigo-600'} break-all`}
-                title={`Open: ${task.task?.task_id || task.task_id}`}
-              >
-                {task.task?.task_id || task.task_id}
-              </a>
-            ) : (
-              <span className={`font-semibold text-sm ${task.status === 'completed' ? 'line-through text-gray-500' : 'text-gray-800'} break-all`}>
-                {task.task?.task_id || task.task_id}
+    <Draggable draggableId={String(task.id)} index={index}>
+      {(provided, snapshot) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          className={`p-2.5 mb-2 border rounded-lg shadow-sm hover:shadow-md transition-shadow duration-150 ${cardColor} ${task.status === 'completed' ? 'opacity-70' : ''}`}
+          style={{
+            ...provided.draggableProps.style,
+            zIndex: snapshot.isDragging ? 9999 : 'auto',
+            opacity: snapshot.isDragging ? 0.8 : 1,
+            boxShadow: snapshot.isDragging
+              ? '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)'
+              : '0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06)',
+          }}
+        >
+          <div className="flex items-start justify-between">
+            <div className="flex items-start min-w-0">
+              <span {...provided.dragHandleProps} className="cursor-move p-1 mr-2 text-gray-400 hover:text-gray-700" title="Drag task">
+                <Bars3Icon className="h-5 w-5" />
               </span>
-            )}
-            <div className="text-xs text-gray-500 mt-0.5">
-              <span>{task.hours_logged}h</span>
-              <span className="mx-1">|</span>
-              <span>{task.type}</span>
+              <div>
+                {task.task?.task_url || task.task_url ? (
+                  <a
+                    href={task.task?.task_url || task.task_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className={`font-semibold text-sm hover:underline ${task.status === 'completed' ? 'line-through text-gray-500' : 'text-indigo-600'} break-all`}
+                    title={`Open: ${task.task?.task_id || task.task_id}`}
+                  >
+                    {task.task?.task_id || task.task_id}
+                  </a>
+                ) : (
+                  <span className={`font-semibold text-sm ${task.status === 'completed' ? 'line-through text-gray-500' : 'text-gray-800'} break-all`}>
+                    {task.task?.task_id || task.task_id}
+                  </span>
+                )}
+                <div className="text-xs text-gray-500 mt-0.5">
+                  <span>{task.hours_logged}h</span>
+                  <span className="mx-1">|</span>
+                  <span>{task.type}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="flex items-center space-x-1 flex-shrink-0 ml-2">
+              <button onClick={toggleStrike} title={task.status === 'completed' ? "Mark as not done" : "Mark as done"} className="p-1 text-gray-500 hover:text-green-600 rounded-full hover:bg-gray-100 transition-colors">
+                {task.status === 'completed' ? <CheckCircleSolidIcon className="h-5 w-5 text-green-600" /> : <CheckCircleIcon className="h-5 w-5" />}
+              </button>
+              <button onClick={(e) => { e.stopPropagation(); onEdit(); }} title="Edit task" className="p-1 text-gray-500 hover:text-[var(--theme-color)] rounded-full hover:bg-gray-100 transition-colors">
+                <PencilIcon className="h-5 w-5" />
+              </button>
+              {task.task?.task_url && (
+                <button onClick={copyLink} title="Copy task link" className="p-1 text-gray-500 hover:text-indigo-600 rounded-full hover:bg-gray-100 transition-colors relative">
+                  <LinkIcon className="h-5 w-5" />
+                  {copied && <CheckCircleSolidIcon className="h-3 w-3 text-green-500 absolute -top-1 -right-1" />}
+                </button>
+              )}
+              <button onClick={duplicateTask} title="Copy log" className="p-1 text-gray-500 hover:text-indigo-600 rounded-full hover:bg-gray-100 transition-colors">
+                <DocumentDuplicateIcon className="h-5 w-5" />
+              </button>
+              <button onClick={deleteTask} title="Delete task" className="p-1 text-gray-500 hover:text-red-600 rounded-full hover:bg-gray-100 transition-colors">
+                <TrashIcon className="h-5 w-5" />
+              </button>
             </div>
           </div>
         </div>
-
-        <div className="flex items-center space-x-1 flex-shrink-0 ml-2">
-          <button onClick={toggleStrike} title={task.status === 'completed' ? "Mark as not done" : "Mark as done"} className="p-1 text-gray-500 hover:text-green-600 rounded-full hover:bg-gray-100 transition-colors">
-            {task.status === 'completed' ? <CheckCircleSolidIcon className="h-5 w-5 text-green-600" /> : <CheckCircleIcon className="h-5 w-5" />}
-          </button>
-          <button onClick={(e) => { e.stopPropagation(); onEdit(); }} title="Edit task" className="p-1 text-gray-500 hover:text-[var(--theme-color)] rounded-full hover:bg-gray-100 transition-colors">
-            <PencilIcon className="h-5 w-5" />
-          </button>
-          {task.task?.task_url && (
-            <button onClick={copyLink} title="Copy task link" className="p-1 text-gray-500 hover:text-indigo-600 rounded-full hover:bg-gray-100 transition-colors relative">
-              <LinkIcon className="h-5 w-5" />
-              {copied && <CheckCircleSolidIcon className="h-3 w-3 text-green-500 absolute -top-1 -right-1" />}
-            </button>
-          )}
-          <button onClick={duplicateTask} title="Copy log" className="p-1 text-gray-500 hover:text-indigo-600 rounded-full hover:bg-gray-100 transition-colors">
-            <DocumentDuplicateIcon className="h-5 w-5" />
-          </button>
-          <button onClick={deleteTask} title="Delete task" className="p-1 text-gray-500 hover:text-red-600 rounded-full hover:bg-gray-100 transition-colors">
-            <TrashIcon className="h-5 w-5" />
-          </button>
-        </div>
-      </div>
-    </div>
+      )}
+    </Draggable>
   );
 }
 
 
 function TaskCell({ date, devId, tasksInCell, setEditingTask, handleTaskUpdate, totalHoursInCell, onDuplicate }) {
   const droppableId = `${date}:${devId}`;
-  const { setNodeRef, isOver } = useDroppable({ id: droppableId });
 
   const cellCapacity = 8;
   const hoursPercentage = Math.min((totalHoursInCell / cellCapacity) * 100, 100);
@@ -223,26 +224,35 @@ function TaskCell({ date, devId, tasksInCell, setEditingTask, handleTaskUpdate, 
   else if (totalHoursInCell > cellCapacity * 0.75) capacityColor = 'bg-yellow-100';
 
 
+  const visibleTasks = tasksInCell.filter(t => !t.deleted);
+
   return (
-    <td
-      ref={setNodeRef}
-      className={`p-2 border border-gray-200 align-top min-w-[200px] relative transition-colors duration-150 ease-in-out ${isOver ? 'bg-[rgb(var(--theme-color-rgb)/0.1)] outline outline-2 outline-[var(--theme-color)]' : 'bg-white hover:bg-gray-50'}`}
-      style={{ minHeight: '100px' }}
-    >
-      <div className={`absolute bottom-0 left-0 right-0 h-1 ${capacityColor} opacity-70 transition-all duration-300`} style={{ width: `${hoursPercentage}%` }} title={`${totalHoursInCell}h / ${cellCapacity}h`}></div>
-      {tasksInCell.filter(t => !t.deleted).map(task => (
-        <TaskCard
-          key={task.id}
-          task={task}
-          onEdit={() => setEditingTask(task)}
-          onTaskUpdate={handleTaskUpdate}
-          onDuplicate={onDuplicate}
-        />
-      ))}
-      {tasksInCell.filter(t => !t.deleted).length === 0 && (
-        <div className="text-center text-gray-400 text-xs mt-4">Drop tasks here</div>
+    <Droppable droppableId={droppableId}>
+      {(provided, snapshot) => (
+        <td
+          ref={provided.innerRef}
+          {...provided.droppableProps}
+          className={`p-2 border border-gray-200 align-top min-w-[200px] relative transition-colors duration-150 ease-in-out ${snapshot.isDraggingOver ? 'bg-[rgb(var(--theme-color-rgb)/0.1)] outline outline-2 outline-[var(--theme-color)]' : 'bg-white hover:bg-gray-50'}`}
+          style={{ minHeight: '100px' }}
+        >
+          <div className={`absolute bottom-0 left-0 right-0 h-1 ${capacityColor} opacity-70 transition-all duration-300`} style={{ width: `${hoursPercentage}%` }} title={`${totalHoursInCell}h / ${cellCapacity}h`}></div>
+          {visibleTasks.map((task, index) => (
+            <TaskCard
+              key={task.id}
+              task={task}
+              index={index}
+              onEdit={() => setEditingTask(task)}
+              onTaskUpdate={handleTaskUpdate}
+              onDuplicate={onDuplicate}
+            />
+          ))}
+          {provided.placeholder}
+          {visibleTasks.length === 0 && (
+            <div className="text-center text-gray-400 text-xs mt-4">Drop tasks here</div>
+          )}
+        </td>
       )}
-    </td>
+    </Droppable>
   );
 }
 
@@ -449,27 +459,27 @@ function Scheduler({ sprintId, projectId, sheetIntegrationEnabled, projectMember
     });
   }, []);
 
-  const handleDragEnd = async (event) => {
-    const { active, over } = event;
-    if (!active || !over || active.id === over.id) return;
+  const handleDragEnd = async (result) => {
+    const { draggableId, destination, source } = result;
+    if (!destination || (source.droppableId === destination.droppableId && source.index === destination.index)) return;
 
-    const taskId = active.id;
-    const [newDate, newDevIdStr] = over.id.split(':');
+    const taskId = draggableId;
+    const [newDate, newDevIdStr] = destination.droppableId.split(':');
     const newDevId = parseInt(newDevIdStr, 10);
 
-    const originalTask = tasks.find(t => t.id === taskId);
+    const originalTask = tasks.find(t => String(t.id) === taskId);
     if (!originalTask) return;
 
     const updatedTaskData = { ...originalTask, log_date: newDate, developer_id: newDevId };
 
-    setTasks(prev => prev.map(t => (t.id === taskId ? updatedTaskData : t)));
+    setTasks(prev => prev.map(t => (String(t.id) === taskId ? updatedTaskData : t)));
 
     try {
       const { data: moved } = await SchedulerAPI.updateTaskLog(taskId, { log_date: newDate, developer_id: newDevId });
-      setTasks(prev => prev.map(t => t.id === taskId ? moved : t));
+      setTasks(prev => prev.map(t => String(t.id) === taskId ? moved : t));
     } catch (error) {
       console.error("Error moving task:", error);
-      setTasks(prev => prev.map(t => t.id === taskId ? original : t));
+      setTasks(prev => prev.map(t => String(t.id) === taskId ? originalTask : t));
       toast.error(`Error: Could not move task. ${error.message}`);
     }
   };
@@ -570,7 +580,7 @@ function Scheduler({ sprintId, projectId, sheetIntegrationEnabled, projectMember
   const stickyTableHeaderOffset = mainHeaderHeight > 0 ? `${mainHeaderHeight}px` : '4rem'; // Default to 4rem (64px) if height not yet calculated
 
   return (
-    <DndContext onDragEnd={handleDragEnd} collisionDetection={closestCenter}>
+    <DragDropContext onDragEnd={handleDragEnd}>
       <div className="min-h-screen bg-gradient-to-br from-slate-50 to-sky-100 flex flex-col">
         <Toaster position="top-right" />
         {processing && <SpinnerOverlay />}
@@ -805,7 +815,7 @@ function Scheduler({ sprintId, projectId, sheetIntegrationEnabled, projectMember
             background: #94a3b8;
         }
       `}</style>
-    </DndContext>
+    </DragDropContext>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,6 @@
     "": {
       "name": "app",
       "dependencies": {
-        "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^10.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
         "@headlessui/react": "^2.2.4",
         "@hello-pangea/dnd": "^18.0.1",
         "@heroicons/react": "^2.2.0",
@@ -68,59 +65,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@dnd-kit/accessibility": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
-      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/core": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
-      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/accessibility": "^3.1.1",
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
-      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
-      "license": "MIT",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.3.0",
-        "react": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/utilities": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
-      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^10.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@headlessui/react": "^2.2.4",
     "@hello-pangea/dnd": "^18.0.1",
     "@heroicons/react": "^2.2.0",

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -32,8 +32,8 @@ export default defineConfig({
           // Heavy 3D library (will be lazy-loaded, but grouped if loaded)
           'three-bundle': ['three'],
           
-          // DnD kit (consolidated to single library)
-          'dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+          // Drag and drop (consolidated to single library)
+          'dnd': ['@hello-pangea/dnd'],
           
           // PDF handling (will be lazy-loaded)
           'pdf': ['pdfjs-dist', 'react-pdf', '@react-pdf/renderer'],
@@ -59,8 +59,7 @@ export default defineConfig({
       'react-router-dom',
       'axios',
       'framer-motion',
-      '@dnd-kit/core',
-      '@dnd-kit/sortable',
+      '@hello-pangea/dnd',
       'date-fns',
       'lucide-react'
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,37 +14,6 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@dnd-kit/accessibility@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz"
-  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
-  dependencies:
-    tslib "^2.0.0"
-
-"@dnd-kit/core@^6.3.0", "@dnd-kit/core@^6.3.1":
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz"
-  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
-  dependencies:
-    "@dnd-kit/accessibility" "^3.1.1"
-    "@dnd-kit/utilities" "^3.2.2"
-    tslib "^2.0.0"
-
-"@dnd-kit/sortable@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz"
-  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
-  dependencies:
-    "@dnd-kit/utilities" "^3.2.2"
-    tslib "^2.0.0"
-
-"@dnd-kit/utilities@^3.2.2":
-  version "3.2.2"
-  resolved "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz"
-  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
-  dependencies:
-    tslib "^2.0.0"
-
 "@esbuild/linux-x64@0.21.5":
   version "0.21.5"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz"


### PR DESCRIPTION
### Motivation

- The repo had both `@dnd-kit/*` and `@hello-pangea/dnd` installed, duplicating drag-and-drop functionality and adding ~150–200KB of unnecessary bundle size.  
- Consolidating to a single DnD library reduces bundle bloat and simplifies maintenance and chunking decisions.  
- Vite chunking and `optimizeDeps` needed updating to reflect the single shared DnD dependency.

### Description

- Removed `@dnd-kit/core`, `@dnd-kit/sortable`, and `@dnd-kit/utilities` from `package.json` and cleaned entries from `package-lock.json`/`yarn.lock`.  
- Migrated the Scheduler component from `@dnd-kit` to `@hello-pangea/dnd` by replacing `DndContext`/`useDraggable`/`useDroppable` usage with `DragDropContext`/`Droppable`/`Draggable` and adapting `handleDragEnd`, `TaskCard`, and `TaskCell` to the new API.  
- Updated `vite.config.mts` to move DnD manual chunking and `optimizeDeps` entries to `@hello-pangea/dnd` (removed `@dnd-kit/*`).  
- Updated `PERFORMANCE_OPTIMIZATION_SUMMARY.md` to reflect the consolidation and removed the old migration TODO.

### Testing

- Ran `npm run build` which completed successfully.  
- Ran tests with `npm test` (Vitest) and all test files passed (`3 files, 17 tests`).  
- Ran `npx vite build` which completed and produced the optimized chunks (build warnings about large chunks but build succeeded).  
- `yarn install` was attempted in this environment and failed with a 403 from the registry, so lockfile cleanup for removed packages was applied manually (note included in PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e7fbddb5483229f8688c254a92f10)