### PR TITLE
Copy vendored PdfMaster into build stage before `bundle install`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ RUN curl -sL https://github.com/nodenv/node-build/archive/master.tar.gz | tar xz
     rm -rf /tmp/node-build-master
 
 COPY Gemfile Gemfile.lock ./
+COPY vendor/pdf_master ./vendor/pdf_master
 RUN bundle install && \
     rm -rf ~/.bundle/ "${BUNDLE_PATH}"/ruby/*/cache "${BUNDLE_PATH}"/ruby/*/bundler/gems/*/.git && \
     bundle exec bootsnap precompile --gemfile


### PR DESCRIPTION
### Motivation
- Fix the Docker build failure where `bundle install` ran before the vendored `PdfMaster` at `vendor/pdf_master` was available, which prevented Bundler from resolving the local path gem during image build.

### Description
- Add `COPY vendor/pdf_master ./vendor/pdf_master` immediately after copying `Gemfile` and `Gemfile.lock` so the local `PdfMaster` gem is present before `RUN bundle install`, preserving dependency-layer caching.

### Testing
- Ran `git diff --check` and a Ruby assertion that verifies the `COPY vendor/pdf_master` line appears before `RUN bundle install` (both passed), attempted `bundle check` which is limited by host Ruby (`3.4.4` vs project `3.3.0`), and attempted `docker build --target build` which could not run because `docker` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a7d4ce4cc8322be756dfd08aee0d9)