### PR TITLE
Allow owner/admin access to admin console and fix modal & notifications UI

### DIFF
--- a/app/controllers/api/admin_controller.rb
+++ b/app/controllers/api/admin_controller.rb
@@ -1,5 +1,5 @@
 class Api::AdminController < Api::BaseController
-  before_action :authorize_site_admin!
+  before_action :authorize_admin_access!
   before_action :set_model, except: [:tables]
   
   def tables
@@ -153,7 +153,9 @@ class Api::AdminController < Api::BaseController
     column.type.in?([:json, :jsonb])
   end
 
-  def authorize_site_admin!
-    head :forbidden unless current_user&.site_admin?
+  def authorize_admin_access!
+    return if current_user&.site_admin? || current_user&.roles&.any? { |role| role.name.in?(%w[owner admin]) }
+
+    head :forbidden
   end
 end

--- a/app/javascript/components/Admin/DynamicAdminTable.jsx
+++ b/app/javascript/components/Admin/DynamicAdminTable.jsx
@@ -370,8 +370,8 @@ function DynamicAdminTable({ table }) {
             <div className="fixed inset-0 bg-black/25 backdrop-blur-sm" />
           </Transition.Child>
 
-          <div className="fixed inset-0 overflow-y-auto">
-            <div className="flex min-h-full items-center justify-center p-4 text-center">
+          <div className="fixed inset-0 overflow-y-auto overscroll-contain">
+            <div className="flex min-h-full items-start justify-center p-4 pt-6 text-center sm:items-center sm:pt-4">
               <Transition.Child
                 as={Fragment}
                 enter="ease-out duration-300"
@@ -381,15 +381,15 @@ function DynamicAdminTable({ table }) {
                 leaveFrom="opacity-100 scale-100"
                 leaveTo="opacity-0 scale-95"
               >
-                <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all">
-                  <Dialog.Title as="h3" className="text-lg font-medium leading-6 text-gray-900 flex justify-between items-center mb-6 border-b pb-4">
+                <Dialog.Panel className="flex max-h-[calc(100vh-2rem)] w-full max-w-2xl transform flex-col overflow-hidden rounded-2xl bg-white text-left align-middle shadow-xl transition-all">
+                  <Dialog.Title as="h3" className="flex items-center justify-between border-b px-6 py-4 text-lg font-medium leading-6 text-gray-900">
                     {modalMode === 'create' ? 'Create New Record' : 'Edit Record'}
                     <button onClick={closeModal} className="text-gray-400 hover:text-gray-500">
                       <X className="w-5 h-5" />
                     </button>
                   </Dialog.Title>
 
-                  <form onSubmit={handleSubmit} className="space-y-4 max-h-[60vh] overflow-y-auto px-1">
+                  <form onSubmit={handleSubmit} className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-5">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       {columns.map(col => {
                         if (col.name === 'id' || col.name === 'created_at' || col.name === 'updated_at') return null;
@@ -427,7 +427,7 @@ function DynamicAdminTable({ table }) {
                     </div>
                   </form>
 
-                  <div className="mt-8 flex justify-end gap-3 pt-4 border-t">
+                  <div className="flex shrink-0 justify-end gap-3 border-t bg-white px-6 py-4">
                     <button
                       type="button"
                       className="inline-flex justify-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -229,7 +229,7 @@ const AppRoutes = () => {
             <Route
               path="/admin"
               element={
-                <PrivateRoute siteAdminOnly>
+                <PrivateRoute allowedRoles={["owner", "admin"]}>
                   <Admin />
                 </PrivateRoute>
               }

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -482,7 +482,7 @@ const Navbar = () => {
   const isOwner = user?.roles?.some((role) => role.name === "owner");
   const profileLinks = [
     user?.site_admin && portfolioEnabled ? { to: "/admin/portfolio", label: "Portfolio Editor", icon: FiBriefcase } : null,
-    user?.site_admin ? { to: "/admin", label: "System Admin", icon: FiGrid } : null,
+    hasAdminRole ? { to: "/admin", label: "System Admin", icon: FiGrid } : null,
     { to: "/profile", label: "My Profile", icon: FiUser },
     { to: "/users", label: "User Management", icon: FiUsers },
     { to: "/departments", label: "Departments", icon: FiGrid },

--- a/app/javascript/pages/Notifications.jsx
+++ b/app/javascript/pages/Notifications.jsx
@@ -285,18 +285,18 @@ const Notifications = () => {
 
         <section className="shell-panel shell-panel-strong overflow-hidden rounded-[32px]">
           <div className="space-y-5 p-5 sm:p-6">
-            <div className="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-              <div>
+            <div className="flex min-w-0 flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+              <div className="min-w-0">
                 <p className="text-xs font-semibold uppercase tracking-[0.28em] text-slate-400">Filter deck</p>
                 <h2 className="mt-1 text-2xl font-semibold tracking-[-0.04em] text-slate-950">Shape the feed by urgency and type.</h2>
               </div>
-              <div className="flex flex-wrap items-center gap-2">
+              <div className="grid grid-cols-3 gap-2 sm:flex sm:flex-wrap sm:items-center">
                 {STATUS_OPTIONS.map((option) => (
                   <button
                     key={option.value}
                     type="button"
                     onClick={() => setStatusFilter(option.value)}
-                    className={`rounded-full border px-4 py-2.5 text-sm font-semibold transition ${
+                    className={`rounded-full border px-3 py-2.5 text-center text-sm font-semibold transition sm:px-4 ${
                       statusFilter === option.value
                         ? "border-slate-950 bg-slate-950 text-white shadow-[0_18px_34px_rgb(15_23_42_/_0.16)]"
                         : "border-white/70 bg-white/72 text-slate-600 hover:bg-white hover:text-slate-950"
@@ -308,18 +308,29 @@ const Notifications = () => {
               </div>
             </div>
 
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,_1fr)_auto]">
-              <div className="relative">
+            <div className="grid min-w-0 gap-4 xl:grid-cols-[minmax(0,_1fr)_auto]">
+              <div className="relative min-w-0">
                 <Search className="absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" />
                 <input
+                  type="search"
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder="Search messages or signal type..."
-                  className="w-full rounded-[22px] border border-white/70 bg-white/80 py-3 pl-12 pr-4 text-sm text-slate-700 outline-none transition focus:border-sky-200 focus:bg-white focus:shadow-[0_18px_34px_rgb(15_23_42_/_0.08)]"
+                  className="w-full rounded-[22px] border border-white/70 bg-white/80 py-3 pl-12 pr-12 text-sm text-slate-700 outline-none transition focus:border-sky-200 focus:bg-white focus:shadow-[0_18px_34px_rgb(15_23_42_/_0.08)]"
                 />
+                {query ? (
+                  <button
+                    type="button"
+                    onClick={() => setQuery("")}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 rounded-full px-2 py-1 text-xs font-semibold text-slate-400 transition hover:bg-slate-100 hover:text-slate-700"
+                    aria-label="Clear notification search"
+                  >
+                    Clear
+                  </button>
+                ) : null}
               </div>
 
-              <div className="scrollbar-hide flex gap-2 overflow-x-auto">
+              <div className="scrollbar-hide -mx-1 flex min-w-0 gap-2 overflow-x-auto px-1 pb-1 xl:mx-0 xl:px-0">
                 {ACTION_OPTIONS.map((option) => {
                   const isActive = actionFilter === option.value;
                   const meta = getActionMeta(option.value);

--- a/app/javascript/pages/Teams.jsx
+++ b/app/javascript/pages/Teams.jsx
@@ -110,7 +110,7 @@ const Modal = ({ isOpen, onClose, title, children, footer, size = 'md' }) => {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
-                    className="fixed inset-0 z-50 flex items-center justify-center p-4"
+                    className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 pt-6 sm:items-center sm:pt-4"
                 >
                     <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
                     <motion.div
@@ -118,7 +118,7 @@ const Modal = ({ isOpen, onClose, title, children, footer, size = 'md' }) => {
                         animate={{ opacity: 1, scale: 1, y: 0 }}
                         exit={{ opacity: 0, scale: 0.95, y: 20 }}
                         transition={{ type: "spring", duration: 0.4 }}
-                        className={`relative bg-white dark:bg-zinc-900 rounded-2xl shadow-2xl w-full ${sizeClasses[size]} overflow-hidden`}
+                        className={`relative flex max-h-[calc(100vh-2rem)] w-full ${sizeClasses[size]} flex-col overflow-hidden rounded-2xl bg-white shadow-2xl dark:bg-zinc-900`}
                     >
                         <div className="flex items-center justify-between p-5 border-b border-zinc-100 dark:border-zinc-800">
                             <h3 className="text-lg font-semibold text-zinc-900 dark:text-white">{title}</h3>
@@ -129,9 +129,9 @@ const Modal = ({ isOpen, onClose, title, children, footer, size = 'md' }) => {
                                 <FiX className="w-5 h-5" />
                             </button>
                         </div>
-                        <div className="p-5 max-h-[60vh] overflow-y-auto">{children}</div>
+                        <div className="min-h-0 flex-1 overflow-y-auto p-5">{children}</div>
                         {footer && (
-                            <div className="flex items-center justify-end gap-3 p-5 border-t border-zinc-100 dark:border-zinc-800 bg-zinc-50 dark:bg-zinc-800/50">
+                            <div className="flex shrink-0 items-center justify-end gap-3 border-t border-zinc-100 bg-zinc-50 p-5 dark:border-zinc-800 dark:bg-zinc-800/50">
                                 {footer}
                             </div>
                         )}

--- a/app/javascript/pages/Users.jsx
+++ b/app/javascript/pages/Users.jsx
@@ -591,7 +591,7 @@ const Users = () => {
       </div>
 
       {createModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/50 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-900/50 p-4 pt-6 backdrop-blur-sm sm:items-center sm:pt-4">
           <form
             onSubmit={handleCreateUser}
             className="bg-white rounded-2xl shadow-2xl w-full max-w-3xl p-6 relative max-h-[90vh] overflow-y-auto"
@@ -788,7 +788,7 @@ const Users = () => {
 
       {/* Photo Update Modal */}
       {photoModalOpen && photoModalUser && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/50 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-900/50 p-4 pt-6 backdrop-blur-sm sm:items-center sm:pt-4">
           <form
             onSubmit={handlePhotoUpdate}
             encType="multipart/form-data"
@@ -867,7 +867,7 @@ const Users = () => {
 
       {/* Custom Modal for Deletion */}
       {editingId && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/50 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-900/50 p-4 pt-6 backdrop-blur-sm sm:items-center sm:pt-4">
           <form onSubmit={handleUpdate} className="bg-white rounded-2xl shadow-2xl w-full max-w-3xl p-6 relative max-h-[90vh] overflow-y-auto">
             <button type="button" onClick={closeEditModal} className="absolute right-3 top-3 text-gray-400 hover:text-gray-600">
               <X size={18} />
@@ -901,7 +901,7 @@ const Users = () => {
       )}
 
       {deleteModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-slate-900/50 backdrop-blur-sm transition-opacity">
+        <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-slate-900/50 p-4 pt-6 backdrop-blur-sm transition-opacity sm:items-center sm:pt-4">
           <div className="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6 transform transition-all scale-100">
             <div className="flex flex-col items-center text-center">
               <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center mb-4 text-red-600">

--- a/app/javascript/pages/WorkLog.jsx
+++ b/app/javascript/pages/WorkLog.jsx
@@ -78,14 +78,14 @@ const Modal = ({ children, isOpen, onClose }) => (
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
         onClick={onClose}
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4"
+        className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/50 p-4 pt-6 backdrop-blur-sm sm:items-center sm:pt-4"
       >
         <motion.div
           initial={{ scale: 0.9, y: 20 }}
           animate={{ scale: 1, y: 0 }}
           exit={{ scale: 0.9, y: 20 }}
           onClick={(e) => e.stopPropagation()}
-          className="shell-panel shell-panel-strong w-full max-w-2xl overflow-y-auto rounded-[30px] shadow-[0_34px_90px_rgb(15_23_42_/_0.22)]"
+          className="shell-panel shell-panel-strong max-h-[calc(100vh-2rem)] w-full max-w-2xl overflow-y-auto rounded-[30px] shadow-[0_34px_90px_rgb(15_23_42_/_0.22)]"
         >
           {children}
         </motion.div>


### PR DESCRIPTION
### Motivation
- Admin console should be reachable by users with `owner` or `admin` roles (not only `site_admin`), and modal forms must remain usable on long pages where centered dialogs can be clipped or require awkward scrolling. 
- Notification filter/search UX needed a clearer search input and better responsive layout for chips and overflow.

### Description
- Permit owner/admin role access to the admin API and front-end route by replacing strict `site_admin` checks with an `authorize_admin_access!` method and using `allowedRoles={['owner','admin']}` for the `/admin` route. (backend: `app/controllers/api/admin_controller.rb`; frontend route: `app/javascript/components/App.jsx`)
- Make the System Admin nav item visible to users that hold `owner` or `admin` roles instead of only `site_admin`. (`app/javascript/components/Navbar.jsx`)
- Convert admin table create/edit modal to a top-aligned, viewport-constrained, scrollable panel so forms open near the top of the screen and remain accessible on long pages. (`app/javascript/components/Admin/DynamicAdminTable.jsx`)
- Apply the same overflow/top-aligned modal pattern to Teams, Users, and Work Log modals by setting modal containers to `items-start`, adding `overflow-y-auto`, and limiting max heights so content is scrollable inside the modal. (`app/javascript/pages/Teams.jsx`, `app/javascript/pages/Users.jsx`, `app/javascript/pages/WorkLog.jsx`)
- Improve Notifications UI: set the search input to `type="search"`, add a clear button, tighten button spacing for small screens, and make the filter chips horizontally scroll-safe. (`app/javascript/pages/Notifications.jsx`)

### Testing
- Ran Ruby syntax check with `bundle exec ruby -c app/controllers/api/admin_controller.rb` and it succeeded. 
- Ran JavaScript unit tests with `yarn test` and all tests passed (`10 files, 35 tests`).
- Built the frontend assets with `yarn build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4686b90e288322b4695f0a48325b1e)