### PR TITLE
Guard Firebase initializer when project ID is absent

### DIFF
--- a/config/initializers/firebase.rb
+++ b/config/initializers/firebase.rb
@@ -1,5 +1,8 @@
-FirebaseIdToken.configure do |config|
-  project_id = ENV.fetch('FIREBASE_PROJECT_ID')
-  config.project_ids = [project_id]
-  config.redis = nil
+project_id = ENV["FIREBASE_PROJECT_ID"].presence
+
+if project_id
+  FirebaseIdToken.configure do |config|
+    config.project_ids = [project_id]
+    config.redis = nil
+  end
 end


### PR DESCRIPTION
### Motivation
- Prevent Rails from raising during `assets:precompile` when `FIREBASE_PROJECT_ID` is not present, because initializers are loaded during asset compilation and the previous `ENV.fetch` caused a boot-time exception.

### Description
- Update `config/initializers/firebase.rb` to use `ENV["FIREBASE_PROJECT_ID"].presence` and only call `FirebaseIdToken.configure` when a nonblank project ID is available, so the initializer is effectively skipped in build environments without Firebase credentials.

### Testing
- `ruby -c config/initializers/firebase.rb` completed successfully to validate syntax.
- Standalone Ruby harnesses were run to simulate both the absence and presence of `FIREBASE_PROJECT_ID`, confirming the initializer is skipped when missing and configures `FirebaseIdToken` when present.
- `git diff --check` passed, and a full Rails boot / `assets:precompile` could not be executed in this environment because the workspace Ruby version (3.4.4) differs from the project requirement (3.3.0) and the bundle/rails executables were not available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a69428a14832283d5ed5e58f42ce7)