### PR TITLE
Default production Active Storage to local disk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,8 +51,8 @@ POSTGRES_PASSWORD=replace-with-a-long-random-password
 # Redis for Action Cable
 REDIS_URL=redis://localhost:6379/1
 
-# Persistent Active Storage (AWS S3, Cloudflare R2, MinIO, DigitalOcean Spaces)
-ACTIVE_STORAGE_SERVICE=s3
+# Active Storage (local disk by default; use s3 for persistent object storage)
+ACTIVE_STORAGE_SERVICE=local
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_REGION=us-east-1

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE", "s3").to_sym
+  config.active_storage.service = ENV.fetch("ACTIVE_STORAGE_SERVICE", "local").to_sym
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
### Motivation
- The production fallback was `s3` which causes errors when `ACTIVE_STORAGE_SERVICE` is unset and no S3 credentials are provided. 
- For quick deployments on ephemeral hosts (e.g. Render) the existing `local` disk service is a safer default for development/portfolio apps. 
- Update the example environment file to reflect a sensible default while keeping S3 available for persistent storage.

### Description
- Change `config.active_storage.service` default in `config/environments/production.rb` to use `ENV.fetch("ACTIVE_STORAGE_SERVICE", "local").to_sym` so the app falls back to the `local` disk service. 
- Update `.env.example` to set `ACTIVE_STORAGE_SERVICE=local` and clarify that `s3` can be used for persistent object storage. 
- No changes were made to `config/storage.yml` because the `local` service is already defined to use `Disk` at `Rails.root/storage`. 

### Testing
- Ran `ruby -c config/environments/production.rb` which returned `Syntax OK`. 
- Parsed `config/storage.yml` (ERB+YAML) and verified the `local` service is `Disk` with root `Rails.root/storage`. 
- Evaluated the production Active Storage expression with and without `ACTIVE_STORAGE_SERVICE` to confirm the default is `:local` and that `ACTIVE_STORAGE_SERVICE=s3` still overrides to `:s3`. 
- Ran `git diff --check -- .env.example config/environments/production.rb` with no issues. 
- Full Rails boot via `bundle exec rails runner` could not be executed because the environment Ruby is `3.4.4` while the `Gemfile` requires `3.3.0` and the bundle does not expose the `rails` executable, so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a85779e5c8322bffbf1c6b87c456c)