### PR TITLE
Fix Bundler activation in Docker asset builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get update -qq && \
       pkg-config \
       python-is-python3
 
+# Match the Bundler version recorded in Gemfile.lock.
+RUN gem install bundler -v 4.0.6
+
 ARG NODE_VERSION=20.18.0
 ARG YARN_VERSION=1.22.22
 ENV PATH=/usr/local/node/bin:$PATH
@@ -43,15 +46,15 @@ RUN yarn install --frozen-lockfile
 COPY . .
 
 RUN bundle exec bootsnap precompile app/ lib/
+
+# Provide non-sensitive placeholders while production assets are compiled.
+ENV SMTP_ADDRESS="smtp.example.com" \
+    SMTP_PORT="587" \
+    SMTP_USERNAME="dummy@example.com" \
+    SMTP_PASSWORD="dummy" \
+    SECRET_KEY_BASE="dummy_secret_key_base_for_build"
+
 RUN RAILS_ENV=production bin/vite build
-
-# Set ENV needed only for build phase
-ENV SMTP_ADDRESS="smtp.example.com"
-ENV SMTP_PORT="587"
-ENV SMTP_USERNAME="dummy@example.com"
-ENV SMTP_PASSWORD="dummy"
-ENV SECRET_KEY_BASE="dummy_secret_key_base_for_build"
-
 RUN RAILS_ENV=production bundle exec rails assets:precompile
 
 # --- Final Runtime Stage ---


### PR DESCRIPTION
### Motivation
- The build was failing because `Gemfile.lock` is `BUNDLED WITH 4.0.6` while the Docker build used the system Bundler (~2.x), causing Bundler activation errors and a downstream Vite assets failure. 
- Build-time environment placeholders (SMTP and `SECRET_KEY_BASE`) were declared after `bin/vite build`, which can break asset compilation that expects those variables to exist.

### Description
- Install the exact Bundler used to generate the lockfile by adding `RUN gem install bundler -v 4.0.6` in the Docker `build` stage before any `bundle` invocation. 
- Move and consolidate non-sensitive build placeholders into a single `ENV` block placed before `bin/vite build` so Vite and Rails asset compilation run with expected vars. 
- Keep all other build steps intact and make a minimal, targeted change limited to `Dockerfile` to correct build ordering and dependency activation.

### Testing
- Verified with a local Ruby check that the `BUNDLED WITH` version in `Gemfile.lock` matches the `gem install bundler -v` pin in `Dockerfile`, and that the build `ENV` block appears before `bin/vite build`, both checks succeeded. 
- Ran `git diff --check -- Dockerfile` to ensure no whitespace or trivial issues, which succeeded. 
- Attempted `docker build --check .` but Docker is not available in the execution environment, so an image build could not be run here. 
- Attempted to install Bundler locally and run `bundle _4.0.6_ check`, but the `gem install` step failed with HTTP `403 Forbidden` from the configured gem source, preventing an additional local bundle validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a6362a054832287ae04712c12a289)