### PR TITLE
Use async ActionCable adapter in production to avoid Redis dependency

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -5,6 +5,6 @@ test:
   adapter: test
 
 production:
-  adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: rails_vite_production
+  # Use the in-process adapter for Redis-free, single-instance deployments.
+  # Switch this to redis when a shared Redis service and the redis gem are configured.
+  adapter: async


### PR DESCRIPTION
### Motivation

- Replace the Redis-backed ActionCable configuration in `config/cable.yml` for `production` so single-instance, Redis-free deployments can run without requiring a shared Redis service or the `redis` gem.

### Description

- In `config/cable.yml` the `production` section was changed from `adapter: redis` with `url` and `channel_prefix` to use the in-process `adapter: async` and a comment explaining to switch to `redis` when a shared Redis service and the `redis` gem are configured.

### Testing

- No automated tests were added or modified for this configuration change and no automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a85f809248322ad5e55a036ba0fc1)