### PR TITLE
Add build-only KEKA_API_KEY_ENCRYPTION_KEY placeholder to Dockerfile to allow assets precompile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ ENV SMTP_ADDRESS="smtp.example.com" \
     SMTP_PORT="587" \
     SMTP_USERNAME="dummy@example.com" \
     SMTP_PASSWORD="dummy" \
-    SECRET_KEY_BASE="dummy_secret_key_base_for_build"
+    SECRET_KEY_BASE="dummy_secret_key_base_for_build" \
+    KEKA_API_KEY_ENCRYPTION_KEY="0123456789abcdef0123456789abcdef"
 
 RUN RAILS_ENV=production bin/vite build
 RUN RAILS_ENV=production bundle exec rails assets:precompile


### PR DESCRIPTION
### Motivation
- Production asset compilation fails because Rails boots during the build and calls `ENV.fetch("KEKA_API_KEY_ENCRYPTION_KEY")`, raising a `KeyError` and aborting `rails assets:precompile` in the Docker build stage.

### Description
- Add a non-sensitive 32-byte `KEKA_API_KEY_ENCRYPTION_KEY` placeholder to the Dockerfile build-stage `ENV` block so Rails can initialize for `bin/vite build` and `rails assets:precompile`, while the final runtime image still requires the real secret.

### Testing
- Ran `git diff --check -- Dockerfile` and a Ruby assertion that the placeholder is exactly 32 bytes (both succeeded), attempted `docker build --target build` but Docker is not available in this environment, and `bundle check` could not be executed due to a local Ruby version mismatch with the `Gemfile` (requires `3.3.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a6cb01bd8832280e1574a1e0dff8f)