### PR TITLE
Improve dashboard query performance

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -8,7 +8,9 @@ class Api::UsersController < Api::BaseController
 
   # GET /api/users.json
   def index
-    users = current_user.workspace.users.order(created_at: :desc)
+    users = current_user.workspace.users
+      .includes(:department, :roles, :projects, profile_picture_attachment: :blob, cover_photo_attachment: :blob)
+      .order(created_at: :desc)
     render_paginated_collection(users, serializer: method(:serialize_user))
   end
 
@@ -51,7 +53,7 @@ class Api::UsersController < Api::BaseController
     role_names = params[:user].delete(:role_names) if params[:user]
 
     if @user.update(user_params)
-      @user.roles = Role.where(name: role_names) if role_names
+      assign_roles!(@user, role_names) if role_names
       render json: serialize_user(@user)
     else
       render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
@@ -169,6 +171,7 @@ class Api::UsersController < Api::BaseController
   def assign_roles!(user, role_names)
     target_role_names = role_names.presence || ['member']
     user.roles = Role.where(name: target_role_names)
+    user.remove_instance_variable(:@role_names) if user.instance_variable_defined?(:@role_names)
   end
 
   def assign_projects!(user, project_ids)
@@ -204,15 +207,20 @@ class Api::UsersController < Api::BaseController
       cover_photo: user.cover_photo.attached? ?
         rails_blob_url(user.cover_photo, only_path: true) : nil,
       avatar_color: user.avatar_color,
-      roles: user.roles.pluck(:name),
+      roles: user.role_names.sort,
       landing_page: user.landing_page,
       phone_number: user.phone_number,
       bio: user.bio,
       social_links: user.social_links || {},
-      projects: user.projects.order(:name).map { |project| { id: project.id, name: project.name } },
+      projects: serialized_projects(user),
       last_seen_at: user.last_seen_at,
       online: user.last_seen_at.present? && user.last_seen_at >= ONLINE_WINDOW.ago
     }
+  end
+
+  def serialized_projects(user)
+    projects = user.association(:projects).loaded? ? user.projects.sort_by { |project| project.name.to_s.downcase } : user.projects.order(:name)
+    projects.map { |project| { id: project.id, name: project.name } }
   end
 
   def authorize_user_creation!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -117,11 +117,20 @@ class User < ApplicationRecord
     hsl_to_hex(hue, saturation, lightness)
   end
 
+  def role_names
+    @role_names ||= if association(:roles).loaded?
+      roles.map(&:name)
+    else
+      UserRole.in_workspace(workspace)
+        .where(user_id: id)
+        .joins(:role)
+        .order("roles.name")
+        .pluck("roles.name")
+    end
+  end
+
   def has_role?(name)
-    UserRole.in_workspace(workspace)
-      .where(user_id: id)
-      .joins(:role)
-      .exists?(roles: { name: name.to_s })
+    role_names.include?(name.to_s)
   end
 
   def owner?
@@ -205,12 +214,7 @@ class User < ApplicationRecord
     payload = as_json(options)
 
     if include_roles
-      role_names = UserRole.in_workspace(workspace)
-        .where(user_id: id)
-        .joins(:role)
-        .order("roles.name")
-        .pluck("roles.name")
-      payload["roles"] = role_names.map { |role_name| { "name" => role_name } }
+      payload["roles"] = role_names.sort.map { |role_name| { "name" => role_name } }
     end
 
     payload

--- a/db/migrate/20270623000000_add_performance_indexes_for_dashboard_queries.rb
+++ b/db/migrate/20270623000000_add_performance_indexes_for_dashboard_queries.rb
@@ -1,0 +1,12 @@
+class AddPerformanceIndexesForDashboardQueries < ActiveRecord::Migration[8.0]
+  def change
+    add_index :tasks, [:workspace_id, :end_date], name: "index_tasks_on_workspace_id_and_end_date", if_not_exists: true
+    add_index :tasks, [:workspace_id, :assigned_to_user, :end_date], name: "index_tasks_on_workspace_assignee_end_date", if_not_exists: true
+    add_index :tasks, [:workspace_id, :project_id, :end_date], name: "index_tasks_on_workspace_project_end_date", if_not_exists: true
+    add_index :tasks, [:workspace_id, :sprint_id, :developer_id, :order], name: "index_tasks_on_workspace_sprint_developer_order", if_not_exists: true
+
+    add_index :users, [:workspace_id, :created_at], name: "index_users_on_workspace_id_and_created_at", if_not_exists: true
+    add_index :work_logs, [:user_id, :log_date], name: "index_work_logs_on_user_id_and_log_date", if_not_exists: true
+    add_index :knowledge_bookmarks, [:user_id, :next_reminder_at], name: "index_knowledge_bookmarks_on_user_next_reminder", if_not_exists: true
+  end
+end


### PR DESCRIPTION
### Motivation
- Reduce API latency and database load for user listing and dashboard endpoints by eliminating N+1 queries and improving index coverage.
- Avoid repeated role lookups and per-user project queries during serialization to reduce query counts on high-traffic pages.

### Description
- Eager-load associations in the users index with `includes(:department, :roles, :projects, profile_picture_attachment: :blob, cover_photo_attachment: :blob)` to prevent N+1 queries during serialization.
- Add `User#role_names` memoization and update `has_role?` and `public_json` to reuse the cached role list, and clear the cache after role assignment to keep data correct.
- Replace per-user project mapping with `serialized_projects(user)` which reuses a preloaded `projects` association when available to avoid extra queries.
- Add a migration `AddPerformanceIndexesForDashboardQueries` that creates composite indexes on `tasks`, `users`, `work_logs`, and `knowledge_bookmarks` to speed common dashboard and list queries.

### Testing
- Ran Ruby syntax checks: `ruby -c app/models/user.rb && ruby -c app/controllers/api/users_controller.rb && ruby -c db/migrate/20270623000000_add_performance_indexes_for_dashboard_queries.rb` and they succeeded.
- Attempted Rails tests `bin/rails test test/models/user_keka_credentials_test.rb test/requests/profile_keka_test.rb test/requests/portfolio_authorization_test.rb` but they could not be executed because the active Ruby is `3.4.4` while the project `Gemfile` requires Ruby `3.3.0` (Bundler Ruby version mismatch).
- Changes were lint/syntax-checked and are ready for CI runs in an environment using the project's specified Ruby version.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3aa1e59b308322a66cf2eca94e88cb)